### PR TITLE
feat: add ide-extension for better i18n handling

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	"recommendations": [
+		"inlang.vs-code-extension"
+	]
+}

--- a/inlang.config.js
+++ b/inlang.config.js
@@ -1,0 +1,20 @@
+/**
+ * @type { import("@inlang/core/config").DefineConfig }
+ */
+export async function defineConfig(env) {
+	const { default: i18nextPlugin } = await env.$import(
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@3/dist/index.js",
+	)
+
+	const { default: standardLintRules } = await env.$import(
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-standard-lint-rules@3/dist/index.js",
+	)
+
+	return {
+		referenceLanguage: "en",
+		plugins: [
+			i18nextPlugin({ pathPattern: "client/src/__locales/{language}.json" }),
+			standardLintRules(),
+		],
+	}
+}


### PR DESCRIPTION
> Let me know if I need to change something to merge this PR

I added the inlang [IDE extension](https://inlang.com/documentation/apps/ide-extension) to AdGuardTeam. Helps with handling translation keys and translation linting.

## What did I add?
- `inlang.config.js` to configure where language translations are
- Added extension to the workspace recommendations (so contributors can use it)

## How to use it?

### Extract Messages (translations)
Extract Messages (translations) via the Inlang: Extract Message code action.

![Extract Messages](https://cdn.jsdelivr.net/gh/inlang/inlang/assets/ide-extension/extract.gif)

### Inline annotations
You can see translations directly in your code. No back-and-forth looking into the translation files themselves. (code example from AdGuardHome)

<img width="785" alt="image" src="https://github.com/AdguardTeam/AdGuardHome/assets/58360188/2f5b5dcf-2810-4b38-91ea-4a7e3a2985b9">


Ootb [CLI](https://inlang.com/documentation/apps/inlang-cli).