### PR TITLE
Fix for docker image being unable to bind webinterface to anything but all interfaces.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ EXPOSE 53/tcp 53/udp 67/tcp 67/udp 68/tcp 68/udp 80/tcp 443/tcp 853/tcp 853/udp 
 VOLUME ["/opt/adguardhome/conf", "/opt/adguardhome/work"]
 
 ENTRYPOINT ["/opt/adguardhome/AdGuardHome"]
-CMD ["-h", "0.0.0.0", "-c", "/opt/adguardhome/conf/AdGuardHome.yaml", "-w", "/opt/adguardhome/work"]
+CMD ["-c", "/opt/adguardhome/conf/AdGuardHome.yaml", "-w", "/opt/adguardhome/work"]


### PR DESCRIPTION
The current Dockerfile prohibits binding of the web interface to anything but 0.0.0.0. We would either like to reconfigure it to a different IP or localhost (using SSH tunneling to access it). As the default setup suggests to start a container with `host` network, this would bind to all interfaces, all public ones included.

Steps to reproduce:

```sh
mkdir -p testconfig
docker run -it -p 3000:3000 -p 3001:80 -v `pwd`/testconfig:/opt/adguardhome/conf --rm adguard/adguardhome 
```

setup with default values, kill server.

```sh
grep "bind_host" testconfig/AdGuardHome.yaml
```
show current setup to be bound to 0.0.0.0.

Reconfigure the server to bind the webinterface to localhost

```sh
sed -i 's/^bind_host: 0.0.0.0/bind_host: 127.0.0.1/' testconfig/AdGuardHome.yaml
```

restart the server with the same line as above. kill it again. the configuration will be back to 0.0.0.0 exposing the interface on all interfaces despite the fact you just reconfigured them.

This is due to the hardcoded `-h 0.0.0.0` argument on the Dockerfile CMD line. From my understanding this value is set to 0.0.0.0 by default in the config.go and this argument should no longer serve any purpose.

This would be the easiest fix, a more sophisticated one would be using getenv() in go and configure fixed stuff through docker environment variables.
