### PR TITLE
Chrome nagging translation popup from portuguese

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -4,6 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta name="theme-color" content="#000000">
+        <meta name="google" content="notranslate" />
         <link rel="shortcut icon" href="favicon.ico">
         <title>AdGuard Home</title>
     </head>

--- a/client/public/install.html
+++ b/client/public/install.html
@@ -4,6 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta name="theme-color" content="#000000">
+        <meta name="google" content="notranslate" />
         <link rel="shortcut icon" href="favicon.ico">
         <title>Setup AdGuard Home</title>
     </head>


### PR DESCRIPTION
Chrome with `de, de-de, en, en-us` language ordering keeps nagging for a translation from portuguese to german. This would disable any nagging, not sure why they do not respect the html[lang] attribute in this case even the content is clearly english.

![Screenshot from 2019-03-26 12-37-20](https://user-images.githubusercontent.com/681514/54996094-aada5680-4fc8-11e9-8ba9-d28b67951c1f.png)
