### PR TITLE
bugfix: Fixed bug which was causing clients to continue following glo…

### DIFF
--- a/internal/home/dns.go
+++ b/internal/home/dns.go
@@ -335,8 +335,6 @@ func applyAdditionalFiltering(clientIP net.IP, clientID string, setts *filtering
 	// pref is a prefix for logging messages around the scope.
 	const pref = "applying filters"
 
-	Context.filters.ApplyBlockedServices(setts, nil)
-
 	log.Debug("%s: looking for client with ip %s and clientid %q", pref, clientIP, clientID)
 
 	if clientIP == nil {
@@ -359,6 +357,8 @@ func applyAdditionalFiltering(clientIP net.IP, clientID string, setts *filtering
 
 	if c.UseOwnBlockedServices {
 		Context.filters.ApplyBlockedServices(setts, c.BlockedServices)
+	} else {
+		Context.filters.ApplyBlockedServices(setts, nil)
 	}
 
 	setts.ClientName = c.Name


### PR DESCRIPTION
This PR fixes #4982 

This line, 
https://github.com/AdguardTeam/AdGuardHome/blob/2ffea605cffd38604f46338857c772d44494798f/internal/home/dns.go#L338

adds globally blocked services because of the line here, https://github.com/AdguardTeam/AdGuardHome/blob/2ffea605cffd38604f46338857c772d44494798f/internal/filtering/blocked.go#L437

It should not call `Context.filters.ApplyBlockedServices(setts, nil)` for a client which has opted to ignore global blocked services.