### PR TITLE
Add "AWAvenue Ads Rule" to AdGuard Home Filter list

### DIFF
--- a/client/src/helpers/filters/filters.js
+++ b/client/src/helpers/filters/filters.js
@@ -34,6 +34,12 @@ export default {
             "homepage": "https://badmojr.github.io/1Hosts/",
             "source": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_38.txt"
         },
+        "awavenue_ads_rule": {
+            "name": "AWAvenue Ads Rule",
+            "categoryId": "general",
+            "homepage": "https://awavenue.top/",
+            "source": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_53.txt"
+        },
         "CHN_adrules": {
             "name": "CHN: AdRules DNS List",
             "categoryId": "regional",


### PR DESCRIPTION
This rule has been added to the "HostlistsRegistry" and is visible in the AdGuard DNS filter list. Hope to add it to the filter list of AdGuard Home to facilitate users to subscribe.

Use Adblock syntax to fight against various advertising SDKs in Android applications from the network level , prevent them from loading.
