### PR TITLE
:ambulance: Corrects typo in parental control API error message

### DIFF
--- a/control.go
+++ b/control.go
@@ -871,7 +871,7 @@ func handleParentalEnable(w http.ResponseWriter, r *http.Request) {
 
 	sensitivity, ok := parameters["sensitivity"]
 	if !ok {
-		http.Error(w, "URL parameter was not specified", 400)
+		http.Error(w, "Sensitivity parameter was not specified", 400)
 		return
 	}
 


### PR DESCRIPTION
Corrects typo in parental control API error message.

When the sensitivity parameter was not passed to the parental control enable control call, it would error about the URL parameter missing.

