### PR TITLE
Support  system service options

### DIFF
--- a/home/home.go
+++ b/home/home.go
@@ -126,7 +126,7 @@ func Main(version string, channel string, armVer string) {
 	}()
 
 	if args.serviceControlAction != "" {
-		handleServiceControlAction(args.serviceControlAction)
+		handleServiceControlAction(args)
 		return
 	}
 

--- a/home/options.go
+++ b/home/options.go
@@ -1,0 +1,255 @@
+package home
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// options passed from command-line arguments
+type options struct {
+	verbose        bool   // is verbose logging enabled
+	configFilename string // path to the config file
+	workDir        string // path to the working directory where we will store the filters data and the querylog
+	bindHost       string // host address to bind HTTP server on
+	bindPort       int    // port to serve HTTP pages on
+	logFile        string // Path to the log file. If empty, write to stdout. If "syslog", writes to syslog
+	pidFile        string // File name to save PID to
+	checkConfig    bool   // Check configuration and exit
+	disableUpdate  bool   // If set, don't check for updates
+
+	// service control action (see service.ControlAction array + "status" command)
+	serviceControlAction string
+
+	// runningAsService flag is set to true when options are passed from the service runner
+	runningAsService bool
+
+	glinetMode bool // Activate GL-Inet mode
+}
+
+// functions used for their side-effects
+type effect func() error
+
+type arg struct {
+	description string // a short, English description of the argument
+	longName    string // the name of the argument used after '--'
+	shortName   string // the name of the argument used after '-'
+
+	// only one of updateWithValue, updateNoValue, and effect should be present
+
+	updateWithValue func(o options, v string) (options, error)         // the mutator for arguments with parameters
+	updateNoValue   func(o options) (options, error)                   // the mutator for arguments without parameters
+	effect          func(o options, exec string) (f effect, err error) // the side-effect closure generator
+}
+
+var args []arg
+
+var configArg = arg{
+	"Path to the config file",
+	"config", "c",
+	func(o options, v string) (options, error) { o.configFilename = v; return o, nil },
+	nil,
+	nil,
+}
+
+var workDirArg = arg{
+	"Path to the working directory",
+	"work-dir", "w",
+	func(o options, v string) (options, error) { o.workDir = v; return o, nil }, nil, nil,
+}
+
+var hostArg = arg{
+	"Host address to bind HTTP server on",
+	"host", "h",
+	func(o options, v string) (options, error) { o.bindHost = v; return o, nil }, nil, nil,
+}
+
+var portArg = arg{
+	"Port to serve HTTP pages on",
+	"port", "p",
+	func(o options, v string) (options, error) {
+		var err error
+		var p int
+		minPort, maxPort := 0, 1<<16-1
+		if p, err = strconv.Atoi(v); err != nil {
+			err = fmt.Errorf("port '%s' is not a number", v)
+		} else if p < minPort || p > maxPort {
+			err = fmt.Errorf("port %d not in range %d - %d", p, minPort, maxPort)
+		} else {
+			o.bindPort = p
+		}
+		return o, err
+	}, nil, nil,
+}
+
+var serviceArg = arg{
+	"Service control action: status, install, uninstall, start, stop, restart, reload (configuration)",
+	"service", "s",
+	func(o options, v string) (options, error) {
+		o.serviceControlAction = v
+		return o, nil
+	}, nil, nil,
+}
+
+var logfileArg = arg{
+	"Path to log file. If empty: write to stdout; if 'syslog': write to system log",
+	"logfile", "l",
+	func(o options, v string) (options, error) { o.logFile = v; return o, nil }, nil, nil,
+}
+
+var pidfileArg = arg{
+	"Path to a file where PID is stored",
+	"pidfile", "",
+	func(o options, v string) (options, error) { o.pidFile = v; return o, nil }, nil, nil,
+}
+
+var checkConfigArg = arg{
+	"Check configuration and exit",
+	"check-config", "",
+	nil, func(o options) (options, error) { o.checkConfig = true; return o, nil }, nil,
+}
+
+var noCheckUpdateArg = arg{
+	"Don't check for updates",
+	"no-check-update", "",
+	nil, func(o options) (options, error) { o.disableUpdate = true; return o, nil }, nil,
+}
+
+var verboseArg = arg{
+	"Enable verbose output",
+	"verbose", "v",
+	nil, func(o options) (options, error) { o.verbose = true; return o, nil }, nil,
+}
+
+var glinetArg = arg{
+	"Run in GL-Inet compatibility mode",
+	"glinet", "",
+	nil, func(o options) (options, error) { o.glinetMode = true; return o, nil }, nil,
+}
+
+var versionArg = arg{
+	"Show the version and exit",
+	"version", "",
+	nil, nil, func(o options, exec string) (effect, error) {
+		return func() error { fmt.Println(version()); os.Exit(0); return nil }, nil
+	},
+}
+
+var helpArg = arg{
+	"Print this help",
+	"help", "",
+	nil, nil, func(o options, exec string) (effect, error) {
+		return func() error { _ = printHelp(exec); os.Exit(64); return nil }, nil
+	},
+}
+
+func init() {
+	args = []arg{
+		configArg,
+		workDirArg,
+		hostArg,
+		portArg,
+		serviceArg,
+		logfileArg,
+		pidfileArg,
+		checkConfigArg,
+		noCheckUpdateArg,
+		verboseArg,
+		glinetArg,
+		versionArg,
+		helpArg,
+	}
+}
+
+func getUsageLines(exec string, args []arg) []string {
+	usage := []string{
+		"Usage:",
+		"",
+		fmt.Sprintf("%s [options]", exec),
+		"",
+		"Options:",
+	}
+	for _, arg := range args {
+		val := ""
+		if arg.updateWithValue != nil {
+			val = " VALUE"
+		}
+		if arg.shortName != "" {
+			usage = append(usage, fmt.Sprintf("  -%s, %-30s %s",
+				arg.shortName,
+				"--"+arg.longName+val,
+				arg.description))
+		} else {
+			usage = append(usage, fmt.Sprintf("  %-34s %s",
+				"--"+arg.longName+val,
+				arg.description))
+		}
+	}
+	return usage
+}
+
+func printHelp(exec string) error {
+	for _, line := range getUsageLines(exec, args) {
+		_, err := fmt.Println(line)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func argMatches(a arg, v string) bool {
+	return v == "--"+a.longName || (a.shortName != "" && v == "-"+a.shortName)
+}
+
+func parse(exec string, ss []string) (o options, f effect, err error) {
+	for i := 0; i < len(ss); i++ {
+		v := ss[i]
+		knownParam := false
+		for _, arg := range args {
+			if argMatches(arg, v) {
+				if arg.updateWithValue != nil {
+					if i+1 >= len(ss) {
+						return o, f, fmt.Errorf("got %s without argument", v)
+					}
+					i++
+					o, err = arg.updateWithValue(o, ss[i])
+					if err != nil {
+						return
+					}
+				} else if arg.updateNoValue != nil {
+					o, err = arg.updateNoValue(o)
+					if err != nil {
+						return
+					}
+				} else if arg.effect != nil {
+					var eff effect
+					eff, err = arg.effect(o, exec)
+					if err != nil {
+						return
+					}
+					if eff != nil {
+						prevf := f
+						f = func() error {
+							var err error
+							if prevf != nil {
+								err = prevf()
+							}
+							if err == nil {
+								err = eff()
+							}
+							return err
+						}
+					}
+				}
+				knownParam = true
+				break
+			}
+		}
+		if !knownParam {
+			return o, f, fmt.Errorf("unknown option %v", v)
+		}
+	}
+
+	return
+}

--- a/home/options_test.go
+++ b/home/options_test.go
@@ -1,0 +1,171 @@
+package home
+
+import (
+	"fmt"
+	"testing"
+)
+
+func testParseOk(t *testing.T, ss ...string) options {
+	o, _, err := parse("", ss)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	return o
+}
+
+func testParseErr(t *testing.T, descr string, ss ...string) {
+	_, _, err := parse("", ss)
+	if err == nil {
+		t.Fatalf("expected an error because %s but no error returned", descr)
+	}
+}
+
+func testParseParamMissing(t *testing.T, param string) {
+	testParseErr(t, fmt.Sprintf("%s parameter missing", param), param)
+}
+
+func TestParseVerbose(t *testing.T) {
+	if testParseOk(t).verbose {
+		t.Fatal("empty is not verbose")
+	}
+	if !testParseOk(t, "-v").verbose {
+		t.Fatal("-v is verbose")
+	}
+	if !testParseOk(t, "--verbose").verbose {
+		t.Fatal("--verbose is verbose")
+	}
+}
+
+func TestParseConfigFilename(t *testing.T) {
+	if testParseOk(t).configFilename != "" {
+		t.Fatal("empty is no config filename")
+	}
+	if testParseOk(t, "-c", "path").configFilename != "path" {
+		t.Fatal("-c is config filename")
+	}
+	testParseParamMissing(t, "-c")
+	if testParseOk(t, "--config", "path").configFilename != "path" {
+		t.Fatal("--configFilename is config filename")
+	}
+	testParseParamMissing(t, "--config")
+}
+
+func TestParseWorkDir(t *testing.T) {
+	if testParseOk(t).workDir != "" {
+		t.Fatal("empty is no work dir")
+	}
+	if testParseOk(t, "-w", "path").workDir != "path" {
+		t.Fatal("-w is work dir")
+	}
+	testParseParamMissing(t, "-w")
+	if testParseOk(t, "--work-dir", "path").workDir != "path" {
+		t.Fatal("--work-dir is work dir")
+	}
+	testParseParamMissing(t, "--work-dir")
+}
+
+func TestParseBindHost(t *testing.T) {
+	if testParseOk(t).bindHost != "" {
+		t.Fatal("empty is no host")
+	}
+	if testParseOk(t, "-h", "addr").bindHost != "addr" {
+		t.Fatal("-h is host")
+	}
+	testParseParamMissing(t, "-h")
+	if testParseOk(t, "--host", "addr").bindHost != "addr" {
+		t.Fatal("--host is host")
+	}
+	testParseParamMissing(t, "--host")
+}
+
+func TestParseBindPort(t *testing.T) {
+	if testParseOk(t).bindPort != 0 {
+		t.Fatal("empty is port 0")
+	}
+	if testParseOk(t, "-p", "65535").bindPort != 65535 {
+		t.Fatal("-p is port")
+	}
+	testParseParamMissing(t, "-p")
+	if testParseOk(t, "--port", "65535").bindPort != 65535 {
+		t.Fatal("--port is port")
+	}
+	testParseParamMissing(t, "--port")
+}
+
+func TestParseBindPortBad(t *testing.T) {
+	testParseErr(t, "not an int", "-p", "x")
+	testParseErr(t, "hex not supported", "-p", "0x100")
+	testParseErr(t, "port negative", "-p", "-1")
+	testParseErr(t, "port too high", "-p", "65536")
+	testParseErr(t, "port too high", "-p", "4294967297")           // 2^32 + 1
+	testParseErr(t, "port too high", "-p", "18446744073709551617") // 2^64 + 1
+}
+
+func TestParseLogfile(t *testing.T) {
+	if testParseOk(t).logFile != "" {
+		t.Fatal("empty is no log file")
+	}
+	if testParseOk(t, "-l", "path").logFile != "path" {
+		t.Fatal("-l is log file")
+	}
+	if testParseOk(t, "--logfile", "path").logFile != "path" {
+		t.Fatal("--logfile is log file")
+	}
+}
+
+func TestParsePidfile(t *testing.T) {
+	if testParseOk(t).pidFile != "" {
+		t.Fatal("empty is no pid file")
+	}
+	if testParseOk(t, "--pidfile", "path").pidFile != "path" {
+		t.Fatal("--pidfile is pid file")
+	}
+}
+
+func TestParseCheckConfig(t *testing.T) {
+	if testParseOk(t).checkConfig {
+		t.Fatal("empty is not check config")
+	}
+	if !testParseOk(t, "--check-config").checkConfig {
+		t.Fatal("--check-config is check config")
+	}
+}
+
+func TestParseDisableUpdate(t *testing.T) {
+	if testParseOk(t).disableUpdate {
+		t.Fatal("empty is not disable update")
+	}
+	if !testParseOk(t, "--no-check-update").disableUpdate {
+		t.Fatal("--no-check-update is disable update")
+	}
+}
+
+func TestParseService(t *testing.T) {
+	if testParseOk(t).serviceControlAction != "" {
+		t.Fatal("empty is no service command")
+	}
+	if testParseOk(t, "-s", "command").serviceControlAction != "command" {
+		t.Fatal("-s is service command")
+	}
+	if testParseOk(t, "--service", "command").serviceControlAction != "command" {
+		t.Fatal("--service is service command")
+	}
+}
+
+func TestParseGLInet(t *testing.T) {
+	if testParseOk(t).glinetMode {
+		t.Fatal("empty is not GL-Inet mode")
+	}
+	if !testParseOk(t, "--glinet").glinetMode {
+		t.Fatal("--glinet is GL-Inet mode")
+	}
+}
+
+func TestParseUnknown(t *testing.T) {
+	testParseErr(t, "unknown word", "x")
+	testParseErr(t, "unknown short", "-x")
+	testParseErr(t, "unknown long", "--x")
+	testParseErr(t, "unknown triple", "---x")
+	testParseErr(t, "unknown plus", "+x")
+	testParseErr(t, "unknown dash", "-")
+}

--- a/home/options_test.go
+++ b/home/options_test.go
@@ -169,3 +169,69 @@ func TestParseUnknown(t *testing.T) {
 	testParseErr(t, "unknown plus", "+x")
 	testParseErr(t, "unknown dash", "-")
 }
+
+func testSerialize(t *testing.T, o options, ss ...string) {
+	result := serialize(o)
+	if len(result) != len(ss) {
+		t.Fatalf("expected %s but got %s", ss, result)
+	}
+	for i, r := range result {
+		if r != ss[i] {
+			t.Fatalf("expected %s but got %s", ss, result)
+		}
+	}
+}
+
+func TestSerializeEmpty(t *testing.T) {
+	testSerialize(t, options{})
+}
+
+func TestSerializeConfigFilename(t *testing.T) {
+	testSerialize(t, options{configFilename: "path"}, "-c", "path")
+}
+
+func TestSerializeWorkDir(t *testing.T) {
+	testSerialize(t, options{workDir: "path"}, "-w", "path")
+}
+
+func TestSerializeBindHost(t *testing.T) {
+	testSerialize(t, options{bindHost: "addr"}, "-h", "addr")
+}
+
+func TestSerializeBindPort(t *testing.T) {
+	testSerialize(t, options{bindPort: 666}, "-p", "666")
+}
+
+func TestSerializeLogfile(t *testing.T) {
+	testSerialize(t, options{logFile: "path"}, "-l", "path")
+}
+
+func TestSerializePidfile(t *testing.T) {
+	testSerialize(t, options{pidFile: "path"}, "--pidfile", "path")
+}
+
+func TestSerializeCheckConfig(t *testing.T) {
+	testSerialize(t, options{checkConfig: true}, "--check-config")
+}
+
+func TestSerializeDisableUpdate(t *testing.T) {
+	testSerialize(t, options{disableUpdate: true}, "--no-check-update")
+}
+
+func TestSerializeService(t *testing.T) {
+	testSerialize(t, options{serviceControlAction: "run"}, "-s", "run")
+}
+
+func TestSerializeGLInet(t *testing.T) {
+	testSerialize(t, options{glinetMode: true}, "--glinet")
+}
+
+func TestSerializeMultiple(t *testing.T) {
+	testSerialize(t, options{
+		serviceControlAction: "run",
+		configFilename:       "config",
+		workDir:              "work",
+		pidFile:              "pid",
+		disableUpdate:        true,
+	}, "-c", "config", "-w", "work", "-s", "run", "--pidfile", "pid", "--no-check-update")
+}

--- a/home/service.go
+++ b/home/service.go
@@ -24,12 +24,14 @@ const (
 
 // Represents the program that will be launched by a service or daemon
 type program struct {
+	opts options
 }
 
 // Start should quickly start the program
 func (p *program) Start(s service.Service) error {
 	// Start should not block. Do the actual work async.
-	args := options{runningAsService: true}
+	args := p.opts
+	args.runningAsService = true
 	go run(args)
 	return nil
 }
@@ -125,7 +127,8 @@ func sendSigReload() {
 // run - this is a special command that is not supposed to be used directly
 // it is specified when we register a service, and it indicates to the app
 // that it is being run as a service/daemon.
-func handleServiceControlAction(action string) {
+func handleServiceControlAction(opts options) {
+	action := opts.serviceControlAction
 	log.Printf("Service control action: %s", action)
 
 	if action == "reload" {
@@ -137,15 +140,17 @@ func handleServiceControlAction(action string) {
 	if err != nil {
 		log.Fatal("Unable to find the path to the current directory")
 	}
+	runOpts := opts
+	runOpts.serviceControlAction = "run"
 	svcConfig := &service.Config{
 		Name:             serviceName,
 		DisplayName:      serviceDisplayName,
 		Description:      serviceDescription,
 		WorkingDirectory: pwd,
-		Arguments:        []string{"-s", "run"},
+		Arguments:        serialize(runOpts),
 	}
 	configureService(svcConfig)
-	prg := &program{}
+	prg := &program{runOpts}
 	s, err := service.New(prg, svcConfig)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
I found that when running AGH with `-s run`, no other command line options were respected. This behavior made it difficult to specify custom working directory, configuration file, pid file, update check disablement, or GL-Inet emulation mode (whatever that is) when running AGH as a service.

This PR is organized into 3 commits:
1. Factor the CLI argument parsing out of `home/home.go` into `home/options.go` and make it generally side-effect free; add some tests
2. Provide a pseudo-inverse serialization operation from an options struct back to CLI arguments (roundtrip is idempotent and canonicalizing)
3. Integrate serialization into the service system so that `-s install` will create a service using whatever other CLI arguments are passed to it and `-s run` will actually use other passed CLI args rather than silently ignoring them.

I'm happy to change names or reorganize tests or whatever you would like to have happen before this change is acceptable to merge. I don't have a great idea to easily test the service integration but it is relatively straightforward to inspect manually for correctness. I am running this patchset now.