### PR TITLE
Fix crash due to concurrent r&w

### DIFF
--- a/internal/stats/unit.go
+++ b/internal/stats/unit.go
@@ -676,7 +676,9 @@ func (s *statsCtx) getData() (statsResponse, bool) {
 		timeUnit = Days
 	}
 
+	s.mu.Lock();
 	units, firstID := s.loadUnits(limit)
+	s.mu.Unlock();
 	if units == nil {
 		return statsResponse{}, false
 	}


### PR DESCRIPTION
I use AdGuardHomeExporter, which fetches the latest metrics via https every 10 seconds.
I noticed that AGH crashes frequently (four times today), due to a concurrent map iteration and map write.
This happens when I try to fetch the metrics, while it is getting updated.
I noticed the statsCtx has a mutex, that is not being used.

Fixes #4342 #4374