### PR TITLE
* dnsforward, config: add unspecified IP blocking option

### DIFF
--- a/config.go
+++ b/config.go
@@ -115,6 +115,7 @@ var config = configuration{
 		FilteringConfig: dnsforward.FilteringConfig{
 			ProtectionEnabled:  true, // whether or not use any of dnsfilter features
 			FilteringEnabled:   true, // whether or not use filter lists
+			NullFilter:         false, // whether to filter with the unspecified address
 			BlockedResponseTTL: 10,   // in seconds
 			QueryLogEnabled:    true,
 			Ratelimit:          20,

--- a/config.go
+++ b/config.go
@@ -115,7 +115,7 @@ var config = configuration{
 		FilteringConfig: dnsforward.FilteringConfig{
 			ProtectionEnabled:  true, // whether or not use any of dnsfilter features
 			FilteringEnabled:   true, // whether or not use filter lists
-			NullFilter:         false, // whether to filter with the unspecified address
+			BlockingMode:       "nxdomain", // mode how to answer filtered requests
 			BlockedResponseTTL: 10,   // in seconds
 			QueryLogEnabled:    true,
 			Ratelimit:          20,

--- a/dnsforward/dnsforward.go
+++ b/dnsforward/dnsforward.go
@@ -26,8 +26,6 @@ const (
 	parentalBlockHost     = "family-block.dns.adguard.com"
 )
 
-const unspecifiedAddress = "0.0.0.0"
-
 // Server is the main way to start a DNS server.
 //
 // Example:
@@ -405,8 +403,7 @@ func (s *Server) genDNSFilterMessage(d *proxy.DNSContext, result *dnsfilter.Resu
 		}
 
 		if s.BlockingMode == "null_ip" {
-			result.IP = net.ParseIP(unspecifiedAddress)
-			return s.genARecord(m, result.IP)
+			return s.genARecord(m, net.IPv4zero)
 		}
 
 		return s.genNXDomain(m)

--- a/dnsforward/dnsforward.go
+++ b/dnsforward/dnsforward.go
@@ -400,11 +400,12 @@ func (s *Server) genDNSFilterMessage(d *proxy.DNSContext, result *dnsfilter.Resu
 	case dnsfilter.FilteredParental:
 		return s.genBlockedHost(m, parentalBlockHost, d)
 	default:
-		if s.NullFilter {
-			result.IP = net.ParseIP(unspecifiedAddress)
+		if result.IP != nil {
+			return s.genARecord(m, result.IP)
 		}
 
-		if result.IP != nil {
+		if s.NullFilter {
+			result.IP = net.ParseIP(unspecifiedAddress)
 			return s.genARecord(m, result.IP)
 		}
 

--- a/dnsforward/dnsforward.go
+++ b/dnsforward/dnsforward.go
@@ -63,7 +63,7 @@ func NewServer(baseDir string) *Server {
 type FilteringConfig struct {
 	ProtectionEnabled  bool     `yaml:"protection_enabled"`   // whether or not use any of dnsfilter features
 	FilteringEnabled   bool     `yaml:"filtering_enabled"`    // whether or not use filter lists
-	NullFilter         bool     `yaml:"null_filter"`          // mode how to answer filtered requests
+	BlockingMode       string   `yaml:"blocking_mode"`        // mode how to answer filtered requests
 	BlockedResponseTTL uint32   `yaml:"blocked_response_ttl"` // if 0, then default is used (3600)
 	QueryLogEnabled    bool     `yaml:"querylog_enabled"`     // if true, query log is enabled
 	Ratelimit          int      `yaml:"ratelimit"`            // max number of requests per second from a given IP (0 to disable)
@@ -404,7 +404,7 @@ func (s *Server) genDNSFilterMessage(d *proxy.DNSContext, result *dnsfilter.Resu
 			return s.genARecord(m, result.IP)
 		}
 
-		if s.NullFilter {
+		if s.BlockingMode == "null_ip" {
 			result.IP = net.ParseIP(unspecifiedAddress)
 			return s.genARecord(m, result.IP)
 		}


### PR DESCRIPTION
This feature adds support to answer filtered queries with the unspecified address (0.0.0.0), also referred to as [NULL blocking mode in pi-hole](https://docs.pi-hole.net/ftldns/blockingmode/). Also see [issue #742 ](https://github.com/AdguardTeam/AdGuardHome/issues/742).

At least in my non-scientific testing on an Android device, this mode works better than the default NXDOMAIN filtering, as it reduces the number of repeated dns queries.

It is enabled by adding `null_filter: true` to the dns section of AdGuardHome.yaml, for example:
```
...
dns:
  bind_host: 0.0.0.0
  port: 53
  protection_enabled: true
  filtering_enabled: true
  null_filter: true
...
```

~~Note that also host entries in filter lists with 127.0.0.1 will be answered with the unspecified address. This is intentional as 0.0.0.0 seems more compatible accross different operation systems than 127.0.0.1.~~

Lastly, an option for this feature would still have to be added to the UI frontend. I had some difficulty adding the React code to my Goland project for debugging.. :p