### PR TITLE
Fix #4714: correctly check thread can bind to privileged ports

### DIFF
--- a/internal/aghnet/net_linux.go
+++ b/internal/aghnet/net_linux.go
@@ -24,7 +24,7 @@ const dhcpcdConf = "etc/dhcpcd.conf"
 func canBindPrivilegedPorts() (can bool, err error) {
 	cnbs, err := unix.PrctlRetInt(
 		unix.PR_CAP_AMBIENT,
-		unix.PR_CAP_AMBIENT_IS_SET,
+		unix.PR_CAP_AMBIENT_RAISE,
 		unix.CAP_NET_BIND_SERVICE,
 		0,
 		0,


### PR DESCRIPTION
Context
---

In order for a non-root user to run AdGuardHome and allow it to bind to privileged ports (e.g. DNS tcp/53), linux offers a set of features collectively called *capabilities*. It can be simply described<sup>1</sup> but is hard to master. And I don't pretend I do.

### Issue

As detailed in [issues/4714](https://github.com/AdguardTeam/AdGuardHome/issues/4714), AduardHome starts by checking it has permission to bind to privileged ports. Unfortunately, the way that check is done makes it return a false negative in some conditions.

### Change

This PR fixes this test, and allow non-root users to run AdGuardHome in a docker container.


Details
---

### How it was

In the modified file, one can find the function definition of `canBindPrivilegedPorts()`. It delegues the check to `unix.PrctlRetInt`, a simple bind to Linux' [`prctl()`](https://man7.org/linux/man-pages/man2/prctl.2.html). The code used to search the capability `CAP_NET_BIND_SERVICE` in the **ambient** set (`PR_CAP_AMBIENT_IS_SET`).

But... even though the thread has this capability, `CAP_NET_BIND_SERVICE` has not (yet) been raised into its ambiant set, and the test fails leading to a premature exit of the program.

### How it will be

The fix is rather simple: we raise the capability to the ambient set.

If the call succeeds, the thread has indeed the privilege to bind to those ports. If it fails, it doesn't. If we happen by some spaghettisation to call multiple times `canBindPrivilegedPorts()`, the way capabilities and sets of capabilities have been implemented guaranties nothing happens.

### Alternatives

#### "Belt and Braces"

An alternative would be to both raise then check:
```go
func allowBindPrivilegedPorts() (can bool, err error) {
	cnbs, err := unix.PrctlRetInt(
		unix.PR_CAP_AMBIENT,
		unix.PR_CAP_AMBIENT_RAISE,
		unix.CAP_NET_BIND_SERVICE,
		0,
		0,
	)
	// Don't check the error because it's always nil on Linux.
	adm, _ := aghos.HaveAdminRights()

	return cnbs == 1 || adm, err
}

func canBindPrivilegedPorts() (can bool, err error) {
	cnbs, err := unix.PrctlRetInt(
		unix.PR_CAP_AMBIENT,
		unix.PR_CAP_AMBIENT_IS_SET,
		unix.CAP_NET_BIND_SERVICE,
		0,
		0,
	)
	// Don't check the error because it's always nil on Linux.
	adm, _ := aghos.HaveAdminRights()

	return cnbs == 1 || adm, err
}
```

IMHO, this brings nothing of value. Let me know if you disagree.

#### "Can I bind to 53? Let's find out!"

A simpler alternative would be to drop completly the idea to _ask_ if we can, but simply do and see what comes.

It could be done pre-emptively:
```go
func canBindPrivilegedPorts() (can bool, err error) {
    // bind to port 53
    // unbind
    return bound_ret, err
}
```

As I'm not a GO developer, I couldn't implement this alternative. If you'd prefer it, please express it by providing a PR.

_______
<sup>1</sup> [`man capabilities`](https://man7.org/linux/man-pages/man7/capabilities.7.html)
>   For the purpose of performing permission checks, traditional UNIX
       implementations distinguish two categories of processes:
       privileged processes (whose effective user ID is 0, referred to
       as superuser or root), and unprivileged processes (whose
       effective UID is nonzero).  Privileged processes bypass all
       kernel permission checks, while unprivileged processes are
       subject to full permission checking based on the process's
       credentials (usually: effective UID, effective GID, and
       supplementary group list).
>
> Starting with kernel 2.2, Linux divides the privileges
       traditionally associated with superuser into distinct units,
       known as capabilities, which can be independently enabled and
       disabled.  Capabilities are a per-thread attribute.