### PR TITLE
Use zoneinfo from Go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,6 @@ RUN apk --update --no-cache add \
     ca-certificates \
     libcap \
     libressl \
-    tzdata \
   && rm -rf /tmp/* /var/cache/apk/*
 
 COPY --from=builder --chown=nobody:nogroup /app/AdGuardHome /opt/adguardhome/AdGuardHome


### PR DESCRIPTION
No need to install tzdata as we already use the zoneinfo from Go. And to also avoid issues like golang/go#42216.