### PR TITLE
Case-insensitive username check

### DIFF
--- a/internal/home/auth.go
+++ b/internal/home/auth.go
@@ -636,7 +636,7 @@ func (a *Auth) UserFind(login, password string) User {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 	for _, u := range a.users {
-		if u.Name == login &&
+		if strings.ToLower(u.Name) == strings.ToLower(login) &&
 			bcrypt.CompareHashAndPassword([]byte(u.PasswordHash), []byte(password)) == nil {
 			return u
 		}

--- a/internal/home/auth_test.go
+++ b/internal/home/auth_test.go
@@ -87,6 +87,9 @@ func TestAuth(t *testing.T) {
 	u := a.UserFind("name", "password")
 	assert.NotEmpty(t, u.Name)
 
+	u = a.UserFind("Name", "password")
+	assert.NotEmpty(t, u.Name)
+
 	time.Sleep(3 * time.Second)
 
 	// load and remove expired sessions


### PR DESCRIPTION
Resolves #2581 by ensuring that auth checks for the username are performed by doing a lower-case comparison.

A test case was also added in `auth_test.go` to ensure that the case-insensitive check is correctly performed.