### PR TITLE
add /control/dns_config to expectsLargerRequests list

### DIFF
--- a/internal/home/middlewares.go
+++ b/internal/home/middlewares.go
@@ -45,7 +45,8 @@ func expectsLargerRequests(r *http.Request) (ok bool) {
 
 	p := r.URL.Path
 	return p == "/control/access/set" ||
-		p == "/control/filtering/set_rules"
+		p == "/control/filtering/set_rules" ||
+		p == "/control/dns_config"
 }
 
 // limitRequestBody wraps underlying handler h, making it's request's body Read


### PR DESCRIPTION
上游DNS服务器配置那里，有需求会配置一大堆的域名来通过另一个域名服务器来解析。
本来这个工作是交给DNSMASQ做的，后来看AdguardHome有这个功能，就想把DNSMASQ去掉。
结果添加了一堆后报错了。
希望这个接口也允许可以POST略大的数据