### PR TITLE
Minor tweaks

### DIFF
--- a/app.go
+++ b/app.go
@@ -176,7 +176,6 @@ func promptAndGet(prompt string) (string, error) {
 		}
 		// try again
 	}
-	return "", nil
 }
 
 func promptAndGetPassword(prompt string) (string, error) {

--- a/control.go
+++ b/control.go
@@ -84,7 +84,7 @@ func handleStatus(w http.ResponseWriter, r *http.Request) {
 		"version":            VersionString,
 	}
 
-	json, err := json.Marshal(data)
+	jsonVal, err := json.Marshal(data)
 	if err != nil {
 		errortext := fmt.Sprintf("Unable to marshal status json: %s", err)
 		log.Println(errortext)
@@ -92,7 +92,7 @@ func handleStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(json)
+	_, err = w.Write(jsonVal)
 	if err != nil {
 		errortext := fmt.Sprintf("Unable to write response json: %s", err)
 		log.Println(errortext)
@@ -195,7 +195,7 @@ func handleTestUpstreamDNS(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	json, err := json.Marshal(result)
+	jsonVal, err := json.Marshal(result)
 	if err != nil {
 		errortext := fmt.Sprintf("Unable to marshal status json: %s", err)
 		log.Println(errortext)
@@ -204,7 +204,7 @@ func handleTestUpstreamDNS(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(json)
+	_, err = w.Write(jsonVal)
 	if err != nil {
 		errortext := fmt.Sprintf("Couldn't write body: %s", err)
 		log.Println(errortext)
@@ -374,7 +374,7 @@ func handleFilteringStatus(w http.ResponseWriter, r *http.Request) {
 	config.RLock()
 	data["filters"] = config.Filters
 	data["user_rules"] = config.UserRules
-	json, err := json.Marshal(data)
+	jsonVal, err := json.Marshal(data)
 	config.RUnlock()
 
 	if err != nil {
@@ -385,7 +385,7 @@ func handleFilteringStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(json)
+	_, err = w.Write(jsonVal)
 	if err != nil {
 		errortext := fmt.Sprintf("Unable to write response json: %s", err)
 		log.Println(errortext)
@@ -802,7 +802,7 @@ func handleSafeBrowsingStatus(w http.ResponseWriter, r *http.Request) {
 	data := map[string]interface{}{
 		"enabled": config.CoreDNS.SafeBrowsingEnabled,
 	}
-	json, err := json.Marshal(data)
+	jsonVal, err := json.Marshal(data)
 	if err != nil {
 		errortext := fmt.Sprintf("Unable to marshal status json: %s", err)
 		log.Println(errortext)
@@ -810,7 +810,7 @@ func handleSafeBrowsingStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(json)
+	_, err = w.Write(jsonVal)
 	if err != nil {
 		errortext := fmt.Sprintf("Unable to write response json: %s", err)
 		log.Println(errortext)
@@ -880,7 +880,7 @@ func handleParentalStatus(w http.ResponseWriter, r *http.Request) {
 	if config.CoreDNS.ParentalEnabled {
 		data["sensitivity"] = config.CoreDNS.ParentalSensitivity
 	}
-	json, err := json.Marshal(data)
+	jsonVal, err := json.Marshal(data)
 	if err != nil {
 		errortext := fmt.Sprintf("Unable to marshal status json: %s", err)
 		log.Println(errortext)
@@ -889,7 +889,7 @@ func handleParentalStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(json)
+	_, err = w.Write(jsonVal)
 	if err != nil {
 		errortext := fmt.Sprintf("Unable to write response json: %s", err)
 		log.Println(errortext)
@@ -916,7 +916,7 @@ func handleSafeSearchStatus(w http.ResponseWriter, r *http.Request) {
 	data := map[string]interface{}{
 		"enabled": config.CoreDNS.SafeSearchEnabled,
 	}
-	json, err := json.Marshal(data)
+	jsonVal, err := json.Marshal(data)
 	if err != nil {
 		errortext := fmt.Sprintf("Unable to marshal status json: %s", err)
 		log.Println(errortext)
@@ -925,7 +925,7 @@ func handleSafeSearchStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(json)
+	_, err = w.Write(jsonVal)
 	if err != nil {
 		errortext := fmt.Sprintf("Unable to write response json: %s", err)
 		log.Println(errortext)

--- a/control.go
+++ b/control.go
@@ -222,7 +222,7 @@ func checkDNS(input string) error {
 	req.Id = dns.Id()
 	req.RecursionDesired = true
 	req.Question = []dns.Question{
-		{"google-public-dns-a.google.com.", dns.TypeA, dns.ClassINET},
+		{Name: "google-public-dns-a.google.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
 	}
 
 	prefix, host := splitDNSServerPrefixServer(input)

--- a/coredns_plugin/querylog.go
+++ b/coredns_plugin/querylog.go
@@ -208,7 +208,7 @@ func HandleQueryLog(w http.ResponseWriter, r *http.Request) {
 		data = append(data, jsonentry)
 	}
 
-	json, err := json.Marshal(data)
+	jsonVal, err := json.Marshal(data)
 	if err != nil {
 		errortext := fmt.Sprintf("Couldn't marshal data into json: %s", err)
 		log.Println(errortext)
@@ -217,7 +217,7 @@ func HandleQueryLog(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(json)
+	_, err = w.Write(jsonVal)
 	if err != nil {
 		errortext := fmt.Sprintf("Unable to write response json: %s", err)
 		log.Println(errortext)

--- a/dnsfilter/dnsfilter.go
+++ b/dnsfilter/dnsfilter.go
@@ -22,9 +22,9 @@ import (
 )
 
 const defaultCacheSize = 64 * 1024 // in number of elements
-const defaultCacheTime time.Duration = 30 * time.Minute
+const defaultCacheTime = 30 * time.Minute
 
-const defaultHTTPTimeout time.Duration = 5 * time.Minute
+const defaultHTTPTimeout = 5 * time.Minute
 const defaultHTTPMaxIdleConnections = 100
 
 const defaultSafebrowsingServer = "sb.adtidy.org"


### PR DESCRIPTION
- `json` is a package name so using `json` as a variable name is bad practice. 
- The return statement outside the `for` loop in `promptAndGet` is unreachable. 
- `go vet` reports: `control.go:225: github.com/miekg/dns.Question composite literal uses unkeyed fields`