### PR TITLE
Update blocked_services.go Snapchat Rules

### DIFF
--- a/home/blocked_services.go
+++ b/home/blocked_services.go
@@ -28,7 +28,7 @@ var serviceRulesArray = []svc{
 	{"twitch", []string{"||twitch.tv^", "||ttvnw.net^"}},
 	{"netflix", []string{"||nflxext.com^", "||netflix.com^"}},
 	{"instagram", []string{"||instagram.com^", "||cdninstagram.com^"}},
-	{"snapchat", []string{"||snapchat.com^", "||sc-cdn.net^"}},
+	{"snapchat", []string{"||snapchat.com^", "||sc-cdn.net^", "||impala-media-production.s3.amazonaws.com^"}},
 	{"discord", []string{"||discord.gg^", "||discordapp.net^", "||discordapp.com^"}},
 	{"ok", []string{"||ok.ru^"}},
 	{"skype", []string{"||skype.com^"}},


### PR DESCRIPTION
Snapchat still works on Android if `impala-media-production.s3.amazonaws.com` isnt blocked