### PR TITLE
Polished the "Blocked services" function a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,3 +226,5 @@ This software wouldn't have been possible without:
 You might have seen that [CoreDNS](https://coredns.io) was mentioned here before — we've stopped using it in AdGuardHome. While we still use it on our servers for [AdGuard DNS](https://adguard.com/adguard-dns/overview.html) service, it seemed like an overkill for Home as it impeded with Home features that we plan to implement.
 
 For a full list of all node.js packages in use, please take a look at [client/package.json](https://github.com/AdguardTeam/AdGuardHome/blob/master/client/package.json) file.
+
+For info on which exact domains that are blocked by the *Blocked services* function, it can be found at [dnsfilter/blocked_services.go](https://github.com/DandelionSprout/AdGuardHome/blob/patch-1/dnsfilter/blocked_services.go)

--- a/README.md
+++ b/README.md
@@ -227,4 +227,4 @@ You might have seen that [CoreDNS](https://coredns.io) was mentioned here before
 
 For a full list of all node.js packages in use, please take a look at [client/package.json](https://github.com/AdguardTeam/AdGuardHome/blob/master/client/package.json) file.
 
-For info on which exact domains that are blocked by the *Blocked services* function, it can be found at [dnsfilter/blocked_services.go](https://github.com/DandelionSprout/AdGuardHome/blob/patch-1/dnsfilter/blocked_services.go)
+For info on which exact domains that are blocked by the *Blocked services* function, it can be found at [dnsfilter/blocked_services.go](https://github.com/AdguardTeam/AdGuardHome/blob/master/dnsfilter/blocked_services.go)

--- a/dnsfilter/blocked_services.go
+++ b/dnsfilter/blocked_services.go
@@ -34,7 +34,7 @@ var serviceRulesArray = []svc{
 	{"twitter", []string{"||twitter.com^", "||t.co^", "||twimg.com^"}},
 	{"youtube", []string{
 		"||youtube.com^",
-	        "||ytimg.com^",
+		"||ytimg.com^",
 		"||youtu.be^",
 		"||googlevideo.com^",
 		"||youtubei.googleapis.com^",

--- a/dnsfilter/blocked_services.go
+++ b/dnsfilter/blocked_services.go
@@ -50,7 +50,7 @@ var serviceRulesArray = []svc{
 		"||one.one^",
 		"||warp.plus^",
 		"||1.1.1.1^",
-		"||dns4torpnlfs2ifuz2s2yf3fc7rdmsbhm6rw75euj35pac6ap25zgqad.onion^"
+		"||dns4torpnlfs2ifuz2s2yf3fc7rdmsbhm6rw75euj35pac6ap25zgqad.onion^",
 	}},
 	{"amazon", []string{
 		"||amazon.com^",
@@ -116,7 +116,7 @@ var serviceRulesArray = []svc{
 		"||ixigua.com^",
 		"||muscdn.com^",
 		"||bytedance.map.fastly.net^",
-		"||douyin.com^"
+		"||douyin.com^",
 	}},
 }
 

--- a/dnsfilter/blocked_services.go
+++ b/dnsfilter/blocked_services.go
@@ -20,19 +20,19 @@ type svc struct {
 // client/src/components/ui/Icons.js
 var serviceRulesArray = []svc{
 	{"whatsapp", []string{"||whatsapp.net^", "||whatsapp.com^"}},
-	{"facebook", []string{"||facebook.com^", "||facebook.net^", "||fbcdn.net^", "||fb.me^", "||fb.com^", "||fbsbx.com^", "||messenger.com^"}},
+	{"facebook", []string{"||facebook.com^", "||facebook.net^", "||fbcdn.net^", "||fb.me^", "||fb.com^", "||fbsbx.com^", "||messenger.com^", "||facebookcorewwwi.onion^", "||fbcdn.com^"}},
 	{"twitter", []string{"||twitter.com^", "||t.co^", "||twimg.com^"}},
-	{"youtube", []string{"||youtube.com^", "||ytimg.com^", "||youtu.be^", "||googlevideo.com^", "||youtubei.googleapis.com^"}},
+	{"youtube", []string{"||youtube.com^", "||ytimg.com^", "||youtu.be^", "||googlevideo.com^", "||youtubei.googleapis.com^", "||youtube-nocookie.com^"}},
 	{"twitch", []string{"||twitch.tv^", "||ttvnw.net^"}},
 	{"netflix", []string{"||nflxext.com^", "||netflix.com^"}},
 	{"instagram", []string{"||instagram.com^", "||cdninstagram.com^"}},
 	{"snapchat", []string{"||snapchat.com^", "||sc-cdn.net^", "||impala-media-production.s3.amazonaws.com^"}},
-	{"discord", []string{"||discord.gg^", "||discordapp.net^", "||discordapp.com^"}},
+	{"discord", []string{"||discord.gg^", "||discordapp.net^", "||discordapp.com^", "||discord.media^"}},
 	{"ok", []string{"||ok.ru^"}},
 	{"skype", []string{"||skype.com^"}},
 	{"vk", []string{"||vk.com^"}},
 	{"origin", []string{"||origin.com^", "||signin.ea.com^", "||accounts.ea.com^"}},
-	{"steam", []string{"||steam.com^"}},
+	{"steam", []string{"||steam.com^", "||steampowered.com^"}},
 	{"epic_games", []string{"||epicgames.com^"}},
 	{"reddit", []string{"||reddit.com^", "||redditstatic.com^", "||redditmedia.com^", "||redd.it^"}},
 	{"mail_ru", []string{"||mail.ru^"}},
@@ -49,6 +49,8 @@ var serviceRulesArray = []svc{
 		"||cloudflare.cn^",
 		"||one.one^",
 		"||warp.plus^",
+		"||1.1.1.1^",
+		"||dns4torpnlfs2ifuz2s2yf3fc7rdmsbhm6rw75euj35pac6ap25zgqad.onion^"
 	}},
 	{"amazon", []string{
 		"||amazon.com^",
@@ -114,6 +116,7 @@ var serviceRulesArray = []svc{
 		"||ixigua.com^",
 		"||muscdn.com^",
 		"||bytedance.map.fastly.net^",
+		"||douyin.com^"
 	}},
 }
 

--- a/dnsfilter/blocked_services.go
+++ b/dnsfilter/blocked_services.go
@@ -20,9 +20,26 @@ type svc struct {
 // client/src/components/ui/Icons.js
 var serviceRulesArray = []svc{
 	{"whatsapp", []string{"||whatsapp.net^", "||whatsapp.com^"}},
-	{"facebook", []string{"||facebook.com^", "||facebook.net^", "||fbcdn.net^", "||fb.me^", "||fb.com^", "||fbsbx.com^", "||messenger.com^", "||facebookcorewwwi.onion^", "||fbcdn.com^"}},
+	{"facebook", []string{
+		"||facebook.com^",
+		"||facebook.net^",
+		"||fbcdn.net^",
+		"||fb.me^",
+		"||fb.com^",
+		"||fbsbx.com^",
+		"||messenger.com^",
+		"||facebookcorewwwi.onion^",
+		"||fbcdn.com^",
+	}},
 	{"twitter", []string{"||twitter.com^", "||t.co^", "||twimg.com^"}},
-	{"youtube", []string{"||youtube.com^", "||ytimg.com^", "||youtu.be^", "||googlevideo.com^", "||youtubei.googleapis.com^", "||youtube-nocookie.com^"}},
+	{"youtube", []string{
+		"||youtube.com^",
+	        "||ytimg.com^",
+		"||youtu.be^",
+		"||googlevideo.com^",
+		"||youtubei.googleapis.com^",
+		"||youtube-nocookie.com^",
+	}},
 	{"twitch", []string{"||twitch.tv^", "||ttvnw.net^"}},
 	{"netflix", []string{"||nflxext.com^", "||netflix.com^"}},
 	{"instagram", []string{"||instagram.com^", "||cdninstagram.com^"}},


### PR DESCRIPTION
After stumbling across the *blocked_services.go* file at random a week ago, I realised most of all that `||steam.com^` alone would have zero chance of blocking Steam as a whole, which I could testify to with the Steam Android app. Thus I became inspired to try to improve this whole function a bit.

Notes:
* I pondered for some days on whether to include .onion domains, since Tor Browser for Android completely disregards any DNS settings or VPNs that are in use. But eventually I decided it couldn't have made things *worse*, so I added them anyway.
* `||1.1.1.1^` was added **solely** because it had an identical GUI to `||cloudflare-dns.com^`. Ideally there should've been some kind of `$` qualifier that limited it to domain responses only and not IP CNAME responses, but I am not aware of any such qualifiers.
* Since it took me more than 7 months to find out that the content of the *Blocked services* blocklists were in fact publicly available and weren't treated as industry secrets or anything like that, I felt it'd be a good thing to make that fact more broadly announced; although I struggled to find a good place in the README to do so.
* I have of course turned on the "Allow edits from maintainers" button, as I do for all PRs to all projects of all kinds. It is *not* required to ask me to make any small commits and changes that you guys feel are needed.