### PR TITLE
feat: Enable dependabot in this repository to make it easier to upgrade dependencies that are being used by this project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
   # Upgrade for npm packages, minor and patch versions only
-  - package-ecosystem: "gomod"
+  - package-ecosystem: "npm"
     directory: "/client"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,12 @@
 
 version: 2
 updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
   # Upgrade for go packages, minor and patch versions only
   - package-ecosystem: "gomod"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,14 +14,28 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
     groups:
-      production_dependencies:
+      go_dependencies:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+  # Upgrade for npm packages, minor and patch versions only
+  - package-ecosystem: "gomod"
+    directory: "/client"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      client_production_dependencies:
         dependency-type: "production"
         update-types:
           - "minor"
           - "patch"
-      development_dependencies:
+      client_development_dependencies:
         dependency-type: "development"
         update-types:
           - "minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Upgrade for go packages, minor and patch versions only
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      production_dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development_dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
This change enables dependabot which will hopefully make it easier to keep dependencies up to date, specifically the following dependencies
- go dependencies
- client npm packages dependencies
- github actions dependencies

Hope it helps!

Here is a couple of screenshots to show you what dependabot will raise as PRs

![image](https://github.com/AdguardTeam/AdGuardHome/assets/30316250/1adb6e37-5ebf-4d5a-b055-b5021373e895)
![image](https://github.com/AdguardTeam/AdGuardHome/assets/30316250/a27fe9ce-af0b-467a-9b66-6eb36401380c)
