### PR TITLE
Update discord block for new domain

### DIFF
--- a/dnsfilter/blocked_services.go
+++ b/dnsfilter/blocked_services.go
@@ -52,7 +52,7 @@ var serviceRulesArray = []svc{
 		"||snapads.com^",
 		"||impala-media-production.s3.amazonaws.com^",
 	}},
-	{"discord", []string{"||discord.gg^", "||discordapp.net^", "||discordapp.com^", "||discord.media^"}},
+	{"discord", []string{"||discord.gg^", "||discordapp.net^", "||discordapp.com^", "||discord.com^", "||discord.media^"}},
 	{"ok", []string{"||ok.ru^"}},
 	{"skype", []string{"||skype.com^", "||skypeassets.com^"}},
 	{"vk", []string{"||vk.com^", "||userapi.com^", "||vk-cdn.net^", "||vkuservideo.net^"}},


### PR DESCRIPTION
Discord now also uses discord.com as domain, this adds it to the blocked services list