### PR TITLE
Fix for config reload using 'AdGuardHome -s reload'

### DIFF
--- a/internal/home/service.go
+++ b/internal/home/service.go
@@ -104,7 +104,7 @@ func sendSigReload() {
 		return
 	}
 
-	pid, err := strconv.Atoi(parts[0])
+	pid, err := strconv.Atoi(strings.TrimSpace(parts[0]))
 	if err != nil {
 		log.Error("Can't read PID file %s: %s", pidfile, err)
 		return

--- a/internal/home/tls.go
+++ b/internal/home/tls.go
@@ -136,6 +136,10 @@ func (t *TLSMod) Reload() {
 	t.certLastMod = fi.ModTime().UTC()
 
 	_ = reconfigureDNSServer()
+
+	t.confLock.Lock()
+	tlsConf = t.conf
+	t.confLock.Unlock()
 	Context.web.TLSConfigChanged(tlsConf)
 }
 


### PR DESCRIPTION
Hi,

I tried to setup AdGuardHome 0.104.0 as service on Ubuntu 20.04 with custom automatic TLS certificate renewal and found two issues with service config reload via '-s reload':

1. When executing 'AdGuardHome -s reload', it fails in case when AGH's pid number is small - 'ps -C ... -o pid=' returns space padded value and Atoi() in sendSigReload() returns error. 
2. After receiving SIGHUP, TLSMod.Reload() loads updated config and certificates from files, but calls Context.web.TLSConfigChanged() with TLS config which was previously loaded in memory, and certificates (returned by web server to client) remain unchanged.

Pull request contains fixes for these two issues. Please review.
