### PR TITLE
docker: Remove CAP_NET_BIND_SERVICE capability

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ LABEL\
 	org.opencontainers.image.version=$VERSION
 
 # Update certificates.
-RUN apk --no-cache add ca-certificates libcap tzdata && \
+RUN apk --no-cache add ca-certificates tzdata && \
 	mkdir -p /opt/adguardhome/conf /opt/adguardhome/work && \
 	chown -R nobody: /opt/adguardhome
 
@@ -35,8 +35,6 @@ ARG TARGETVARIANT
 COPY --chown=nobody:nogroup\
 	./${DIST_DIR}/docker/AdGuardHome_${TARGETOS}_${TARGETARCH}_${TARGETVARIANT}\
 	/opt/adguardhome/AdGuardHome
-
-RUN setcap 'cap_net_bind_service=+eip' /opt/adguardhome/AdGuardHome
 
 # 53     : TCP, UDP : DNS
 # 67     :      UDP : DHCP (server)


### PR DESCRIPTION
The capability was added in commit 58868b7, but since then, the USER instruction was removed from the Dockerfile, so that Adguard Home runs as root by default.

Even if it is run as non-root user, the capability is not required in docker versions >= 20.10.0 (released on Dec 9, 2020), because of commit 888da28[1], which sets `net.ipv4.ip_unprivileged_port_start` to `0` by default. Users running older docker versions or using the `host` network mode can still configure this sysctl manually.

[1] https://github.com/moby/moby/commit/888da28d42f7d0f9fa250dd8a75d51c2a6cf3098