### PR TITLE
Added Roblox and Minecraft to Blocked Services.

### DIFF
--- a/client/src/helpers/constants.js
+++ b/client/src/helpers/constants.js
@@ -253,6 +253,10 @@ export const SERVICES = [
         name: 'Mail.ru',
     },
     {
+        id: 'minecraft',
+        name: 'Minecraft',
+    },
+    {
         id: 'netflix',
         name: 'Netflix',
     },
@@ -275,6 +279,10 @@ export const SERVICES = [
     {
         id: 'reddit',
         name: 'Reddit',
+    },
+    {
+        id: 'roblox',
+        name: 'Roblox',
     },
     {
         id: 'skype',

--- a/internal/dnsfilter/blocked.go
+++ b/internal/dnsfilter/blocked.go
@@ -33,6 +33,8 @@ var serviceRulesArray = []svc{
 		"||fbcdn.com^",
 	}},
 	{"twitter", []string{"||twitter.com^", "||twttr.com^", "||t.co^", "||twimg.com^"}},
+	{"roblox", []string{"||roblox.com^"}},
+	{"minecraft", []string{"||minecraft.com^"}},
 	{"youtube", []string{
 		"||youtube.com^",
 		"||ytimg.com^",

--- a/internal/dnsfilter/blocked.go
+++ b/internal/dnsfilter/blocked.go
@@ -34,7 +34,7 @@ var serviceRulesArray = []svc{
 	}},
 	{"twitter", []string{"||twitter.com^", "||twttr.com^", "||t.co^", "||twimg.com^"}},
 	{"roblox", []string{"||roblox.com^"}},
-	{"minecraft", []string{"||minecraft.com^"}},
+	{"minecraft", []string{"||minecraft.net^"}},
 	{"youtube", []string{
 		"||youtube.com^",
 		"||ytimg.com^",


### PR DESCRIPTION
Updated blocked.go - Added Roblox and Minecraft Services.
Roblox.com will block all instances of Roblox game in any platform.
Minecraft.com will block all instances of Minecraft game in any platform.

I created a custom rule where I blocked both domains with all its subdomains and it works as expected. I just would like them to be added to the block services switch so it is easier and faster to control and apply to particular clients.