### PR TITLE
Initial config for snap build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,7 +31,3 @@ apps:
     daemon: simple
     stop-command: AdGuardHome -s stop 
     restart-condition: always
-  status:
-    command: AdGuardHome -s status 
-  restart:
-    command: AdGuardHome -s restart 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,37 @@
+name: adguard-home
+base: core18
+version: '0.101.0-1'
+summary: Network-wide ads & trackers blocking DNS server
+description: |
+  AdGuard Home is a network-wide software for blocking ads & tracking. After
+  you set it up, it'll cover ALL your home devices, and you don't need any
+  client-side software for that.
+  It operates as a DNS server that re-routes tracking domains to a "black hole,"
+  thus preventing your devices from connecting to those servers. It's based
+  on software we use for our public AdGuard DNS servers -- both share a lot
+  of common code.
+
+grade: stable
+confinement: strict
+
+parts:
+  adguard-home:
+    plugin: make
+    source: .
+    build-snaps: [ node/13/stable, go ]
+    build-packages: [ build-essential ]
+    override-build: |
+      make
+      cp AdGuardHome $SNAPCRAFT_PART_INSTALL/
+
+apps:
+  dns:
+    command: AdGuardHome -c ${SNAP_COMMON}/AdGuardHome.yaml -w ${SNAP_DATA} --no-check-update
+    plugs: [ network-bind ]
+    daemon: simple
+    stop-command: AdGuardHome -s stop 
+    restart-condition: always
+  status:
+    command: AdGuardHome -s status 
+  restart:
+    command: AdGuardHome -s restart 


### PR DESCRIPTION
This adds the build configuration to make a snap package for AdGuard Home. Provides an easy way to provide AdGuard Home along with auto-updating features.

Currently, I reserved the adguard-home name in the app store, but kept it private for testing. I'd much rather hand it over to the development team though.