### PR TITLE
External link use 'target="_blank" rel="noopener noreferrer"'

### DIFF
--- a/client/src/components/Settings/Clients/Form.js
+++ b/client/src/components/Settings/Clients/Form.js
@@ -259,7 +259,7 @@ let Form = (props) => {
                         </div>
                         <div className="form__desc mt-0 mb-2">
                             <Trans components={[
-                                <a href="https://github.com/AdguardTeam/AdGuardHome/wiki/Hosts-Blocklists#ctag"
+                                <a target="_blank" rel="noopener noreferrer" href="https://github.com/AdguardTeam/AdGuardHome/wiki/Hosts-Blocklists#ctag"
                                    key="0">link</a>,
                             ]}>
                                 tags_desc

--- a/client/src/components/Settings/Encryption/Form.js
+++ b/client/src/components/Settings/Encryption/Form.js
@@ -232,7 +232,7 @@ let Form = (props) => {
                             <Trans
                                 values={{ link: 'letsencrypt.org' }}
                                 components={[
-                                    <a href="https://letsencrypt.org/" key="0">
+                                    <a target="_blank" rel="noopener noreferrer" href="https://letsencrypt.org/" key="0">
                                         link
                                     </a>,
                                 ]}


### PR DESCRIPTION
1. tags_desc:
     <0>{{link}}</0>  -> https://github.com/AdguardTeam/AdGuardHome/wiki/Hosts-Blocklists#ctag
2. encryption_certificates_desc:
     <0>letsencrypt.org</0> -> https://letsencrypt.org