### PR TITLE
Fix #1940 - Corrects the provided homepage for "The Big List of Hacked Malware Web Sites"

### DIFF
--- a/client/src/helpers/filters/filters.json
+++ b/client/src/helpers/filters/filters.json
@@ -75,7 +75,7 @@
         "the-big-list-of-hacked-malware-web-sites": {
             "name": "The Big List of Hacked Malware Web Sites",
             "categoryId": "security",
-            "homepage": "https://github.com/hoshsadiq/adblock-nocoin-list/",
+            "homepage": "https://github.com/mitchellkrogza/The-Big-List-of-Hacked-Malware-Web-Sites",
             "source": "https://raw.githubusercontent.com/mitchellkrogza/The-Big-List-of-Hacked-Malware-Web-Sites/master/hacked-domains.list"
         },
         "scam-blocklist-by-durable-napkin": {


### PR DESCRIPTION
As simple as that.

Fix #1940. 