### PR TITLE
Remove a superfluous condition

### DIFF
--- a/client/src/helpers/validators.js
+++ b/client/src/helpers/validators.js
@@ -64,7 +64,7 @@ export const validateClientId = (value) => {
     if (!value) {
         return undefined;
     }
-    const formattedValue = value ? value.trim() : value;
+    const formattedValue = value.trim();
     if (formattedValue && !(
         R_IPV4.test(formattedValue)
             || R_IPV6.test(formattedValue)


### PR DESCRIPTION
`value` is always evaluated to true, due to the
check on the previous line