### PR TITLE
Added Minecraft (Bedrock) endpoints to Minecraft service block list

### DIFF
--- a/internal/filtering/servicelist.go
+++ b/internal/filtering/servicelist.go
@@ -1401,6 +1401,8 @@ var blockedServices = []blockedService{{
 		"||minecraft.net^",
 		"||minecraftservices.com^",
 		"||mojang.com^",
+		"||20ca2.playfabapi.com^", // Bedrock PlayFab Services (Login, Marketplace, etc.)
+		"||minecraft-services.net^", // Bedrock Services (Realms)
 	},
 }, {
 	ID:      "netflix",


### PR DESCRIPTION
Minecraft dev here! Thought I would add a few more URLs to the Minecraft service list.  

This PR adds two URLs to the Minecraft block list:
- The (production) Minecraft PlayFab endpoint which handles marketplace, featured 3rd party server lists, and any sort of "store" stuff
- The general, Minecraft authored services which handle things like Realms

Minecraft will still launch and function but its backing services won't connect. 