### PR TITLE
Updated PT locale - "Repor" replaced with "Actualizar"

### DIFF
--- a/client/src/__locales/pt-pt.json
+++ b/client/src/__locales/pt-pt.json
@@ -103,7 +103,7 @@
     "enabled_protection": "Ativar proteção",
     "disable_protection": "Desativar proteção",
     "disabled_protection": "Desativar proteção",
-    "refresh_statics": "Repor estatísticas",
+    "refresh_statics": "Actualizar estatísticas",
     "dns_query": "Consultas de DNS",
     "blocked_by": "<0>Bloqueado por filtros</0>",
     "stats_malware_phishing": "Malware/phishing bloqueados",


### PR DESCRIPTION
Updated PT locale
TLDR: "Repor" means "Reset" and "Actualizar" means "Refresh"
Under **refresh_statistics** "Repor" was used in translation which confuses users that may think that button is used to reset the statistics instead of updating them.