### PR TITLE
Update README with instructions for setcap non-root use

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,21 @@ Now open the browser and navigate to http://localhost:3000/ to control your AdGu
 
 ### Running without superuser
 
-You can run AdGuard Home without superuser privileges, but you need to instruct it to use a different port rather than 53. You can do that by editing `AdGuardHome.yaml` and finding these two lines:
+You can run AdGuard Home without superuser privileges, but you need to either grant the binary a capability (on Linux) or instruct it to use a different port (all platforms).
+
+#### Granting the CAP_NET_BIND_SERVICE capability (on Linux)
+
+To allow AdGuard Home running on Linux to listen on port 53 without superuser privileges, run:
+
+```bash
+sudo setcap CAP_NET_BIND_SERVICE=+eip ./AdGuardHome
+```
+
+Then run `./AdGuardHome` as a unprivileged user.
+
+#### Changing the DNS listen port
+
+To configure AdGuard Home to listen on a port that does not require superuser privileges, edit `AdGuardHome.yaml` and find these two lines:
 
 ```yaml
 dns:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ You can run AdGuard Home without superuser privileges, but you need to either gr
 
 #### Granting the CAP_NET_BIND_SERVICE capability (on Linux)
 
+Note: using this method requires installing the `setcap` utilty.  You may need to install it using your Linux distribution's package manager.
+
 To allow AdGuard Home running on Linux to listen on port 53 without superuser privileges, run:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You can run AdGuard Home without superuser privileges, but you need to either gr
 
 #### Granting the CAP_NET_BIND_SERVICE capability (on Linux)
 
-Note: using this method requires installing the `setcap` utilty.  You may need to install it using your Linux distribution's package manager.
+Note: using this method requires the `setcap` utilty.  You may need to install it using your Linux distribution's package manager.
 
 To allow AdGuard Home running on Linux to listen on port 53 without superuser privileges, run:
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You can run AdGuard Home without superuser privileges, but you need to either gr
 
 #### Granting the CAP_NET_BIND_SERVICE capability (on Linux)
 
-Note: using this method requires the `setcap` utilty.  You may need to install it using your Linux distribution's package manager.
+Note: using this method requires the `setcap` utility.  You may need to install it using your Linux distribution's package manager.
 
 To allow AdGuard Home running on Linux to listen on port 53 without superuser privileges, run:
 


### PR DESCRIPTION
On Linux you can run it listening on port 53 without root privs.  This is the best option: clients still send on port 53 (no wonky configs) and AdGuard doesn't run as root (!).