### PR TITLE
Correct architecture builds

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -18,7 +18,10 @@ grade: stable
 confinement: strict
 
 architectures:
-  - build-on: [ amd64, i386, arm64, armhf ]
+  - build-on: amd64
+  - build-on: armhf
+  - build-on: i386
+  - build-on: arm64
 
 parts:
   adguard-home:


### PR DESCRIPTION
The current syntax means it will build on one of the architectures to run on all. That would be useful if it was an arch-independent snap, such as a shell script. But this contains arch-specific binaries. Using the syntax here, will get four separate builds (one per arch) which is the desired outcome. More information in the docs at https://snapcraft.io/docs/architectures