### PR TITLE
Fix unsupported regex for QQ blocked rules

### DIFF
--- a/internal/filtering/blocked.go
+++ b/internal/filtering/blocked.go
@@ -181,7 +181,7 @@ var serviceRulesArray = []svc{
 	}},
 	{"qq", []string{
 		// block qq.com and subdomains excluding WeChat domains
-		"^(?!weixin|wx)([^.]+\\.)?qq\\.com$",
+		"||qq.com^$denyallow=wx*.qq.com|weixin.qq.com",
 		"||qqzaixian.com^",
 	}},
 	{"wechat", []string{


### PR DESCRIPTION
The source rule uses regex that Golang doesn't support and is now changed to a normal rule.