### PR TITLE
feature: Allow unencrypted DOH

### DIFF
--- a/home/config.go
+++ b/home/config.go
@@ -115,6 +115,7 @@ type tlsConfigSettings struct {
 	ServerName     string `yaml:"server_name" json:"server_name,omitempty"`             // ServerName is the hostname of your HTTPS/TLS server
 	ForceHTTPS     bool   `yaml:"force_https" json:"force_https,omitempty"`             // ForceHTTPS: if true, forces HTTP->HTTPS redirect
 	PortHTTPS      int    `yaml:"port_https" json:"port_https,omitempty"`               // HTTPS port. If 0, HTTPS will be disabled
+	AllowClearDOH  bool   `yaml:"allow_clear_doh" json:"allow_clear_doh"`               // Allow queries to http port for DOH Queries (for reverse proxying)
 	PortDNSOverTLS int    `yaml:"port_dns_over_tls" json:"port_dns_over_tls,omitempty"` // DNS-over-TLS port. If 0, DOT will be disabled
 
 	dnsforward.TLSConfig `yaml:",inline" json:",inline"`

--- a/home/control.go
+++ b/home/control.go
@@ -144,7 +144,7 @@ func handleGetProfile(w http.ResponseWriter, r *http.Request) {
 // DNS-over-HTTPS
 // --------------
 func handleDOH(w http.ResponseWriter, r *http.Request) {
-	if r.TLS == nil {
+	if !config.TLS.AllowClearDOH && r.TLS == nil {
 		httpError(w, http.StatusNotFound, "Not Found")
 		return
 	}


### PR DESCRIPTION
This is a first step to implement #1009.
This adds the config option
```yaml
tls:
  allow_clear_doh: true
```
If `allow_clear_doh` is true (defaults to false), AdGuardHome allows serving DoH queries from `bind_host`:`bind_port` - so the normal http interface of AdGuardHome.

- Note
If you want to pass the remote ip to AdGuardHome, you can setup nginx as follows:
```
        location /dns-query {
              proxy_set_header Host $http_host;
              proxy_set_header X-Real-IP $remote_addr;
              proxy_redirect off;
              proxy_buffering off;
              proxy_pass http://127.0.0.1:3000;
        }
```