### PR TITLE
dnsfilter/blocked_services: update netflix with nflxso.net SLD

### DIFF
--- a/dnsfilter/blocked_services.go
+++ b/dnsfilter/blocked_services.go
@@ -43,7 +43,7 @@ var serviceRulesArray = []svc{
 		"||youtube",
 	}},
 	{"twitch", []string{"||twitch.tv^", "||ttvnw.net^", "||jtvnw.net^", "||twitchcdn.net^"}},
-	{"netflix", []string{"||nflxext.com^", "||netflix.com^", "||nflximg.net^", "||nflxvideo.net^"}},
+	{"netflix", []string{"||nflxext.com^", "||netflix.com^", "||nflximg.net^", "||nflxvideo.net^", "||nflxso.net^"}},
 	{"instagram", []string{"||instagram.com^", "||cdninstagram.com^"}},
 	{"snapchat", []string{
 		"||snapchat.com^",


### PR DESCRIPTION
I used this domain list as a starting point for a NetFlix ipset whitelist and found that nflxso.net was a critical domain needed to use the NetFlix UI (GUI elements and cover art static content).

This blocked services system is currently explicitly for blacklisting but it stands to reason that these domain sets could be used for whitelisting as well. Where do you see this functionality going? I have found that YouTube requires a couple of extra domains that aren't exclusively used by YouTube so this directory schema may need some updating if it becomes whitelistable as well.

Thanks!