### PR TITLE
Add `amazon.com.be` to the filter list.

### DIFF
--- a/internal/filtering/servicelist.go
+++ b/internal/filtering/servicelist.go
@@ -32,6 +32,7 @@ var blockedServices = []blockedService{{
 		"||amazon.co.jp^",
 		"||amazon.co.uk^",
 		"||amazon.com.au^",
+		"||amazon.com.be^",
 		"||amazon.com.br^",
 		"||amazon.com.mx^",
 		"||amazon.com^",


### PR DESCRIPTION
For https://github.com/AdguardTeam/AdGuardHome/issues/5090.