### PR TITLE
Update list of projects in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Here's what you can also do to contribute:
 * [Prometheus exporter for AdGuard Home](https://github.com/ebrianne/adguard-exporter) by [@ebrianne](https://github.com/ebrianne)
 * [AdGuard Home on GLInet routers](https://forum.gl-inet.com/t/adguardhome-on-gl-routers/10664) by [Gl-Inet](https://gl-inet.com/)
 * [Cloudron app](https://git.cloudron.io/cloudron/adguard-home-app) by [@gramakri](https://github.com/gramakri)
+* [Asuswrt-Merlin-AdGuardHome-Installer](https://github.com/jumpsmm7/Asuswrt-Merlin-AdGuardHome-Installer) by [@jumpsmm7](https://github.com/jumpsmm7) a.k.a [@SomeWhereOverTheRainBow](https://www.snbforums.com/members/somewhereovertherainbow.64179/)
 
 <a id="acknowledgments"></a>
 ## Acknowledgments


### PR DESCRIPTION
* Add Asuswrt-Merlin-AdGuardHome-Installer (a.k.a. the installer that made adguardhome available to Asuswrt-Merlin Asus Routers)