### PR TITLE
add allow_unencrypted_doh field to api

### DIFF
--- a/internal/home/tls.go
+++ b/internal/home/tls.go
@@ -369,6 +369,7 @@ func (m *tlsManager) setConfig(newConf tlsConfigSettings, status *tlsConfigStatu
 	m.conf.PrivateKey = newConf.PrivateKey
 	m.conf.PrivateKeyPath = newConf.PrivateKeyPath
 	m.conf.PrivateKeyData = newConf.PrivateKeyData
+	m.conf.AllowUnencryptedDoH = newConf.AllowUnencryptedDoH
 	m.status = status
 
 	return restartHTTPS

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2216,6 +2216,11 @@
           'example': true
           'description': >
             Set to true if both certificate and private key are correct.
+        'allow_unencrypted_doh':
+          'type': 'boolean'
+          'example': false
+          'description': >
+            Set to true for allow DoH queries via unencrypted HTTP.
     'NetInterface':
       'type': 'object'
       'description': 'Network interface info'


### PR DESCRIPTION
Issue: https://github.com/AdguardTeam/AdGuardHome/issues/5207
```
POST /control/tls/configure
{
    "allow_unencrypted_doh": true
}
```
```
GET /control/tls/status
{
    ...
    "allow_unencrypted_doh": true,
    ...
}
```