### PR TITLE
Disabled autocapitalize on username field in mobile browsers

### DIFF
--- a/client/src/login/Login/Form.js
+++ b/client/src/login/Login/Form.js
@@ -27,6 +27,7 @@ const Form = (props) => {
                         component={renderInputField}
                         placeholder={t('username_placeholder')}
                         autoComplete="username"
+                        autocapitalize="none"
                         disabled={processing}
                         validate={[validateRequiredValue]}
                     />


### PR DESCRIPTION
The username is case sensitive. Since most usernames are not capitalized, it is annoying that mobile browsers automatically capitalize the first letter in the login username input field. This pull request adds the autocapitalize="none" property which disables such behavior.