### PR TITLE
Replace Packr with go:embed for Web-UI memory improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/AdguardTeam/AdGuardHome
 
-go 1.15
+go 1.16
 
 require (
 	github.com/AdguardTeam/dnsproxy v0.37.2

--- a/internal/webembed/webembed.go
+++ b/internal/webembed/webembed.go
@@ -1,0 +1,24 @@
+// Package webembed contains AdGuard Home Web-UI resources.
+package webembed
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+)
+
+var webEmbed embed.FS
+
+// Embed - create embed
+func Embed(e embed.FS) {
+	webEmbed = e
+}
+
+// MakeFS - returns a embed http.FileSystem
+func MakeFS(prefix string) http.FileSystem {
+	subFS, err := fs.Sub(webEmbed, prefix)
+	if err != nil {
+		panic(err)
+	}
+	return http.FS(subFS)
+}

--- a/main.go
+++ b/main.go
@@ -1,11 +1,16 @@
-//go:generate rm -f ./internal/home/a_home-packr.go
-//go:generate packr -i ./internal/home -z
 package main
 
 import (
+	"embed"
+
 	"github.com/AdguardTeam/AdGuardHome/internal/home"
+	"github.com/AdguardTeam/AdGuardHome/internal/webembed"
 )
 
+//go:embed build/static build2/static
+var webEmbed embed.FS
+
 func main() {
+	webembed.Embed(webEmbed)
 	home.Main()
 }


### PR DESCRIPTION
- packr:
**boot**, VmRSS:     25896 kB
**access Web-UI**, VmRSS:     40152 kB

- go:embed
**boot**, VmRSS:     15264 kB
**access Web-UI**, VmRSS:     19952 kB

linux mipsle, no filters