### PR TITLE
Proposes adding tzdata to Dockerfile so that container will respect T…

### DIFF
--- a/scripts/make/Dockerfile
+++ b/scripts/make/Dockerfile
@@ -17,7 +17,7 @@ LABEL maintainer="AdGuard Team <devteam@adguard.com>" \
   org.opencontainers.image.licenses="GPL-3.0"
 
 # Update certificates.
-RUN apk --no-cache --update add ca-certificates libcap && \
+RUN apk --no-cache --update add ca-certificates libcap tzdata && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /opt/adguardhome/conf /opt/adguardhome/work && \
     chown -R nobody: /opt/adguardhome


### PR DESCRIPTION
…Z= environment variable.

Example docker-compose.yml

```
version: '3.6'

services:

  adguardhome:
    container_name: adguardhome
    image: adguard/adguardhome
    restart: unless-stopped
    environment:
      - TZ=Australia/Sydney
    ports:
      - "53:53/tcp"
      - "53:53/udp"
      - "8089:8089/tcp"
      - "3001:3000/tcp"
    volumes:
       - ./volumes/adguardhome/workdir:/opt/adguardhome/work
       - ./volumes/adguardhome/confdir:/opt/adguardhome/conf
```

Start container:

```
$ docker-compose up -d adguardhome
Creating adguardhome ... done
```

Test 1: shows container ignoring TZ= and running UTC.

```
$ docker exec adguardhome date
Wed Mar 31 11:05:37 UTC 2021
```

Add tzdata package to container:

```
$ docker exec adguardhome apk add --no-cache tzdata
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/armv7/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/armv7/APKINDEX.tar.gz
(1/1) Installing tzdata (2021a-r0)
Executing busybox-1.31.1-r19.trigger
OK: 8 MiB in 17 packages
```

Test 2: shows container respecting TZ= and running UTC+11.

```
$ docker exec adguardhome date
Wed Mar 31 22:07:58 AEDT 2021
```