### PR TITLE
Remove Access-Control-Allow-Origin

### DIFF
--- a/internal/home/control.go
+++ b/internal/home/control.go
@@ -227,7 +227,6 @@ func postInstall(handler func(http.ResponseWriter, *http.Request)) func(http.Res
 			return
 		}
 
-		w.Header().Set("Access-Control-Allow-Origin", "*")
 		handler(w, r)
 	}
 }


### PR DESCRIPTION
It doesn't server any purpose, and allows website to
probe if AdGuard Home is currently running on the LAN of the
user by bruteforcing common IP addresses (192.168.1.0/24 and 192.168.0.0/24)
until one of them returns AGH's html.