### PR TITLE
Fix #4925: Allow users to choose TLS ciphers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,18 @@ and this project adheres to
 
 See also the [v0.107.16 GitHub milestone][ms-v0.107.15].
 
-[ms-v0.107.16]:   https://github.com/AdguardTeam/AdGuardHome/milestone/52?closed=1
--->
+[ms-v0.107.16]:   https://github.com/AdguardTeam/AdGuardHome/milestone/52?closed=
 
+### Added
+
+- The new optional `tls.override_tls_ciphers` property list, which can be set in
+  the configuration file.  It allows overriding TLS Ciphers that are used for
+  https listeners ([#4925])
+
+[#4925]: https://github.com/AdguardTeam/AdGuardHome/issues/4925
+
+
+-->
 
 
 ## [v0.107.15] - 2022-10-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ and this project adheres to
 See also the [v0.107.16 GitHub milestone][ms-v0.107.15].
 
 [ms-v0.107.16]:   https://github.com/AdguardTeam/AdGuardHome/milestone/52?closed=
-
 -->
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+
+### Added
+
+- The new optional `tls.override_tls_ciphers` property list, which can be set in
+  the configuration file.  It allows overriding TLS Ciphers that are used for
+  https listeners ([#4925])
+
+[#4925]: https://github.com/AdguardTeam/AdGuardHome/issues/4925
+
 <!--
 ## [v0.108.0] - TBA (APPROX.)
 -->
@@ -23,15 +32,6 @@ and this project adheres to
 See also the [v0.107.16 GitHub milestone][ms-v0.107.15].
 
 [ms-v0.107.16]:   https://github.com/AdguardTeam/AdGuardHome/milestone/52?closed=
-
-### Added
-
-- The new optional `tls.override_tls_ciphers` property list, which can be set in
-  the configuration file.  It allows overriding TLS Ciphers that are used for
-  https listeners ([#4925])
-
-[#4925]: https://github.com/AdguardTeam/AdGuardHome/issues/4925
-
 
 -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to
 
 See also the [v0.107.16 GitHub milestone][ms-v0.107.15].
 
-[ms-v0.107.16]:   https://github.com/AdguardTeam/AdGuardHome/milestone/52?closed=
+[ms-v0.107.16]: https://github.com/AdguardTeam/AdGuardHome/milestone/52?closed=1
 -->
 
 

--- a/internal/aghtls/aghtls.go
+++ b/internal/aghtls/aghtls.go
@@ -34,11 +34,14 @@ func SaferCipherSuites() (safe []uint16) {
 	return safe
 }
 
-func UserPreferredCipherSuites(ciphers []string) (userCiphers []uint16) {
+// ParseCipherIDs returns a set of cipher suites with the cipher names provided
+func ParseCipherIDs(ciphers []string) (userCiphers []uint16) {
 	for _, s := range tls.CipherSuites() {
 		if slices.Contains(ciphers, s.Name) {
 			userCiphers = append(userCiphers, s.ID)
 			log.Debug("user specified cipher : %s, ID : %d", s.Name, s.ID)
+		} else {
+			log.Error("unknown cipher : %s ", s)
 		}
 	}
 

--- a/internal/aghtls/aghtls.go
+++ b/internal/aghtls/aghtls.go
@@ -3,9 +3,7 @@ package aghtls
 
 import (
 	"crypto/tls"
-
-	"github.com/AdguardTeam/golibs/log"
-	"golang.org/x/exp/slices"
+	"fmt"
 )
 
 // SaferCipherSuites returns a set of default cipher suites with vulnerable and
@@ -35,15 +33,26 @@ func SaferCipherSuites() (safe []uint16) {
 }
 
 // ParseCipherIDs returns a set of cipher suites with the cipher names provided
-func ParseCipherIDs(ciphers []string) (userCiphers []uint16) {
-	for _, s := range tls.CipherSuites() {
-		if slices.Contains(ciphers, s.Name) {
-			userCiphers = append(userCiphers, s.ID)
-			log.Debug("user specified cipher : %s, ID : %d", s.Name, s.ID)
+func ParseCipherIDs(ciphers []string) (userCiphers []uint16, err error) {
+	for _, cipher := range ciphers {
+		exists, cipherID := CipherExists(cipher)
+		if exists {
+			userCiphers = append(userCiphers, cipherID)
 		} else {
-			log.Error("unknown cipher : %s ", s)
+			return nil, fmt.Errorf("unknown cipher : %s ", cipher)
 		}
 	}
 
-	return userCiphers
+	return userCiphers, nil
+}
+
+// CipherExists returns cipherid if exists, else return false in boolean
+func CipherExists(cipher string) (exists bool, cipherID uint16) {
+	for _, s := range tls.CipherSuites() {
+		if s.Name == cipher {
+			return true, s.ID
+		}
+	}
+
+	return false, 0
 }

--- a/internal/dnsforward/config.go
+++ b/internal/dnsforward/config.go
@@ -166,8 +166,10 @@ type TLSConfig struct {
 	// DNS names from certificate (SAN) or CN value from Subject
 	dnsNames []string
 
-	// ciphers specified by user
-	TLSCiphers []string `yaml:"tls_ciphers" json:"-"`
+	// OverrideTLSCiphers holds the cipher names. If the slice is empty
+	// default set of ciphers are used for https listener, else this is
+	// considered.
+	OverrideTLSCiphers []string `yaml:"override_tls_ciphers" json:"-"`
 }
 
 // DNSCryptConfig is the DNSCrypt server configuration struct.

--- a/internal/home/home.go
+++ b/internal/home/home.go
@@ -369,6 +369,11 @@ func initWeb(args options, clientBuildFS fs.FS) (web *Web, err error) {
 		}
 	}
 
+	tlsCiphers, err := getTLSCiphers()
+	if err != nil {
+		return nil, err
+	}
+
 	webConf := webConfig{
 		firstRun:     Context.firstRun,
 		BindHost:     config.BindHost,
@@ -383,7 +388,7 @@ func initWeb(args options, clientBuildFS fs.FS) (web *Web, err error) {
 		clientBetaFS: clientBetaFS,
 
 		serveHTTP3: config.DNS.ServeHTTP3,
-		tlsCiphers: getTLSCiphers(),
+		tlsCiphers: tlsCiphers,
 	}
 
 	web = newWeb(&webConf)
@@ -889,15 +894,13 @@ type jsonError struct {
 	Message string `json:"message"`
 }
 
-// getTLSCiphers check for overriden tls ciphers, if the slice is
+// getTLSCiphers check for overridden tls ciphers, if the slice is
 // empty, then default safe ciphers are used
-func getTLSCiphers() []uint16 {
-	var cipher []uint16
-
+func getTLSCiphers() (cipherIds []uint16, err error) {
 	if len(config.TLS.OverrideTLSCiphers) == 0 {
-		cipher = aghtls.SaferCipherSuites()
+		return aghtls.SaferCipherSuites(), nil
 	} else {
-		cipher = aghtls.ParseCipherIDs(config.TLS.OverrideTLSCiphers)
+		log.Info("Overriding TLS Ciphers : %s", config.TLS.OverrideTLSCiphers)
+		return aghtls.ParseCipherIDs(config.TLS.OverrideTLSCiphers)
 	}
-	return cipher
 }

--- a/internal/home/home.go
+++ b/internal/home/home.go
@@ -383,7 +383,7 @@ func initWeb(args options, clientBuildFS fs.FS) (web *Web, err error) {
 		clientBetaFS: clientBetaFS,
 
 		serveHTTP3: config.DNS.ServeHTTP3,
-		tlsCiphers: config.TLS.TLSCiphers,
+		tlsCiphers: getTLSCiphers(),
 	}
 
 	web = newWeb(&webConf)
@@ -887,4 +887,17 @@ func getHTTPProxy(_ *http.Request) (*url.URL, error) {
 type jsonError struct {
 	// Message is the error message, an opaque string.
 	Message string `json:"message"`
+}
+
+// getTLSCiphers check for overriden tls ciphers, if the slice is
+// empty, then default safe ciphers are used
+func getTLSCiphers() []uint16 {
+	var cipher []uint16
+
+	if len(config.TLS.OverrideTLSCiphers) == 0 {
+		cipher = aghtls.SaferCipherSuites()
+	} else {
+		cipher = aghtls.ParseCipherIDs(config.TLS.OverrideTLSCiphers)
+	}
+	return cipher
 }

--- a/internal/home/web.go
+++ b/internal/home/web.go
@@ -33,7 +33,6 @@ const (
 )
 
 type webConfig struct {
-
 	// Ciphers that are used for https listener
 	tlsCiphers []uint16
 

--- a/internal/home/web.go
+++ b/internal/home/web.go
@@ -318,7 +318,7 @@ func (web *Web) tlsServerLoop() {
 		printHTTPAddresses(aghhttp.SchemeHTTPS)
 
 		if web.conf.serveHTTP3 {
-			go web.mustStartHTTP3(addr)
+			go web.mustStartHTTP3(addr, cipher)
 		}
 
 		log.Debug("web: starting https server")
@@ -330,7 +330,7 @@ func (web *Web) tlsServerLoop() {
 	}
 }
 
-func (web *Web) mustStartHTTP3(address string) {
+func (web *Web) mustStartHTTP3(address string, ciphers []uint16) {
 	defer log.OnPanic("web: http3")
 
 	web.httpsServer.server3 = &http3.Server{
@@ -340,7 +340,7 @@ func (web *Web) mustStartHTTP3(address string) {
 		TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{web.httpsServer.cert},
 			RootCAs:      Context.tlsRoots,
-			CipherSuites: aghtls.SaferCipherSuites(),
+			CipherSuites: ciphers,
 			MinVersion:   tls.VersionTLS12,
 		},
 		Handler: withMiddlewares(Context.mux, limitRequestBody),


### PR DESCRIPTION
Issue https://github.com/AdguardTeam/AdGuardHome/issues/4925

The Cipher `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA` needs to be supported in order to pass `Forward Secrecy` test of [SSL Labs](https://www.ssllabs.com/ssltest/analyze.html)

SSL Lab result after supporting this Cipher

<img width="989" alt="image" src="https://user-images.githubusercontent.com/15570570/191305455-8cf2fc0f-b90d-4b26-bbe6-bbcf0ee823d8.png">

Ref : https://www.namecheap.com/support/knowledgebase/article.aspx/9653/38/how-to-check-whether-the-server-supports-forward-secrecy/


This Cipher is allowed in [d.adguard-dns.com](d.adguard-dns.com) as well, 
SSL Labs report : [link](https://www.ssllabs.com/ssltest/analyze.html?d=d.adguard%2ddns.com&s=94.140.14.49&latest)