### PR TITLE
add an openrc service-script

### DIFF
--- a/scripts/openrc-service-script/README.md
+++ b/scripts/openrc-service-script/README.md
@@ -21,5 +21,5 @@ rc-update add adguardhome
 
 Controlling AdGuardHome:
 ```
-service adguardhome <start|stop|restart|checkconfig>
+service adguardhome <start|stop|restart|status|checkconfig>
 ```

--- a/scripts/openrc-service-script/README.md
+++ b/scripts/openrc-service-script/README.md
@@ -1,0 +1,19 @@
+## openrc service-script for AdGuardHome
+
+A service-script for openrc based systems, for example if you run AdGuardHome in Alpine (without using Docker).
+
+### Installation
+
+Copy the script to /etc/init.d/adguardhome
+
+### Usage
+
+Enable running AdGuardHome on boot:
+```
+rc-update add adguardhome
+```
+
+Controlling AdGuardHome:
+```
+service adguardhome <start|stop|restart|checkconfig>
+```

--- a/scripts/openrc-service-script/README.md
+++ b/scripts/openrc-service-script/README.md
@@ -4,7 +4,13 @@ A service-script for openrc based systems, for example if you run AdGuardHome in
 
 ### Installation
 
-Copy the script to /etc/init.d/adguardhome
+Install openrc:
+```
+apk update
+apk add openrc
+```
+
+Then copy the script to /etc/init.d/adguardhome
 
 ### Usage
 

--- a/scripts/openrc-service-script/adguardhome
+++ b/scripts/openrc-service-script/adguardhome
@@ -1,0 +1,38 @@
+#!/sbin/openrc-run
+#
+# openrc service-script for AdGuardHome
+#
+# place in /etc/init.d/
+# start on boot: "rc-update add adguardhome"
+# control service: "service adguardhome <start|stop|restart|checkconfig>"
+#
+
+description="AdGuard Home: Network-level blocker"
+
+pidfile="/run/$RC_SVCNAME.pid"
+command="/opt/AdGuardHome/AdGuardHome"
+command_args="-s run"
+command_background=true
+
+extra_commands="checkconfig"
+
+depend() {
+	need net
+	provide dns
+	after firewall
+}
+
+checkconfig() {
+	"$command" --check-config || return 1
+}
+
+stop() {
+	if [ "${RC_CMD}" = "restart" ] ; then
+		checkconfig || return 1
+	fi
+
+	ebegin "Stopping $RC_SVCNAME"
+	start-stop-daemon --stop --exec "$command" \
+		--pidfile "$pidfile" --quiet
+	eend $?
+}

--- a/scripts/openrc-service-script/adguardhome
+++ b/scripts/openrc-service-script/adguardhome
@@ -4,7 +4,7 @@
 #
 # place in /etc/init.d/
 # start on boot: "rc-update add adguardhome"
-# control service: "service adguardhome <start|stop|restart|checkconfig>"
+# control service: "service adguardhome <start|stop|restart|status|checkconfig>"
 #
 
 description="AdGuard Home: Network-level blocker"


### PR DESCRIPTION
Hi!

Here's a simple openrc service-script I'm using to run AdGuardHome in a LXC container under Proxmox Virtual Environment. PVE has no support for running Docker natively, but for LXC.

regards
Oliver