### PR TITLE
Webhooks for syncing and automation

### DIFF
--- a/dhcpd/dhcp_http.go
+++ b/dhcpd/dhcp_http.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AdguardTeam/AdGuardHome/event"
 	"github.com/AdguardTeam/AdGuardHome/util"
 
 	"github.com/AdguardTeam/golibs/log"
@@ -92,7 +93,7 @@ func (s *Server) handleDHCPSetConfig(w http.ResponseWriter, r *http.Request) {
 		httpError(r, w, http.StatusBadRequest, "Invalid DHCP configuration: %s", err)
 		return
 	}
-	s.conf.ConfigModified()
+	s.conf.ConfigModified(event.DHCP)
 
 	if newconfig.Enabled {
 		staticIP, err := HasStaticIP(newconfig.InterfaceName)
@@ -314,7 +315,7 @@ func (s *Server) handleReset(w http.ResponseWriter, r *http.Request) {
 	s.conf.HTTPRegister = oldconf.HTTPRegister
 	s.conf.ConfigModified = oldconf.ConfigModified
 	s.conf.DBFilePath = oldconf.DBFilePath
-	s.conf.ConfigModified()
+	s.conf.ConfigModified(event.DHCP)
 }
 
 func (s *Server) registerHandlers() {

--- a/dhcpd/dhcpd.go
+++ b/dhcpd/dhcpd.go
@@ -51,7 +51,7 @@ type ServerConfig struct {
 	DBFilePath string `json:"-" yaml:"-"` // path to DB file
 
 	// Called when the configuration is changed by HTTP request
-	ConfigModified func() `json:"-" yaml:"-"`
+	ConfigModified func(string) `json:"-" yaml:"-"`
 
 	// Register an HTTP handler
 	HTTPRegister func(string, string, func(http.ResponseWriter, *http.Request)) `json:"-" yaml:"-"`

--- a/dnsfilter/blocked_services.go
+++ b/dnsfilter/blocked_services.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/AdguardTeam/AdGuardHome/event"
 	"github.com/AdguardTeam/golibs/log"
 	"github.com/AdguardTeam/urlfilter/rules"
 )
@@ -233,7 +234,7 @@ func (d *Dnsfilter) handleBlockedServicesSet(w http.ResponseWriter, r *http.Requ
 
 	log.Debug("Updated blocked services list: %d", len(list))
 
-	d.ConfigModified()
+	d.ConfigModified(event.BlockedServices)
 }
 
 // registerBlockedServicesHandlers - register HTTP handlers

--- a/dnsfilter/dnsfilter.go
+++ b/dnsfilter/dnsfilter.go
@@ -58,7 +58,7 @@ type Config struct {
 	AutoHosts *util.AutoHosts `yaml:"-"`
 
 	// Called when the configuration is changed by HTTP request
-	ConfigModified func() `yaml:"-"`
+	ConfigModified func(string) `yaml:"-"`
 
 	// Register an HTTP handler
 	HTTPRegister func(string, string, func(http.ResponseWriter, *http.Request)) `yaml:"-"`

--- a/dnsfilter/rewrites.go
+++ b/dnsfilter/rewrites.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/AdguardTeam/AdGuardHome/event"
 	"github.com/AdguardTeam/golibs/log"
 	"github.com/miekg/dns"
 )
@@ -180,7 +181,7 @@ func (d *Dnsfilter) handleRewriteAdd(w http.ResponseWriter, r *http.Request) {
 	log.Debug("Rewrites: added element: %s -> %s [%d]",
 		ent.Domain, ent.Answer, len(d.Config.Rewrites))
 
-	d.Config.ConfigModified()
+	d.Config.ConfigModified(event.DNSRewrite)
 }
 
 func (d *Dnsfilter) handleRewriteDelete(w http.ResponseWriter, r *http.Request) {
@@ -208,7 +209,7 @@ func (d *Dnsfilter) handleRewriteDelete(w http.ResponseWriter, r *http.Request) 
 	d.Config.Rewrites = arr
 	d.confLock.Unlock()
 
-	d.Config.ConfigModified()
+	d.Config.ConfigModified(event.DNSRewrite)
 }
 
 func (d *Dnsfilter) registerRewritesHandlers() {

--- a/dnsfilter/security.go
+++ b/dnsfilter/security.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AdguardTeam/AdGuardHome/event"
 	"github.com/AdguardTeam/dnsproxy/upstream"
 	"github.com/AdguardTeam/golibs/cache"
 	"github.com/AdguardTeam/golibs/log"
@@ -296,12 +297,12 @@ func httpError(r *http.Request, w http.ResponseWriter, code int, format string, 
 
 func (d *Dnsfilter) handleSafeBrowsingEnable(w http.ResponseWriter, r *http.Request) {
 	d.Config.SafeBrowsingEnabled = true
-	d.Config.ConfigModified()
+	d.Config.ConfigModified(event.DNSSafeBrowsing)
 }
 
 func (d *Dnsfilter) handleSafeBrowsingDisable(w http.ResponseWriter, r *http.Request) {
 	d.Config.SafeBrowsingEnabled = false
-	d.Config.ConfigModified()
+	d.Config.ConfigModified(event.DNSSafeBrowsing)
 }
 
 func (d *Dnsfilter) handleSafeBrowsingStatus(w http.ResponseWriter, r *http.Request) {
@@ -323,12 +324,12 @@ func (d *Dnsfilter) handleSafeBrowsingStatus(w http.ResponseWriter, r *http.Requ
 
 func (d *Dnsfilter) handleParentalEnable(w http.ResponseWriter, r *http.Request) {
 	d.Config.ParentalEnabled = true
-	d.Config.ConfigModified()
+	d.Config.ConfigModified(event.DNSParental)
 }
 
 func (d *Dnsfilter) handleParentalDisable(w http.ResponseWriter, r *http.Request) {
 	d.Config.ParentalEnabled = false
-	d.Config.ConfigModified()
+	d.Config.ConfigModified(event.DNSParental)
 }
 
 func (d *Dnsfilter) handleParentalStatus(w http.ResponseWriter, r *http.Request) {
@@ -351,12 +352,12 @@ func (d *Dnsfilter) handleParentalStatus(w http.ResponseWriter, r *http.Request)
 
 func (d *Dnsfilter) handleSafeSearchEnable(w http.ResponseWriter, r *http.Request) {
 	d.Config.SafeSearchEnabled = true
-	d.Config.ConfigModified()
+	d.Config.ConfigModified(event.DNSSafeSearch)
 }
 
 func (d *Dnsfilter) handleSafeSearchDisable(w http.ResponseWriter, r *http.Request) {
 	d.Config.SafeSearchEnabled = false
-	d.Config.ConfigModified()
+	d.Config.ConfigModified(event.DNSSafeSearch)
 }
 
 func (d *Dnsfilter) handleSafeSearchStatus(w http.ResponseWriter, r *http.Request) {

--- a/dnsforward/access.go
+++ b/dnsforward/access.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/AdguardTeam/AdGuardHome/event"
 	"github.com/AdguardTeam/golibs/log"
 	"github.com/AdguardTeam/urlfilter"
 	"github.com/AdguardTeam/urlfilter/filterlist"
@@ -196,7 +197,7 @@ func (s *Server) handleAccessSet(w http.ResponseWriter, r *http.Request) {
 	s.conf.BlockedHosts = j.BlockedHosts
 	s.access = a
 	s.Unlock()
-	s.conf.ConfigModified()
+	s.conf.ConfigModified(event.DNSAccess)
 
 	log.Debug("Access: updated lists: %d, %d, %d",
 		len(j.AllowedClients), len(j.DisallowedClients), len(j.BlockedHosts))

--- a/dnsforward/dnsforward.go
+++ b/dnsforward/dnsforward.go
@@ -191,7 +191,7 @@ type ServerConfig struct {
 	TLSCiphers  []uint16       // list of TLS ciphers to use
 
 	// Called when the configuration is changed by HTTP request
-	ConfigModified func()
+	ConfigModified func(string)
 
 	// Register an HTTP handler
 	HTTPRegister func(string, string, func(http.ResponseWriter, *http.Request))

--- a/dnsforward/dnsforward_http.go
+++ b/dnsforward/dnsforward_http.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/AdguardTeam/AdGuardHome/event"
 	"github.com/AdguardTeam/dnsproxy/upstream"
 	"github.com/AdguardTeam/golibs/jsonutil"
 	"github.com/AdguardTeam/golibs/log"
@@ -178,7 +179,7 @@ func (s *Server) handleSetConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.Unlock()
-	s.conf.ConfigModified()
+	s.conf.ConfigModified(event.DNSConfig)
 
 	if restart {
 		err = s.Reconfigure(nil)

--- a/event/event.go
+++ b/event/event.go
@@ -1,0 +1,34 @@
+package event
+
+const (
+	// DNSConfig event when dns config changes
+	DNSConfig = "dns_config"
+	// DNSRewrite event when rewrite rules change
+	DNSRewrite = "dns_rewrite"
+	// DNSSafeBrowsing event when safe browsing status changes
+	DNSSafeBrowsing = "dns_safe_browsing"
+	// DNSAccess event when ...
+	DNSAccess = "dns_access"
+	// DNSParental event when parental controls change
+	DNSParental = "dns_parental"
+	// DNSSafeSearch event when safe serach status changes
+	DNSSafeSearch = "dns_safe_search"
+	// BlockedServices event when blocked services change
+	BlockedServices = "blocked_services"
+	// DHCP event when dhcp settings change
+	DHCP = "dpcp"
+	// Stats event when stats config is modified
+	Stats = "stats"
+	// QueryLog event when query log config is modified
+	QueryLog = "query_log"
+	// Filter event when filtering lists and blacklist/whitelist change
+	Filter = "filter"
+	// FilterRule event when filter rules change
+	FilterRule = "filter_rule"
+	// I18N event when i18n settings change
+	I18N = "i19n"
+	// Client event when clients are added, removed, or modified
+	Client = "client"
+	// TLS event when tls settings change
+	TLS = "tls"
+)

--- a/home/clients_http.go
+++ b/home/clients_http.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/AdguardTeam/AdGuardHome/event"
 )
 
 type clientJSON struct {
@@ -173,7 +175,7 @@ func (clients *clientsContainer) handleAddClient(w http.ResponseWriter, r *http.
 		return
 	}
 
-	onConfigModified()
+	onConfigModified(event.Client)
 }
 
 // Remove client
@@ -196,7 +198,7 @@ func (clients *clientsContainer) handleDelClient(w http.ResponseWriter, r *http.
 		return
 	}
 
-	onConfigModified()
+	onConfigModified(event.Client)
 }
 
 type updateJSON struct {
@@ -235,7 +237,7 @@ func (clients *clientsContainer) handleUpdateClient(w http.ResponseWriter, r *ht
 		return
 	}
 
-	onConfigModified()
+	onConfigModified(event.Client)
 }
 
 // Get the list of clients by IP address list

--- a/home/config.go
+++ b/home/config.go
@@ -60,6 +60,8 @@ type configuration struct {
 
 	DHCP dhcpd.ServerConfig `yaml:"dhcp"`
 
+	Webhooks []Webhook `yaml:"webhooks"`
+
 	// Note: this array is filled only before file read/write and then it's cleared
 	Clients []clientObject `yaml:"clients"`
 

--- a/home/control_filtering.go
+++ b/home/control_filtering.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AdguardTeam/AdGuardHome/event"
 	"github.com/AdguardTeam/AdGuardHome/util"
 	"github.com/AdguardTeam/golibs/log"
 	"github.com/miekg/dns"
@@ -85,7 +86,7 @@ func (f *Filtering) handleFilteringAddURL(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	onConfigModified()
+	onConfigModified(event.Filter)
 	enableFilters(true)
 
 	_, err = fmt.Fprintf(w, "OK %d rules\n", filt.RulesCount)
@@ -128,7 +129,7 @@ func (f *Filtering) handleFilteringRemoveURL(w http.ResponseWriter, r *http.Requ
 	*filters = newFilters
 	config.Unlock()
 
-	onConfigModified()
+	onConfigModified(event.Filter)
 	enableFilters(true)
 
 	// Note: the old files "filter.txt.old" aren't deleted - it's not really necessary,
@@ -175,7 +176,7 @@ func (f *Filtering) handleFilteringSetURL(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	onConfigModified()
+	onConfigModified(event.Filter)
 	restart := false
 	if (status & statusEnabledChanged) != 0 {
 		// we must add or remove filter rules
@@ -208,7 +209,7 @@ func (f *Filtering) handleFilteringSetRules(w http.ResponseWriter, r *http.Reque
 	}
 
 	config.UserRules = strings.Split(string(body), "\n")
-	onConfigModified()
+	onConfigModified(event.FilterRule)
 	enableFilters(true)
 }
 
@@ -328,7 +329,7 @@ func (f *Filtering) handleFilteringConfig(w http.ResponseWriter, r *http.Request
 
 	config.DNS.FilteringEnabled = req.Enabled
 	config.DNS.FiltersUpdateIntervalHours = req.Interval
-	onConfigModified()
+	onConfigModified(event.Filter)
 	enableFilters(true)
 }
 

--- a/home/dns.go
+++ b/home/dns.go
@@ -17,7 +17,8 @@ import (
 )
 
 // Called by other modules when configuration is changed
-func onConfigModified() {
+func onConfigModified(e string) {
+	go webhookHandleEvent(e)
 	_ = config.write()
 }
 

--- a/home/i18n.go
+++ b/home/i18n.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/AdguardTeam/AdGuardHome/event"
 	"github.com/AdguardTeam/golibs/log"
 )
 
@@ -85,6 +86,6 @@ func handleI18nChangeLanguage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	config.Language = language
-	onConfigModified()
+	onConfigModified(event.I18N)
 	returnOK(w)
 }

--- a/home/tls.go
+++ b/home/tls.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/AdguardTeam/AdGuardHome/event"
 	"github.com/AdguardTeam/golibs/log"
 	"github.com/joomcode/errorx"
 )
@@ -268,7 +269,7 @@ func (t *TLSMod) handleTLSConfigure(w http.ResponseWriter, r *http.Request) {
 	t.status = status
 	t.confLock.Unlock()
 	t.setCertFileTime()
-	onConfigModified()
+	onConfigModified(event.TLS)
 	err = reconfigureDNSServer()
 	if err != nil {
 		httpError(w, http.StatusInternalServerError, "%s", err)

--- a/home/webhook.go
+++ b/home/webhook.go
@@ -1,0 +1,58 @@
+package home
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/AdguardTeam/AdGuardHome/util"
+	"github.com/AdguardTeam/golibs/log"
+)
+
+// Webhook objectd
+type Webhook struct {
+	URL           string   `yaml:"url"`
+	Authorization string   `yaml:"authorization"`
+	Events        []string `yaml:"categories"`
+}
+
+type webhookPayload struct {
+	Events []string `json:"events"`
+}
+
+func webhookHandleEvent(e string) {
+	client := &http.Client{
+		Timeout: time.Second,
+	}
+	for _, v := range config.Webhooks {
+		if util.ContainsString(v.Events, e) < 0 {
+			// this hook does not subscribe to this event
+			continue
+		}
+		body := &webhookPayload{
+			Events: []string{e},
+		}
+		buf := new(bytes.Buffer)
+		err := json.NewEncoder(buf).Encode(body)
+		if err != nil {
+			log.Debug("Failed to marshal Webhook payload")
+			continue
+		}
+
+		req, err := http.NewRequest("POST", v.URL, buf)
+		if err != nil {
+			log.Debug("Failed to notify %s of event '%s'", v.URL, e)
+			continue
+		}
+		req.Header.Add("Content-Type", "application/json")
+		if v.Authorization != "" {
+			req.Header.Add("Authorization", v.Authorization)
+		}
+		resp, err := client.Do(req)
+		if err == nil {
+			log.Debug("Notified %s of event '%s' and got response '%s'", v.URL, e, resp.Status)
+		}
+		resp.Body.Close()
+	}
+}

--- a/querylog/qlog_http.go
+++ b/querylog/qlog_http.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/AdguardTeam/AdGuardHome/event"
 	"github.com/AdguardTeam/golibs/jsonutil"
 	"github.com/AdguardTeam/golibs/log"
 	"github.com/miekg/dns"
@@ -159,7 +160,7 @@ func (l *queryLog) handleQueryLogConfig(w http.ResponseWriter, r *http.Request) 
 	l.conf = &conf
 	l.lock.Unlock()
 
-	l.conf.ConfigModified()
+	l.conf.ConfigModified(event.QueryLog)
 }
 
 // Register web handlers

--- a/querylog/querylog.go
+++ b/querylog/querylog.go
@@ -40,7 +40,7 @@ type Config struct {
 	AnonymizeClientIP bool   // anonymize clients' IP addresses
 
 	// Called when the configuration is changed by HTTP request
-	ConfigModified func()
+	ConfigModified func(string)
 
 	// Register an HTTP handler
 	HTTPRegister func(string, string, func(http.ResponseWriter, *http.Request))

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -22,7 +22,7 @@ type Config struct {
 	AnonymizeClientIP bool           // anonymize clients' IP addresses
 
 	// Called when the configuration is changed by HTTP request
-	ConfigModified func()
+	ConfigModified func(string)
 
 	// Register an HTTP handler
 	HTTPRegister func(string, string, func(http.ResponseWriter, *http.Request))

--- a/stats/stats_http.go
+++ b/stats/stats_http.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/AdguardTeam/AdGuardHome/event"
 	"github.com/AdguardTeam/golibs/log"
 )
 
@@ -76,7 +77,7 @@ func (s *statsCtx) handleStatsConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.setLimit(int(reqData.IntervalDays))
-	s.conf.ConfigModified()
+	s.conf.ConfigModified(event.Stats)
 }
 
 // Reset data

--- a/util/helpers.go
+++ b/util/helpers.go
@@ -69,6 +69,16 @@ func MinInt(a, b int) int {
 	return b
 }
 
+// ContainsString checks if str is found in []string
+func ContainsString(slice []string, str string) int {
+	for i, val := range slice {
+		if str == val {
+			return i
+		}
+	}
+	return -1
+}
+
 // IsOpenWrt checks if OS is OpenWRT
 func IsOpenWrt() bool {
 	if runtime.GOOS != "linux" {


### PR DESCRIPTION
This is my attempt at a preliminary solution to #573.  That's a pretty popular issue, and I think it deserves to be addressed.

See my comment on the issue for more details: https://github.com/AdguardTeam/AdGuardHome/issues/573#issuecomment-623792666

Adds new config, example:

```yaml
webhooks:
- url: http://target.url/endpoint
  authorization: "Token iuaorfjaljinfilauhiolkjsnaliufvwqier"
  categories:
  - dns_config
  - dns_rewrite
  - filter
```

I've opened this issue to start a discussion with the maintainers, but if it makes sense to do something like this, we still need

- [ ] tests 
- [ ] documentation
- [ ] UI support (maybe we can push this off for now?) 

I've also created https://github.com/subdavis/adguardhome-sync as a proof-of-concept microservice to subscribe to these webhooks and propagate updates.  I think the cleverness of that project comes from using TypeScript together with [openapi-generator](https://github.com/OpenAPITools/openapi-generator) so that future API changes will be detectable at build-time, making it easy to maintain.

EDIT: removed DRAFT status to avoid confusion.  Even though this is a work in progress, I'm asking for feedback now.