### PR TITLE
Fix blank settings page when access clients first

### DIFF
--- a/client/src/components/Settings/LogsConfig/index.js
+++ b/client/src/components/Settings/LogsConfig/index.js
@@ -62,7 +62,7 @@ class LogsConfig extends Component {
                             interval,
                             customInterval,
                             anonymize_client_ip,
-                            ignored: ignored.join('\n'),
+                            ignored: ignored?.join('\n'),
                         }}
                         onSubmit={this.handleFormSubmit}
                         processing={processing}


### PR DESCRIPTION
**Step to reproduce bug:**
1. Open dashboard
2. Open client setting
3. Open settings

**Actual:**
Blank page by queryLogs.ignored undefined error

**Expect:**
Settings page display normally

It may a fix for #6634