### PR TITLE
Fixing FreeBSD install

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/gobuffalo/packr v1.30.1
 	github.com/joomcode/errorx v1.0.1
-	github.com/kardianos/service v1.0.0
+	github.com/kardianos/service v1.1.0
 	github.com/krolaw/dhcp4 v0.0.0-20180925202202-7cead472c414
 	github.com/miekg/dns v1.1.29
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/joomcode/errorx v1.0.1 h1:CalpDWz14ZHd68fIqluJasJosAewpz2TFaJALrUxjrk
 github.com/joomcode/errorx v1.0.1/go.mod h1:kgco15ekB6cs+4Xjzo7SPeXzx38PbJzBwbnu9qfVNHQ=
 github.com/kardianos/service v1.0.0 h1:HgQS3mFfOlyntWX8Oke98JcJLqt1DBcHR4kxShpYef0=
 github.com/kardianos/service v1.0.0/go.mod h1:8CzDhVuCuugtsHyZoTvsOBuvonN/UDBvl0kH+BUxvbo=
+github.com/kardianos/service v1.1.0 h1:QV2SiEeWK42P0aEmGcsAgjApw/lRxkwopvT+Gu6t1/0=
+github.com/kardianos/service v1.1.0/go.mod h1:RrJI2xn5vve/r32U5suTbeaSGoMU6GbNPoj36CVYcHc=
 github.com/karrick/godirwalk v1.10.12/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/home/service.go
+++ b/home/service.go
@@ -272,6 +272,8 @@ func configureService(c *service.Config) {
 	// On OpenWrt we're using a different type of sysvScript
 	if util.IsOpenWrt() {
 		c.Option["SysvScript"] = openWrtScript
+	} else if util.IsFreeBSD() {
+		c.Option["SysvScript"] = freeBSDScript
 	}
 }
 
@@ -492,4 +494,17 @@ status() {
         exit 1
     fi
 }
+`
+const freeBSDScript = `#!/bin/sh
+# PROVIDE: {{.Name}}
+# REQUIRE: networking
+# KEYWORD: shutdown
+. /etc/rc.subr
+name="{{.Name}}"
+{{.Name}}_env="IS_DAEMON=1"
+{{.Name}}_user="root"
+pidfile="/var/run/${name}.pid"
+command="/usr/sbin/daemon"
+command_args="-P ${pidfile} -r -f {{.WorkingDirectory}}/{{.Name}}"
+run_rc_command "$1"
 `

--- a/util/helpers.go
+++ b/util/helpers.go
@@ -92,3 +92,12 @@ func IsOpenWrt() bool {
 
 	return strings.Contains(string(body), "OpenWrt")
 }
+
+// IsFreeBSD checks if OS is FreeBSD
+func IsFreeBSD() bool {
+	if runtime.GOOS == "freebsd" {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
Support to install AdGuardHome (`AdGuardHome -s install`) seems to be missing for FreeBSD. 
It looks like 1.0 version of `kardianos/service` package  does not seem to support FreeBSD. 

This patch has following changes

- Update `kardianos/service` to 1.1
- Add utility function (`util.IsFreeBSD()`) to detect if AdGuardHome is running on FreeBSD environment.
- Add FreeBSD rc script template to be processed by `kardianos/service`.

I have tested these changes on FreeBSD 12.1-Release on AMD64 and on ARM64 (Raspberry Pi 3B & AWS ARM64 AMI) platform.

In addition, I see that FreeBSD ARM64 (e.g. 64 bit Raspberry Pi) build is not available for downloads. I can help provide that build if AdGuard team is interested. (I have been running AdGuardHome on Raspberry Pi running FreeBSD 12.1 for over a week)