### PR TITLE
feat: support unicast for dhcp replies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-ping/ping v0.0.0-20210506233800-ff8be3320020
 	github.com/google/go-cmp v0.5.5
+	github.com/google/gopacket v1.1.19
 	github.com/google/renameio v1.0.1
 	github.com/insomniacslk/dhcp v0.0.0-20210310193751-cfd4d47082c2
 	github.com/kardianos/service v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
+github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v1.0.1 h1:Lh/jXZmvZxb0BBeSY5VKEfidcbcbenKjZFzM/q0fSeU=
@@ -269,6 +271,7 @@ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -376,6 +379,7 @@ golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191216052735-49a3e744a425/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/dhcpd/sendEthernet.go
+++ b/internal/dhcpd/sendEthernet.go
@@ -1,0 +1,94 @@
+// Copyright 2018-present the CoreDHCP Authors. All rights reserved
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package dhcpd
+
+import (
+	"fmt"
+	"net"
+	"syscall"
+
+	"github.com/AdguardTeam/golibs/log"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/insomniacslk/dhcp/dhcpv4"
+)
+
+//this function sends an unicast to the hardware address defined in resp.ClientHWAddr,
+//the layer3 destination address is still the broadcast address;
+//iface: the interface where the DHCP message should be sent;
+//resp: DHCPv4 struct, which should be sent;
+func sendEthernet(iface net.Interface, resp *dhcpv4.DHCPv4) error {
+	eth := layers.Ethernet{
+		EthernetType: layers.EthernetTypeIPv4,
+		SrcMAC:       iface.HardwareAddr,
+		DstMAC:       resp.ClientHWAddr,
+	}
+	ip := layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		SrcIP:    resp.ServerIPAddr,
+		DstIP:    resp.YourIPAddr,
+		Protocol: layers.IPProtocolUDP,
+		Flags:    layers.IPv4DontFragment,
+	}
+	udp := layers.UDP{
+		SrcPort: dhcpv4.ServerPort,
+		DstPort: dhcpv4.ClientPort,
+	}
+
+	err := udp.SetNetworkLayerForChecksum(&ip)
+	if err != nil {
+		return fmt.Errorf("Send Ethernet: Couldn't set network layer: %v", err)
+	}
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{
+		ComputeChecksums: true,
+		FixLengths:       true,
+	}
+
+	// Decode a packet
+	packet := gopacket.NewPacket(resp.ToBytes(), layers.LayerTypeDHCPv4, gopacket.NoCopy)
+	dhcpLayer := packet.Layer(layers.LayerTypeDHCPv4)
+	dhcp, ok := dhcpLayer.(gopacket.SerializableLayer)
+	if !ok {
+		return fmt.Errorf("Layer %s is not serializable", dhcpLayer.LayerType().String())
+	}
+	err = gopacket.SerializeLayers(buf, opts, &eth, &ip, &udp, dhcp)
+	if err != nil {
+		return fmt.Errorf("Cannot serialize layer: %v", err)
+	}
+	data := buf.Bytes()
+
+	fd, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_RAW, 0)
+	if err != nil {
+		return fmt.Errorf("Send Ethernet: Cannot open socket: %v", err)
+	}
+	defer func() {
+		err = syscall.Close(fd)
+		if err != nil {
+			log.Error("Send Ethernet: Cannot close socket: %v", err)
+		}
+	}()
+
+	err = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+	if err != nil {
+		log.Error("Send Ethernet: Cannot set option for socket: %v", err)
+	}
+
+	var hwAddr [8]byte
+	copy(hwAddr[0:6], resp.ClientHWAddr[0:6])
+	ethAddr := syscall.SockaddrLinklayer{
+		Protocol: 0,
+		Ifindex:  iface.Index,
+		Halen:    6,
+		Addr:     hwAddr, //not used
+	}
+	err = syscall.Sendto(fd, data, 0, &ethAddr)
+	if err != nil {
+		return fmt.Errorf("Cannot send frame via socket: %v", err)
+	}
+	return nil
+}


### PR DESCRIPTION
closes #3443
closes #3053
and maybe addresses some of the latest DHCP bug issuses and maybe also
addresses #3366 

# Background
By using Wireshark I noticed most clients requests Unicast responses instead of Broadcasts from DHCP servers and these well-known / battle-tested DHCP servers respect these requirements. Some device fallback and also allow Broadcast responses, but some are not (like ESP32, ESP8266, my HP-printer, Chromecast, Smart-TV etc.).

# Changes
This PR adds support for unicast responses inspired / using code from [coredhcp](https://github.com/coredhcp/coredhcp/blob/master/server/sendEthernet.go). This code allows to send a response to a mac address by using [gopacket](https://github.com/google/gopacket) to create and send a raw network packet.

# TODO
- [x] detect if request wanted old broadcast response and properly answer if so
- [x] test if dhcp requests with broadcast flag are handled correctly

# Tests
- I tested it with some device I had lying around and it worked for all of them so far
  - Android
  - Linux PC
  - ESP32 / ESP8266
  - Chromecast
  - Alexa Echo Dot