### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -262,7 +262,7 @@ func (filter *filter) Path() string {
 	return filepath.Join(config.ourWorkingDir, dataDir, filterDir, strconv.FormatInt(filter.ID, 10)+".txt")
 }
 
-// LastUpdated returns the time when the filter was last time updated
+// LastTimeUpdated returns the time when the filter was last time updated
 func (filter *filter) LastTimeUpdated() time.Time {
 	filterFilePath := filter.Path()
 	if _, err := os.Stat(filterFilePath); os.IsNotExist(err) {


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?