### PR TITLE
i386/linux: don't build binary with sse by default

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -36,7 +36,7 @@ mkdir -p $dst
 # Prepare releases
 CHANNEL=$channel GOOS=darwin GOARCH=amd64 f
 CHANNEL=$channel GOOS=linux GOARCH=amd64 f
-CHANNEL=$channel GOOS=linux GOARCH=386 f
+CHANNEL=$channel GOOS=linux GOARCH=386 GO386=387 f
 CHANNEL=$channel GOOS=linux GOARCH=arm GOARM=6 f
 CHANNEL=$channel GOOS=linux GOARCH=arm64 GOARM=6 f
 CHANNEL=$channel GOOS=windows GOARCH=amd64 f


### PR DESCRIPTION
The vast majority of today's x86 routers are amd64-based, and the rest are probably either
very old computers or specialized hardware such as PCEngines' ALIX series. For Go language,
adding GO386=387 disables SSE optimizations made by a compiler, effectively allowing binary
to run on old CPUs such as SC1100 or Geode LX.