### PR TITLE
WIP: Add udb-buf-size configuration option

### DIFF
--- a/internal/dnsforward/config.go
+++ b/internal/dnsforward/config.go
@@ -83,6 +83,7 @@ type FilteringConfig struct {
 	EnableDNSSEC           bool     `yaml:"enable_dnssec"`      // Set DNSSEC flag in outcoming DNS request
 	EnableEDNSClientSubnet bool     `yaml:"edns_client_subnet"` // Enable EDNS Client Subnet option
 	MaxGoroutines          uint32   `yaml:"max_goroutines"`     // Max. number of parallel goroutines for processing incoming requests
+	UDPBufSize             uint32   `yaml:"udp_buf_size"`       // The size of the UDP read buffer
 
 	// IPSET configuration - add IP addresses of the specified domain names to an ipset list
 	// Syntax:
@@ -168,6 +169,7 @@ func (s *Server) createProxyConfig() (proxy.Config, error) {
 		RequestHandler:         s.handleDNSRequest,
 		EnableEDNSClientSubnet: s.conf.EnableEDNSClientSubnet,
 		MaxGoroutines:          int(s.conf.MaxGoroutines),
+		UDPBufferSize:          int(s.conf.UDPBufSize),
 	}
 
 	if s.conf.CacheSize != 0 {


### PR DESCRIPTION
This allows the user to set the UDP read buffer size on the underlying UDP socket. On a Raspberry Pi 4, setting the UDP buffer size to 4M rather than the system default doubles the number of burst requests AGH can handle:

```
root@nas:~/software/blackhole# docker run --rm aiys0211/flamethrower_v0.10.2 -r google.com -n 1000 -c 10 -p 3333 192.168.1.224
binding to 0.0.0.0
flaming target(s) [192.168.1.224] on port 3333 with 10 concurrent generators, each sending 10 queries every 1ms on protocol udp
query generator [static] contains 1 record(s)
0.476239s: send: 1000, avg send: 1000, recv: 352, avg recv: 352, min/avg/max resp: 13.3312/37.2766/48.6955ms, in flight: 658, timeouts: 0
stopping, waiting up to 3s for in flight to finish...

------
run id      : 7fffb31d45d0
run start   : 2021-01-14T04:30:35Z
runtime     : 3.47748 s
total sent  : 1000
total rcvd  : 352
min resp    : 13.3312 ms
avg resp    : 37.2766 ms
max resp    : 48.6955 ms
avg r qps   : 352
avg s qps   : 1000
avg pkt     : 39 bytes
tcp conn.   : 0
timeouts    : 648 (64.8%)
bad recv    : 0
net errors  : 0
responses   :
  NOERROR: 352
```

```
root@nas:~/software/blackhole# docker run --rm aiys0211/flamethrower_v0.10.2 -r google.com -n 1000 -c 10 -p 3333 192.168.1.224
binding to 0.0.0.0
flaming target(s) [192.168.1.224] on port 3333 with 10 concurrent generators, each sending 10 queries every 1ms on protocol udp
query generator [static] contains 1 record(s)
0.476318s: send: 1000, avg send: 1000, recv: 725, avg recv: 725, min/avg/max resp: 1.86035/43.9398/75.2817ms, in flight: 285, timeouts: 0
stopping, waiting up to 3s for in flight to finish...

------
run id      : 7ffd09c5ae50
run start   : 2021-01-14T04:32:07Z
runtime     : 3.47772 s
total sent  : 1000
total rcvd  : 725
min resp    : 1.86035 ms
avg resp    : 43.9398 ms
max resp    : 75.2817 ms
avg r qps   : 725
avg s qps   : 1000
avg pkt     : 39 bytes
tcp conn.   : 0
timeouts    : 275 (27.5%)
bad recv    : 0
net errors  : 0
responses   :
  NOERROR: 725
```