### PR TITLE
README -- plural word instead of singular in requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ You will need:
  * [go](https://golang.org/dl/) v1.13 or later.
  * [node.js](https://nodejs.org/en/download/) v10 or later.
 
-You can either install it via the provided links or use [brew.sh](https://brew.sh/) if you're on Mac:
+You can either install them via the provided links or use [brew.sh](https://brew.sh/) if you're on Mac:
 
 ```bash
 brew install go node


### PR DESCRIPTION
More than one requirement, so instead of `it` use plural `them`.