### PR TITLE
ci & build: build, tag and push for ghcr.io

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,12 @@
       'uses': 'docker/setup-qemu-action@v1'
     - 'name': 'Set up Docker Buildx'
       'uses': 'docker/setup-buildx-action@v1'
+    - 'name': Login to GitHub Container Registry 🔑
+      'uses': 'docker/login-action@v3.0.0'
+      'with':
+        'registry': ghcr.io
+        'username': ${{ github.repository_owner }}
+        'password': ${{ secrets.GHCR_TOKEN }}
     - 'name': 'Run snapshot build'
       'run': 'make SIGN=0 VERBOSE=1 build-release build-docker'
 

--- a/scripts/make/build-docker.sh
+++ b/scripts/make/build-docker.sh
@@ -62,17 +62,17 @@ readonly docker_output
 case "$channel"
 in
 ('release')
-	docker_version_tag="--tag=${docker_image_name}:${version}"
-	docker_channel_tag="--tag=${docker_image_name}:latest"
+	docker_version_tag="--tag=${docker_image_name}:${version} --tag=ghcr.io/${docker_image_name}:${version}"
+	docker_channel_tag="--tag=${docker_image_name}:latest --tag=ghcr.io/${docker_image_name}:latest"
 	;;
 ('beta')
-	docker_version_tag="--tag=${docker_image_name}:${version}"
-	docker_channel_tag="--tag=${docker_image_name}:beta"
+	docker_version_tag="--tag=${docker_image_name}:${version} --tag=ghcr.io/${docker_image_name}:${version}"
+	docker_channel_tag="--tag=${docker_image_name}:beta --tag=ghcr.io/${docker_image_name}:beta"
 	;;
 ('edge')
 	# Set the version tag to an empty string when pushing to the edge channel.
 	docker_version_tag=''
-	docker_channel_tag="--tag=${docker_image_name}:edge"
+	docker_channel_tag="--tag=${docker_image_name}:edge --tag=ghcr.io/${docker_image_name}:edge"
 	;;
 ('development')
 	# Set both tags to an empty string for development builds.


### PR DESCRIPTION
Fixes #5975, fixes #2482 (which was closed for some reason)

Ensure tags for ghcr.io are also created when building Docker images. These should be harmless in local environments as well.

The only requirement for this before merge is to have the ``GHCR_TOKEN`` added so GitHub Actions can login into the registry.
