### PR TITLE
correct openapi schema

### DIFF
--- a/internal/home/controlfiltering.go
+++ b/internal/home/controlfiltering.go
@@ -316,7 +316,7 @@ type filterJSON struct {
 	URL         string `json:"url"`
 	Name        string `json:"name"`
 	RulesCount  uint32 `json:"rules_count"`
-	LastUpdated string `json:"last_updated"`
+	LastUpdated string `json:"last_updated,omitempty"`
 }
 
 type filteringConfig struct {

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1396,7 +1396,6 @@
       'required':
       - 'enabled'
       - 'id'
-      - 'last_updated'
       - 'name'
       - 'rules_count'
       - 'url'
@@ -1434,6 +1433,10 @@
           'type': 'array'
           'items':
             '$ref': '#/components/schemas/Filter'
+        'whitelist_filters':
+          'type': 'array'
+          'items':
+            '$ref': '#/components/schemas/Filter'
         'user_rules':
           'type': 'array'
           'items':
@@ -1451,14 +1454,7 @@
       'description': 'Filtering URL settings'
       'properties':
         'data':
-          'properties':
-            'enabled':
-              'type': 'boolean'
-            'name':
-              'type': 'string'
-            'url':
-              'type': 'string'
-          'type': 'object'
+          '$ref': '#/components/schemas/Filter'
         'url':
           'type': 'string'
         'whitelist':
@@ -1860,6 +1856,8 @@
           'description': 'Previously added URL containing filtering rules'
           'type': 'string'
           'example': 'https://filters.adtidy.org/windows/filters/15.txt'
+        'whitelist':
+          'type': 'boolean'
     'QueryLogItem':
       'type': 'object'
       'description': 'Query log item'


### PR DESCRIPTION
This PR fixes some issues in the openapi scheme.

- RemoveUrlRequest is missing property 'whitelist'
- FilterStatus is missing property 'whitelist_filters'
- FilterSetUrl property 'data' is set to type Filter instead of inline object
- 'last_updated' of Filter is not required. At least it comes back as an empty string from the API

It also sets the filter 'last_updated' property to omitempty, to make sure the Filter json and scheme are valid.