### PR TITLE
Fix #4986 Web UI HTTP/3 not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ and this project adheres to
 
 
 ## [Unreleased]
+### Fixed
+- Web UI HTTP/3 not working  [#4986]
 
+[#4986]: https://github.com/AdguardTeam/AdGuardHome/issues/4986
 <!--
 ## [v0.108.0] - TBA (APPROX.)
 -->

--- a/internal/home/control.go
+++ b/internal/home/control.go
@@ -348,7 +348,8 @@ func handleHTTPSRedirect(w http.ResponseWriter, r *http.Request) (ok bool) {
 	}
 
 	if config.DNS.ServeHTTP3 {
-		w.Header().Set("Alt-Svc", `h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"`)
+		altSvc := fmt.Sprintf(`h3=":%[1]v"; ma=2592000,h3-29=":%[1]v"; ma=2592000,h3-Q050=":%[1]v";ma=2592000,h3-Q046=":%[1]v"; ma=2592000,h3-Q043=":%[1]v"; ma=2592000,quic=":%[1]v"; ma=2592000; v="46,43"`, config.TLS.PortHTTPS)
+		w.Header().Set("Alt-Svc", altSvc)
 	}
 
 	w.Header().Set("Access-Control-Allow-Origin", originURL.String())

--- a/internal/home/control.go
+++ b/internal/home/control.go
@@ -346,6 +346,11 @@ func handleHTTPSRedirect(w http.ResponseWriter, r *http.Request) (ok bool) {
 		Scheme: aghhttp.SchemeHTTP,
 		Host:   r.Host,
 	}
+
+	if config.DNS.ServeHTTP3 {
+		w.Header().Set("Alt-Svc", `h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"`)
+	}
+
 	w.Header().Set("Access-Control-Allow-Origin", originURL.String())
 	w.Header().Set("Vary", "Origin")
 


### PR DESCRIPTION
Fix https://github.com/AdguardTeam/AdGuardHome/issues/4986
Even though the udp listener was listening on :443, the traffic was not sent to it, reason being the browser does not know that the website supports `h3`. 

reference : [link](https://www.smashingmagazine.com/2021/09/http3-practical-deployment-options-part3/#alt-svc)

So adding [Alt-Svc](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Alt-Svc) in the header, let the browser know that http3 is enabled

After adding the header 
<img width="1188" alt="image" src="https://user-images.githubusercontent.com/15570570/193742781-5724efd1-098d-4dcf-8296-5d79671b51ae.png">

`h3` is used
<img width="568" alt="image" src="https://user-images.githubusercontent.com/15570570/193742106-1c01c11d-302f-451f-864f-698b04d59baa.png">
