### PR TITLE
Mention AdGuardHome sync in usages

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,8 @@ bug or implementing the feature.
  *  [OpenWrt LUCI app](https://github.com/kongfl888/luci-app-adguardhome) by
     [@kongfl888](https://github.com/kongfl888) (originally by
     [@rufengsuixing](https://github.com/rufengsuixing)).
+ *  [AdGuardHome sync](https://github.com/bakito/adguardhome-sync) by
+    [@bakito](https://github.com/bakito).
 
  *  [Terminal-based, real-time traffic monitoring and statistics for your AdGuard Home
     instance](https://github.com/Lissy93/AdGuardian-Term) by


### PR DESCRIPTION
Mention 'AdGuardHome sync' in Applications that use AdGuardHome.