### PR TITLE
dhcp offer ip by client id in dhcpv4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,8 @@ require (
 	howett.net/plist v1.0.1
 )
 
+require github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701
+
 require (
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
 	github.com/aead/poly1305 v0.0.0-20180717145839-3fee0db0b635 // indirect
@@ -56,7 +58,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.4.0 // indirect
-	github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 // indirect
 	go.uber.org/mock v0.4.0 // indirect
 	golang.org/x/mod v0.18.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,8 @@ require (
 	howett.net/plist v1.0.1
 )
 
+require github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 // indirect
+
 require (
 	cloud.google.com/go v0.123.0 // indirect
 	cloud.google.com/go/auth v0.22.0 // indirect
@@ -89,7 +91,6 @@ require (
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tidwall/sjson v1.2.5 // indirect
-	github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 // indirect
 	github.com/uudashr/gocognit v1.2.1 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/internal/dhcpd/v4_unix.go
+++ b/internal/dhcpd/v4_unix.go
@@ -24,6 +24,7 @@ import (
 
 	//lint:ignore SA1019 See the TODO in go.mod.
 	"github.com/go-ping/ping"
+	"github.com/insomniacslk/dhcp/iana"
 )
 
 // v4Server is a DHCPv4 server.
@@ -1251,6 +1252,54 @@ func (s *v4Server) updateOptions(req, resp *dhcpv4.DHCPv4) {
 // client(255.255.255.255:68) <- (Reply:YourIP,ClientMAC,Type=Offer,ServerID,SubnetMask,LeaseTime) <- server(<IP>:67)
 // client(0.0.0.0:68) -> (Request:ClientMAC,Type=Request,ClientID,ReqIP||ClientIP,HostName,ServerID,ParamReqList) -> server(255.255.255.255:67)
 // client(255.255.255.255:68) <- (Reply:YourIP,ClientMAC,Type=ACK,ServerID,SubnetMask,LeaseTime) <- server(<IP>:67)
+
+// clientMAC returns the hardware address of the client sending the request,
+// preferring the chaddr field and falling back to the legacy Ethernet MAC
+// carried by the client identifier option (61) when chaddr is not usable.
+//
+// See https://datatracker.ietf.org/doc/html/rfc4361#section-6.3.
+func clientMAC(req *dhcpv4.DHCPv4) (mac net.HardwareAddr) {
+	if mac = clientIDMAC(req.Options.Get(dhcpv4.OptionClientIdentifier)); mac != nil &&
+		!hwAddrSet(req.ClientHWAddr) {
+		return mac
+	}
+
+	return req.ClientHWAddr
+}
+
+// clientIDMAC extracts the legacy Ethernet MAC address from the DHCP client
+// identifier option (option 61), if it contains one.  It returns nil if the
+// option doesn't contain a hardware address.
+//
+// The value of the client identifier option consists of a hardware type byte
+// followed by the client identifier itself.  Only the legacy form — hardware
+// type 1 (Ethernet) followed by a six-byte MAC address — is treated as a
+// hardware address.  All other forms, most notably the type-255 (IAID + DUID)
+// form defined by RFC 4361, carry an opaque client identity and must not be
+// interpreted as a hardware address.
+//
+// See https://datatracker.ietf.org/doc/html/rfc4361#section-6.1.
+func clientIDMAC(opt []byte) (mac net.HardwareAddr) {
+	// The client identifier is a hardware type byte followed by the
+	// identifier, so the legacy Ethernet form is seven bytes long.
+	if len(opt) != 7 || opt[0] != byte(iana.HWTypeEthernet) {
+		return nil
+	}
+
+	return net.HardwareAddr(opt[1:])
+}
+
+// hwAddrSet returns true if hw contains at least one non-zero byte.
+func hwAddrSet(hw net.HardwareAddr) (ok bool) {
+	for _, b := range hw {
+		if b != 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (s *v4Server) packetHandler(conn net.PacketConn, peer net.Addr, req *dhcpv4.DHCPv4) {
 	log.Debug("dhcpv4: received message: %s", req.Summary())
 
@@ -1273,6 +1322,15 @@ func (s *v4Server) packetHandler(conn net.PacketConn, peer net.Addr, req *dhcpv4
 
 		return
 	}
+
+	// Some clients, e.g. those compliant with RFC 4361, may not fill in the
+	// chaddr field with a usable hardware address.  In that case, fall back to
+	// the legacy Ethernet MAC carried by the client identifier option (61)
+	// when it contains one.  A non-zero chaddr is always preferred, so the
+	// option is never used to overwrite a usable hardware address.
+	//
+	// See https://datatracker.ietf.org/doc/html/rfc4361#section-6.3.
+	req.ClientHWAddr = clientMAC(req)
 
 	err = netutil.ValidateMAC(req.ClientHWAddr)
 	if err != nil {

--- a/internal/dhcpd/v4_unix_internal_test.go
+++ b/internal/dhcpd/v4_unix_internal_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/AdguardTeam/golibs/stringutil"
 	"github.com/AdguardTeam/golibs/testutil"
 	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/insomniacslk/dhcp/iana"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -980,6 +981,77 @@ func TestV4Server_validateStaticLease_emptyHostname(t *testing.T) {
 			// leases.
 			err = s4.validateStaticLease(tc.lease)
 			testutil.AssertErrorMsg(t, tc.wantErr, err)
+		})
+	}
+}
+func TestV4Server_clientMAC(t *testing.T) {
+	ethMAC := net.HardwareAddr{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}
+	otherMAC := net.HardwareAddr{0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB}
+	zeroMAC := make(net.HardwareAddr, 6)
+
+	// legacyID returns the legacy Ethernet client identifier carrying mac.
+	legacyID := func(mac net.HardwareAddr) (id []byte) {
+		return append([]byte{byte(iana.HWTypeEthernet)}, mac...)
+	}
+
+	// duidID is a type-255 (IAID + DUID) client identifier, an opaque client
+	// identity which must not be interpreted as a hardware address.
+	//
+	// See https://datatracker.ietf.org/doc/html/rfc4361#section-6.1.
+	duidID := []byte{0xFF, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}
+
+	testCases := []struct {
+		name     string
+		chaddr   net.HardwareAddr
+		clientID []byte
+		wantMAC  net.HardwareAddr
+	}{{
+		name:     "valid_chaddr_is_preferred",
+		chaddr:   ethMAC,
+		clientID: legacyID(otherMAC),
+		wantMAC:  ethMAC,
+	}, {
+		name:     "zero_chaddr_falls_back_to_legacy_id",
+		chaddr:   zeroMAC,
+		clientID: legacyID(otherMAC),
+		wantMAC:  otherMAC,
+	}, {
+		name:     "nil_chaddr_falls_back_to_legacy_id",
+		chaddr:   nil,
+		clientID: legacyID(otherMAC),
+		wantMAC:  otherMAC,
+	}, {
+		name:     "duid_is_not_a_mac",
+		chaddr:   zeroMAC,
+		clientID: duidID,
+		wantMAC:  zeroMAC,
+	}, {
+		name:     "non_ethernet_type_is_not_a_mac",
+		chaddr:   zeroMAC,
+		clientID: append([]byte{6}, otherMAC...),
+		wantMAC:  zeroMAC,
+	}, {
+		name:     "wrong_length_is_not_a_mac",
+		chaddr:   zeroMAC,
+		clientID: []byte{byte(iana.HWTypeEthernet), 0x01, 0x02},
+		wantMAC:  zeroMAC,
+	}, {
+		name:     "no_client_id",
+		chaddr:   zeroMAC,
+		clientID: nil,
+		wantMAC:  zeroMAC,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &dhcpv4.DHCPv4{ClientHWAddr: tc.chaddr}
+			if tc.clientID != nil {
+				req.Options = dhcpv4.OptionsFromList(
+					dhcpv4.OptClientIdentifier(tc.clientID),
+				)
+			}
+
+			assert.Equal(t, tc.wantMAC, clientMAC(req))
 		})
 	}
 }


### PR DESCRIPTION
I have configured a virtual machine that utilizes the host network on my physical machine. Upon examination, I discovered that the AdGuard Home server being hosted offers IP addresses based on the MAC address of the physical host machine rather than the virtual machine itself. Specifically, the actual MAC address of the virtual machine is present in the client-id field of DHCP requests. For proper functionality, the DHCP server should be offering IP addresses based on the client-id field, which contains the MAC address of the virtual machine. This would allow the DHCP server to correctly identify the virtual machine and provide it an IP address accordingly. The current behavior indicates a misconfiguration, where the DHCP server is assigning IP addresses using the physical host's MAC address instead of the virtual machine client's MAC address contained in the DHCP request.

resolve #6135