### PR TITLE
ipset wildcard match support (dnsmasq parity)

### DIFF
--- a/dnsforward/ipset.go
+++ b/dnsforward/ipset.go
@@ -122,15 +122,17 @@ func (c *ipsetCtx) processMembers(ctx *dnsContext, addMember func(string, string
 
 	log.Debug("IPSET: found ipsets %v for host %s", ipsetNames, host)
 
-	for _, it := range ctx.proxyCtx.Res.Answer {
-		ip := c.getIP(it)
-		if ip == nil {
-			continue
-		}
+	if ctx.proxyCtx.Res != nil {
+		for _, it := range ctx.proxyCtx.Res.Answer {
+			ip := c.getIP(it)
+			if ip == nil {
+				continue
+			}
 
-		ipStr := ip.String()
-		for _, name := range ipsetNames {
-			addMember(host, name, ipStr)
+			ipStr := ip.String()
+			for _, name := range ipsetNames {
+				addMember(host, name, ipStr)
+			}
 		}
 	}
 

--- a/dnsforward/ipset.go
+++ b/dnsforward/ipset.go
@@ -131,7 +131,7 @@ func addToIpset(host string, ipsetName string, ipStr string) {
 // Call addMember for each (host, ipset, ip) triple
 func (c *ipsetCtx) processMembers(ctx *dnsContext, addMember func(string, string, string)) int {
 	req := ctx.proxyCtx.Req
-	if !(req.Question[0].Qtype == dns.TypeA ||
+	if req == nil || !(req.Question[0].Qtype == dns.TypeA ||
 		req.Question[0].Qtype == dns.TypeAAAA) ||
 		!ctx.responseFromUpstream {
 		return resultDone

--- a/dnsforward/ipset_test.go
+++ b/dnsforward/ipset_test.go
@@ -1,6 +1,7 @@
 package dnsforward
 
 import (
+	"net"
 	"testing"
 
 	"github.com/AdguardTeam/dnsproxy/proxy"
@@ -8,13 +9,91 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIPSET(t *testing.T) {
-	s := Server{}
-	s.conf.IPSETList = append(s.conf.IPSETList, "HOST.com/name")
-	s.conf.IPSETList = append(s.conf.IPSETList, "host2.com,host3.com/name23")
-	s.conf.IPSETList = append(s.conf.IPSETList, "host4.com/name4,name41")
-	c := ipsetCtx{}
+var s Server
+var c ipsetCtx
+var ctx *dnsContext
+
+type Binding struct {
+	host  string
+	ipset string
+	ipStr string
+}
+
+var b map[Binding]int
+
+func setup() {
+	s = Server{}
+	s.conf.IPSETList = []string{
+		"HOST.com/name",
+		"host2.com,host3.com/name23",
+		"host4.com/name4,name41",
+		"sub.host4.com/subhost4",
+	}
+
+	c = ipsetCtx{}
 	c.init(s.conf.IPSETList)
+
+	ctx = &dnsContext{
+		srv: &s,
+	}
+	ctx.responseFromUpstream = true
+	ctx.proxyCtx = &proxy.DNSContext{}
+
+	b = make(map[Binding]int)
+}
+
+func makeReq(fqdn string, qtype uint16) *dns.Msg {
+	return &dns.Msg{
+		Question: []dns.Question{
+			{
+				Name:  fqdn,
+				Qtype: qtype,
+			},
+		},
+	}
+}
+
+func makeReqA(fqdn string) *dns.Msg {
+	return makeReq(fqdn, dns.TypeA)
+}
+
+func makeReqAAAA(fqdn string) *dns.Msg {
+	return makeReq(fqdn, dns.TypeAAAA)
+}
+
+func makeA(fqdn string, ip net.IP) *dns.A {
+	return &dns.A{
+		Hdr: dns.RR_Header{Name: fqdn, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 0},
+		A:   ip,
+	}
+}
+
+func makeAAAA(fqdn string, ip net.IP) *dns.AAAA {
+	return &dns.AAAA{
+		Hdr:  dns.RR_Header{Name: fqdn, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 0},
+		AAAA: ip,
+	}
+}
+
+func makeCNAME(fqdn string, cnameFqdn string) *dns.CNAME {
+	return &dns.CNAME{
+		Hdr:    dns.RR_Header{Name: fqdn, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 0},
+		Target: cnameFqdn,
+	}
+}
+
+func addToBindings(host string, ipset string, ipStr string) {
+	binding := Binding{host, ipset, ipStr}
+	count := b[binding]
+	b[binding] = count + 1
+}
+
+func doProcess(t *testing.T) {
+	assert.Equal(t, resultDone, c.processMembers(ctx, addToBindings))
+}
+
+func TestIpsetParsing(t *testing.T) {
+	setup()
 
 	assert.Equal(t, "name", c.ipsetList["host.com"][0])
 	assert.Equal(t, "name23", c.ipsetList["host2.com"][0])
@@ -24,18 +103,74 @@ func TestIPSET(t *testing.T) {
 
 	_, ok := c.ipsetList["host0.com"]
 	assert.False(t, ok)
+}
 
-	ctx := &dnsContext{
-		srv: &s,
-	}
-	ctx.proxyCtx = &proxy.DNSContext{}
-	ctx.proxyCtx.Req = &dns.Msg{
-		Question: []dns.Question{
-			{
-				Name:  "host.com.",
-				Qtype: dns.TypeA,
-			},
+func TestIpsetNoAnswer(t *testing.T) {
+	setup()
+
+	ctx.proxyCtx.Req = makeReqA("HOST4.COM.")
+
+	doProcess(t)
+	assert.Equal(t, 0, len(b))
+}
+
+func TestIpsetCache(t *testing.T) {
+	setup()
+
+	ctx.proxyCtx.Req = makeReqA("HOST4.COM.")
+	ctx.proxyCtx.Res = &dns.Msg{
+		Answer: []dns.RR{
+			makeA("HOST4.COM.", net.IPv4(127, 0, 0, 1)),
+			makeAAAA("HOST4.COM.", net.IPv6loopback),
 		},
 	}
-	assert.Equal(t, resultDone, c.process(ctx))
+
+	doProcess(t)
+
+	assert.Equal(t, 1, b[Binding{"host4.com", "name4", "127.0.0.1"}])
+	assert.Equal(t, 1, b[Binding{"host4.com", "name41", "127.0.0.1"}])
+	assert.Equal(t, 1, b[Binding{"host4.com", "name4", net.IPv6loopback.String()}])
+	assert.Equal(t, 1, b[Binding{"host4.com", "name41", net.IPv6loopback.String()}])
+	assert.Equal(t, 4, len(b))
+
+	doProcess(t)
+
+	assert.Equal(t, 1, b[Binding{"host4.com", "name4", "127.0.0.1"}])
+	assert.Equal(t, 1, b[Binding{"host4.com", "name41", "127.0.0.1"}])
+	assert.Equal(t, 1, b[Binding{"host4.com", "name4", net.IPv6loopback.String()}])
+	assert.Equal(t, 1, b[Binding{"host4.com", "name41", net.IPv6loopback.String()}])
+	assert.Equal(t, 4, len(b))
+}
+
+func TestIpsetSubdomainOverride(t *testing.T) {
+	setup()
+
+	ctx.proxyCtx.Req = makeReqA("sub.host4.com.")
+	ctx.proxyCtx.Res = &dns.Msg{
+		Answer: []dns.RR{
+			makeA("sub.host4.com.", net.IPv4(127, 0, 0, 1)),
+		},
+	}
+
+	doProcess(t)
+
+	assert.Equal(t, 1, b[Binding{"sub.host4.com", "subhost4", "127.0.0.1"}])
+	assert.Equal(t, 1, len(b))
+}
+
+func TestIpsetCnameThirdParty(t *testing.T) {
+	setup()
+
+	ctx.proxyCtx.Req = makeReqA("host.com.")
+	ctx.proxyCtx.Res = &dns.Msg{
+		Answer: []dns.RR{
+			makeCNAME("host.com.", "foo.bar.baz.elb.amazonaws.com."),
+			makeA("foo.bar.baz.elb.amazonaws.com.", net.IPv4(8, 8, 8, 8)),
+		},
+	}
+
+	doProcess(t)
+
+	assert.Equal(t, 1, b[Binding{"host.com", "name", "8.8.8.8"}])
+	assert.Equal(t, 1, len(b))
 }

--- a/dnsforward/ipset_test.go
+++ b/dnsforward/ipset_test.go
@@ -105,6 +105,13 @@ func TestIpsetParsing(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestIpsetNoQuestion(t *testing.T) {
+	setup()
+
+	doProcess(t)
+	assert.Equal(t, 0, len(b))
+}
+
 func TestIpsetNoAnswer(t *testing.T) {
 	setup()
 

--- a/dnsforward/ipset_test.go
+++ b/dnsforward/ipset_test.go
@@ -158,6 +158,22 @@ func TestIpsetSubdomainOverride(t *testing.T) {
 	assert.Equal(t, 1, len(b))
 }
 
+func TestIpsetSubdomainWildcard(t *testing.T) {
+	setup()
+
+	ctx.proxyCtx.Req = makeReqA("sub.host.com.")
+	ctx.proxyCtx.Res = &dns.Msg{
+		Answer: []dns.RR{
+			makeA("sub.host.com.", net.IPv4(127, 0, 0, 1)),
+		},
+	}
+
+	doProcess(t)
+
+	assert.Equal(t, 1, b[Binding{"sub.host.com", "name", "127.0.0.1"}])
+	assert.Equal(t, 1, len(b))
+}
+
 func TestIpsetCnameThirdParty(t *testing.T) {
 	setup()
 


### PR DESCRIPTION
I started using the ipset functionality to grant restricted internet access to a smart projector and found that it did not behave as dnsmasq's ipset functionality. Specifically, `man dnsmasq` for `--ipset` states:

>  Domains and subdomains are matched in the same way as --address.

`man dnsmasq` for `--address` states:

> so --address=/example.com/ is equivalent to --server=/example.com/ and returns NXDOMAIN for example.com and all its subdomains.

and indeed we find at <http://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=blob;f=src/forward.c;hb=f60fea1fb0a288011f57a25dfb653b8f6f8b46b9#l588>:

```c
 591       /* Similar algorithm to search_servers. */
 592       struct ipsets *ipset_pos;
 593       unsigned int namelen = strlen(daemon->namebuff);
 594       unsigned int matchlen = 0;
 595       for (ipset_pos = daemon->ipsets; ipset_pos; ipset_pos = ipset_pos->next) 
 596         {
 597           unsigned int domainlen = strlen(ipset_pos->domain);
 598           char *matchstart = daemon->namebuff + namelen - domainlen;
 599           if (namelen >= domainlen && hostname_isequal(matchstart, ipset_pos->domain) &&
 600               (domainlen == 0 || namelen == domainlen || *(matchstart - 1) == '.' ) &&
 601               domainlen >= matchlen) 
 602             {
 603               matchlen = domainlen;
 604               sets = ipset_pos->sets;
 605             }
 606         }
```

Prior to this patchset, AGH was matching exactly and only the domain name passed in the ipset configuration setting and provided no way to specify the domain as a wildcard domain. One could argue that all topological operations should be available for this functionality (i.e. 'boundary domain', 'open set below domain', and 'closed set below domain') but dnsmasq does not offer that functionality and I do not require it for my deployment so it's out of scope.

In updating this behavior of `ipset`, I've refactored `dnsforward/ipset.go` slightly to make it easier to test by moving the side effects into a parameter function. I then expanded the tests and caught a segfault on some edge cases for DNS responses (missing question and/or answer sections... I'm not sure these arise in practice).

I have found some further issues that I have not included in this PR as I think they require a fundamental rethink of the way AGH interacts with ipsets. Specifically, invoking the `ipset` command is slow, the stderr is thrown away when an error occurs (and stdout which is logged is empty), there is no easy way to distinguish between IPv4 and IPv6 ipsets except for parsing `ipset list` (and this isn't done currently), so if you have both IPv4 and IPv6 ipsets, the logs will be full of error messages about bad `ipset add` invocations. Finally, because of the discarded stderr, when IPv4 `ipset add` commands occasionally fail, there is no way to know why.

Rather than trying to address these issues in the current design or doing the work myself before I submit it to you for review, I propose that AGH adopt https://github.com/ti-mo/netfilter and interface with a netlink kernel socket directly in pure go. I'm happy to reimplement the current `ipset add` functionality in terms of that library if you'd be willing to accept the new dependency.

Finally, please let me know if you'd like issues opened for any of the bugs or my dependency proposal. I am currently running this patchset and it is successfully keeping my projector from talking to anyone except NetFlix :-).