### PR TITLE
Remove `theme-color` from static HTML pages

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
-        <meta name="theme-color" content="#000000">
         <meta name="google" content="notranslate">
         <meta http-equiv="x-dns-prefetch-control" content="off">
         <meta name="mobile-web-app-capable" content="yes" />

--- a/client/public/install.html
+++ b/client/public/install.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
-        <meta name="theme-color" content="#000000">
         <meta name="google" content="notranslate">
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/client/public/login.html
+++ b/client/public/login.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
-        <meta name="theme-color" content="#000000">
         <meta name="google" content="notranslate">
         <link rel="apple-touch-icon" sizes="180x180" href="assets/apple-touch-icon-180x180.png" />
         <meta name="mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
This way, headers are no longer black, but the browser automatically fetches the appropriate color

**Current**:

<img width="1229" alt="Screen Shot 2022-01-18 at 9 01 06 PM" src="https://user-images.githubusercontent.com/19761269/149967804-02a6449a-eec9-41e0-b90e-7aa39b9ca80b.png">

**New**:

<img width="1229" alt="Screen Shot 2022-01-18 at 9 07 32 PM" src="https://user-images.githubusercontent.com/19761269/149968812-dab5465f-402e-4724-af32-d4ccbd6685b0.png">

This also lets CSS themes be compatible:

<img width="1229" alt="Screen Shot 2022-01-18 at 9 05 08 PM" src="https://user-images.githubusercontent.com/19761269/149968347-d0369869-0af6-479d-a491-83b7f917945c.png">