### PR TITLE
Added 2 entries for YouTube and Amazon AWS

### DIFF
--- a/dnsfilter/blocked_services.go
+++ b/dnsfilter/blocked_services.go
@@ -40,6 +40,7 @@ var serviceRulesArray = []svc{
 		"||googlevideo.com^",
 		"||youtubei.googleapis.com^",
 		"||youtube-nocookie.com^",
+		"||youtube",
 	}},
 	{"twitch", []string{"||twitch.tv^", "||ttvnw.net^", "||jtvnw.net^", "||twitchcdn.net^"}},
 	{"netflix", []string{"||nflxext.com^", "||netflix.com^", "||nflximg.net^", "||nflxvideo.net^"}},
@@ -110,6 +111,7 @@ var serviceRulesArray = []svc{
 		"||amazon.com.mx^",
 		"||amazon.co.uk^",
 		"||createspace.com^",
+		"||aws",
 	}},
 	{"ebay", []string{
 		"||ebay.com^",


### PR DESCRIPTION
Since I've learned this weekend that very, *very* few people out there know that entire TLDs can be blocked in adblockers, here's my honestly rather small attempt at showcasing the use of such.

Example pages:
```
! https://2018.rewind.youtube/
||youtube

! https://calculator.aws/
||aws
```