### PR TITLE
Add security to openapi spec

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -12,6 +12,9 @@
 'servers':
 - 'url': '/control'
 
+'security':
+- 'basicAuth': []
+
 'tags':
 - 'name': 'clients'
   'description': 'Clients list operations'
@@ -2084,3 +2087,7 @@
           'description': 'The error message, an opaque string.'
           'type': 'string'
       'type': 'object'
+  'securitySchemes':
+    'basicAuth':
+      'type': 'http'
+      'scheme': 'basic'


### PR DESCRIPTION
I went to create a client with the swagger codegen client (never tried it before) and after digging around in the generated code it looked like the auth settings were missing. After referencing [this](https://swagger.io/docs/specification/authentication/basic-authentication/) I got the codegen client working after adding those elements to the spec.