### PR TITLE
Bump workflow actions, update node to 18 and update go to 1.20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
 'name': 'build'
 
 'env':
-  'GO_VERSION': '1.18.9'
-  'NODE_VERSION': '14'
+  'GO_VERSION': '1.19.5'
+  'NODE_VERSION': '18'
 
 'on':
   'push':
@@ -99,7 +99,7 @@
     - 'name': 'Set up QEMU'
       'uses': 'docker/setup-qemu-action@v2'
     - 'name': 'Set up Docker Buildx'
-      'uses': 'docker/setup-buildx-action@v1'
+      'uses': 'docker/setup-buildx-action@v2'
     - 'name': 'Run snapshot build'
       'run': 'make SIGN=0 VERBOSE=1 build-release build-docker'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 'name': 'build'
 
 'env':
-  'GO_VERSION': '1.19.5'
+  'GO_VERSION': '1.20'
   'NODE_VERSION': '18'
 
 'on':

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@
         - 'windows-latest'
     'steps':
     - 'name': 'Checkout'
-      'uses': 'actions/checkout@v2'
+      'uses': 'actions/checkout@v3'
       'with':
         'fetch-depth': 0
     - 'name': 'Set up Go'
@@ -35,11 +35,11 @@
       'with':
         'go-version': '${{ env.GO_VERSION }}'
     - 'name': 'Set up Node'
-      'uses': 'actions/setup-node@v1'
+      'uses': 'actions/setup-node@v3'
       'with':
         'node-version': '${{ env.NODE_VERSION }}'
     - 'name': 'Set up Go modules cache'
-      'uses': 'actions/cache@v2'
+      'uses': 'actions/cache@v3'
       'with':
         'path': '~/go/pkg/mod'
         'key': "${{ runner.os }}-go-${{ hashFiles('go.sum') }}"
@@ -48,7 +48,7 @@
       'id': 'npm-cache'
       'run': 'echo "::set-output name=dir::$( npm config get cache )"'
     - 'name': 'Set up npm cache'
-      'uses': 'actions/cache@v2'
+      'uses': 'actions/cache@v3'
       'with':
         'path': '${{ steps.npm-cache.outputs.dir }}'
         'key': "${{ runner.os }}-node-${{ hashFiles('client/package-lock.json') }}"
@@ -57,7 +57,7 @@
       'shell': 'bash'
       'run': 'make VERBOSE=1 ci'
     - 'name': 'Upload coverage'
-      'uses': 'codecov/codecov-action@v1'
+      'uses': 'codecov/codecov-action@v3'
       'if': "success() && matrix.os == 'ubuntu-latest'"
       'with':
         'token': '${{ secrets.CODECOV_TOKEN }}'
@@ -68,7 +68,7 @@
     'needs': 'test'
     'steps':
     - 'name': 'Checkout'
-      'uses': 'actions/checkout@v2'
+      'uses': 'actions/checkout@v3'
       'with':
         'fetch-depth': 0
     - 'name': 'Set up Go'
@@ -76,11 +76,11 @@
       'with':
         'go-version': '${{ env.GO_VERSION }}'
     - 'name': 'Set up Node'
-      'uses': 'actions/setup-node@v1'
+      'uses': 'actions/setup-node@v3'
       'with':
         'node-version': '${{ env.NODE_VERSION }}'
     - 'name': 'Set up Go modules cache'
-      'uses': 'actions/cache@v2'
+      'uses': 'actions/cache@v3'
       'with':
         'path': '~/go/pkg/mod'
         'key': "${{ runner.os }}-go-${{ hashFiles('go.sum') }}"
@@ -89,7 +89,7 @@
       'id': 'npm-cache'
       'run': 'echo "::set-output name=dir::$(npm config get cache)"'
     - 'name': 'Set up npm cache'
-      'uses': 'actions/cache@v2'
+      'uses': 'actions/cache@v3'
       'with':
         'path': '${{ steps.npm-cache.outputs.dir }}'
         'key': "${{ runner.os }}-node-${{ hashFiles('client/package-lock.json') }}"
@@ -97,7 +97,7 @@
     - 'name': 'Set up Snapcraft'
       'run': 'sudo apt-get -yq --no-install-suggests --no-install-recommends install snapcraft'
     - 'name': 'Set up QEMU'
-      'uses': 'docker/setup-qemu-action@v1'
+      'uses': 'docker/setup-qemu-action@v2'
     - 'name': 'Set up Docker Buildx'
       'uses': 'docker/setup-buildx-action@v1'
     - 'name': 'Run snapshot build'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 'name': 'lint'
 
 'env':
-  'GO_VERSION': '1.18.9'
+  'GO_VERSION': '1.19.5'
 
 'on':
   'push':

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@
   'go-lint':
     'runs-on': 'ubuntu-latest'
     'steps':
-    - 'uses': 'actions/checkout@v2'
+    - 'uses': 'actions/checkout@v3'
     - 'name': 'Set up Go'
       'uses': 'actions/setup-go@v3'
       'with':
@@ -27,7 +27,7 @@
   'eslint':
     'runs-on': 'ubuntu-latest'
     'steps':
-    - 'uses': 'actions/checkout@v2'
+    - 'uses': 'actions/checkout@v3'
     - 'name': 'Install modules'
       'run': 'npm --prefix="./client" ci'
     - 'name': 'Run ESLint'
@@ -54,7 +54,7 @@
     'runs-on': 'ubuntu-latest'
     'steps':
     - 'name': 'Conclusion'
-      'uses': 'technote-space/workflow-conclusion-action@v1'
+      'uses': 'technote-space/workflow-conclusion-action@v3'
     - 'name': 'Send Slack notif'
       'uses': '8398a7/action-slack@v3'
       'with':

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 'name': 'lint'
 
 'env':
-  'GO_VERSION': '1.19.5'
+  'GO_VERSION': '1.20'
 
 'on':
   'push':


### PR DESCRIPTION
Bumps all actions that have new updates to them. Ex) checkout from v2 to v3