### PR TITLE
home/config: improve error message when validating bind hosts

### DIFF
--- a/internal/home/config.go
+++ b/internal/home/config.go
@@ -463,7 +463,7 @@ func validateBindHosts(conf *configuration) (err error) {
 
 	for i, addr := range conf.DNS.BindHosts {
 		if !addr.IsValid() {
-			return fmt.Errorf("dns.bind_hosts at index %d is not a valid ip address", i)
+			return fmt.Errorf("dns.bind_hosts at index %d with value '%s' is not a valid ip address. try quoting the value", i, addr)
 		}
 	}
 


### PR DESCRIPTION
Hey, This PR improves error message when the program sees an invalid address. 

The `BindHosts` field in `Config` struct in the program is of type `netip.Addr`. `yaml` reads the (unquoted)value `2a0a:6040:4050::` incorrectly and it's set to 'Invalid IP' by `netip`.  

```
dns:
  bind_hosts:
    - 10.1.1.3
    - 2a0a:6040:4050::
  port: 53
  anonymize_client_ip: false
  ratelimit: 200
  ratelimit_subnet_len_ipv4: 24
  ratelimit_subnet_len_ipv6: 56
  ratelimit_whitelist: []
  refuse_any: true
```


The error message has been updated from 

```
2023/11/23 13:49:07.012617 [error] parsing configuration file: dns.bind_hosts at index 3 is not a valid ip address
```
to 
```
2023/11/23 13:48:35.042301 [error] parsing configuration file: dns.bind_host at index 3 with value 'invalid IP' is not a valid ip address. try quoting the value
```


There is no associated issue or wiki discussion since this is a relatively small change.