### PR TITLE
Add DOH bootstraps

### DIFF
--- a/internal/dnsforward/dnsforward.go
+++ b/internal/dnsforward/dnsforward.go
@@ -41,7 +41,7 @@ const (
 var defaultDNS = []string{
 	"https://dns10.quad9.net/dns-query",
 }
-var defaultBootstrap = []string{"9.9.9.10", "149.112.112.10", "2620:fe::10", "2620:fe::fe:10", "https://1.1.1.1/dns-query"}
+var defaultBootstrap = []string{"9.9.9.10", "149.112.112.10", "https://9.9.9.10/dns-query", "2620:fe::10", "2620:fe::fe:10"}
 
 // Often requested by all kinds of DNS probes
 var defaultBlockedHosts = []string{"version.bind", "id.server", "hostname.bind"}

--- a/internal/dnsforward/dnsforward.go
+++ b/internal/dnsforward/dnsforward.go
@@ -41,7 +41,7 @@ const (
 var defaultDNS = []string{
 	"https://dns10.quad9.net/dns-query",
 }
-var defaultBootstrap = []string{"9.9.9.10", "149.112.112.10", "2620:fe::10", "2620:fe::fe:10"}
+var defaultBootstrap = []string{"9.9.9.10", "149.112.112.10", "2620:fe::10", "2620:fe::fe:10", "https://1.1.1.1/dns-query"}
 
 // Often requested by all kinds of DNS probes
 var defaultBlockedHosts = []string{"version.bind", "id.server", "hostname.bind"}


### PR DESCRIPTION
If the ISP blocks (or redirects to an overloaded server) communication on port 53, adguardhome will not be able to resolve the ip address of the dns over https servers.
For this reason cloudflare (and many others) provide dns over https service on their ip addresses, without a domain name.

I tested this change by blocking everything with ufw on my local machine, and then I added https://1.1.1.1/dns-query to the list of bootstrap servers and it seems to work.