### PR TITLE
disable notify in forked repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,8 @@
     # Use always() to signal to the runner that this job must run even if the
     # previous ones failed.
     'if':
-      ${{ always() &&
+      ${{ github.repository_owner == 'AdguardTeam' &&
+        always() &&
         (
           github.event_name == 'push' ||
           github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,8 @@
     # Use always() to signal to the runner that this job must run even if the
     # previous ones failed.
     'if':
-      ${{ always() &&
+      ${{ github.repository_owner == 'AdguardTeam' &&
+        always() &&
         (
           github.event_name == 'push' ||
           github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
This is for us who fork this repository, and when we push a commit, we will always get two errors in github actions.

For example:

https://github.com/hellodword/AdGuardHome/actions?query=is%3Afailure