### PR TITLE
Readme: Add browser extension project

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,7 +491,8 @@ bug or implementing the feature.
  *  [Node.js library](https://github.com/Andrea055/AdguardHomeAPI) by
     [@Andrea055](https://github.com/Andrea055/).
 
-
+ *  [Browser Extension](https://github.com/satheshshiva/Adguard-Home-Browser-Ext) by
+    [@satheshshiva](https://github.com/satheshshiva/).
 
 ## <a href="#acknowledgments" id="acknowledgments" name="acknowledgments">Acknowledgments</a>
 


### PR DESCRIPTION
Closes https://github.com/AdguardTeam/AdGuardHome/issues/6671

Adds the https://github.com/satheshshiva/Adguard-Home-Browser-Ext under the list of [Projects that use AdGuard Home](https://github.com/satheshshiva/AdGuardHome#uses) title