### PR TITLE
correct schema type for client upstreams_cache_size

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2709,7 +2709,7 @@
             changed.
 
             This behaviour can be changed in the future versions.
-          'type': 'boolean'
+          'type': 'integer'
     'ClientAuto':
       'type': 'object'
       'description': 'Auto-Client information'


### PR DESCRIPTION
The openapi schema has a wrong data type for the Client field upstreams_cache_size.

Currently in the schema it is defined as boolean, but in the struct an integer.