### PR TITLE
Renamed Dutch to Nederlands in language selector

### DIFF
--- a/.twosky.json
+++ b/.twosky.json
@@ -19,7 +19,7 @@
       "it": "Italiano",
       "ja": "日本語",
       "ko": "한국어",
-      "nl": "Dutch",
+      "nl": "Nederlands",
       "no": "Norsk",
       "pl": "Polski",
       "pt-br": "Português (BR)",


### PR DESCRIPTION
In line with how the other languages have their local names.