### PR TITLE
Run as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,21 @@ FROM alpine:latest
 LABEL maintainer="AdGuard Team <devteam@adguard.com>"
 
 # Update CA certs
-RUN apk --no-cache --update add ca-certificates && \
-    rm -rf /var/cache/apk/* && mkdir -p /opt/adguardhome
+RUN apk --no-cache --update add ca-certificates libcap && \
+    rm -rf /var/cache/apk/* && mkdir -p /opt/adguardhome/conf /opt/adguardhome/work
 
 COPY --from=build /src/AdGuardHome/AdGuardHome /opt/adguardhome/AdGuardHome
+
+RUN chown -R nobody: /opt/adguardhome \
+    && setcap 'cap_net_bind_service=+eip' /opt/adguardhome/AdGuardHome
 
 EXPOSE 53/tcp 53/udp 67/tcp 67/udp 68/tcp 68/udp 80/tcp 443/tcp 853/tcp 853/udp 3000/tcp
 
 VOLUME ["/opt/adguardhome/conf", "/opt/adguardhome/work"]
+
+WORKDIR /opt/adguardhome/work
+
+USER nobody
 
 ENTRYPOINT ["/opt/adguardhome/AdGuardHome"]
 CMD ["-c", "/opt/adguardhome/conf/AdGuardHome.yaml", "-w", "/opt/adguardhome/work"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,13 @@ LABEL maintainer="AdGuard Team <devteam@adguard.com>"
 
 # Update CA certs
 RUN apk --no-cache --update add ca-certificates libcap && \
-    rm -rf /var/cache/apk/* && mkdir -p /opt/adguardhome/conf /opt/adguardhome/work
+    rm -rf /var/cache/apk/* && \
+    mkdir -p /opt/adguardhome/conf /opt/adguardhome/work && \
+    chown -R nobody: /opt/adguardhome
 
-COPY --from=build /src/AdGuardHome/AdGuardHome /opt/adguardhome/AdGuardHome
+COPY --from=build --chown=nobody: /src/AdGuardHome/AdGuardHome /opt/adguardhome/AdGuardHome
 
-RUN chown -R nobody: /opt/adguardhome \
-    && setcap 'cap_net_bind_service=+eip' /opt/adguardhome/AdGuardHome
+RUN setcap 'cap_net_bind_service=+eip' /opt/adguardhome/AdGuardHome
 
 EXPOSE 53/tcp 53/udp 67/tcp 67/udp 68/tcp 68/udp 80/tcp 443/tcp 853/tcp 853/udp 3000/tcp
 
@@ -25,7 +26,7 @@ VOLUME ["/opt/adguardhome/conf", "/opt/adguardhome/work"]
 
 WORKDIR /opt/adguardhome/work
 
-USER nobody
+#USER nobody
 
 ENTRYPOINT ["/opt/adguardhome/AdGuardHome"]
 CMD ["-c", "/opt/adguardhome/conf/AdGuardHome.yaml", "-w", "/opt/adguardhome/work"]

--- a/Dockerfile.travis
+++ b/Dockerfile.travis
@@ -2,15 +2,22 @@ FROM alpine:latest
 LABEL maintainer="AdGuard Team <devteam@adguard.com>"
 
 # Update CA certs
-RUN apk --no-cache --update add ca-certificates && \
-    rm -rf /var/cache/apk/* && mkdir -p /opt/adguardhome
+RUN apk --no-cache --update add ca-certificates libcap && \
+    rm -rf /var/cache/apk/* && mkdir -p /opt/adguardhome/conf /opt/adguardhome/work
 
 
 COPY ./AdGuardHome /opt/adguardhome/AdGuardHome
 
+RUN chown -R nobody: /opt/adguardhome \
+    && setcap 'cap_net_bind_service=+eip' /opt/adguardhome/AdGuardHome
+
 EXPOSE 53/tcp 53/udp 67/tcp 67/udp 68/tcp 68/udp 80/tcp 443/tcp 853/tcp 853/udp 3000/tcp
 
 VOLUME ["/opt/adguardhome/conf", "/opt/adguardhome/work"]
+
+WORKDIR /opt/adguardhome/work
+
+USER nobody
 
 ENTRYPOINT ["/opt/adguardhome/AdGuardHome"]
 CMD ["-h", "0.0.0.0", "-c", "/opt/adguardhome/conf/AdGuardHome.yaml", "-w", "/opt/adguardhome/work"]

--- a/Dockerfile.travis
+++ b/Dockerfile.travis
@@ -3,13 +3,13 @@ LABEL maintainer="AdGuard Team <devteam@adguard.com>"
 
 # Update CA certs
 RUN apk --no-cache --update add ca-certificates libcap && \
-    rm -rf /var/cache/apk/* && mkdir -p /opt/adguardhome/conf /opt/adguardhome/work
+    rm -rf /var/cache/apk/* && \
+    mkdir -p /opt/adguardhome/conf /opt/adguardhome/work && \
+    chown -R nobody: /opt/adguardhome
 
+COPY --chown=nobody: ./AdGuardHome /opt/adguardhome/AdGuardHome
 
-COPY ./AdGuardHome /opt/adguardhome/AdGuardHome
-
-RUN chown -R nobody: /opt/adguardhome \
-    && setcap 'cap_net_bind_service=+eip' /opt/adguardhome/AdGuardHome
+RUN setcap 'cap_net_bind_service=+eip' /opt/adguardhome/AdGuardHome
 
 EXPOSE 53/tcp 53/udp 67/tcp 67/udp 68/tcp 68/udp 80/tcp 443/tcp 853/tcp 853/udp 3000/tcp
 
@@ -17,7 +17,7 @@ VOLUME ["/opt/adguardhome/conf", "/opt/adguardhome/work"]
 
 WORKDIR /opt/adguardhome/work
 
-USER nobody
+#USER nobody
 
 ENTRYPOINT ["/opt/adguardhome/AdGuardHome"]
 CMD ["-h", "0.0.0.0", "-c", "/opt/adguardhome/conf/AdGuardHome.yaml", "-w", "/opt/adguardhome/work"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+%YAML 1.2
+---
+# https://docs.docker.com/compose/compose-file/
+
+version: '2.4'
+
+services:
+
+  adguard-home:
+    image: adguard/adguardhome:armhf-latest
+    init: true
+    ports:
+    - "53:53/tcp"
+    - "53:53/udp"
+    - "67:67/tcp"
+    - "67:67/udp"
+    - "68:68/tcp"
+    - "68:68/udp"
+    - "80:80/tcp"
+    - "443:443/tcp"
+    - "853:853/tcp"
+    - "853:853/udp"
+    - "3000:3000/tcp"
+    volumes:
+    - /opt/adguard-home:/opt/adguardhome/conf
+    - /srv/adguard-home:/opt/adguardhome/work
+    #user: nobody
+    read_only: true
+    restart: always
+
+...


### PR DESCRIPTION
Containers security best practices say we should not run anything as root. In fact, this is actually enforced in some OpenStack distributions.

This patch makes AdguardHome run as `nobody`.

A drawback is that volume writing will happen as non-root (obviously), and thus file permissions will show their ugly head in the face of the user when she tries to mount a local directory in the container.  
Since the target user is advanced enough to use Docker, I think this is a reasonable tradeoff.