### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@
         'restore-keys': '${{ runner.os }}-go-'
     - 'name': 'Get npm cache directory'
       'id': 'npm-cache'
-      'run': 'echo "::set-output name=dir::$( npm config get cache )"'
+      'run': 'echo "dir=$( npm config get cache )"' >> "$GITHUB_OUTPUT"
     - 'name': 'Set up npm cache'
       'uses': 'actions/cache@v2'
       'with':
@@ -87,7 +87,7 @@
         'restore-keys': '${{ runner.os }}-go-'
     - 'name': 'Get npm cache directory'
       'id': 'npm-cache'
-      'run': 'echo "::set-output name=dir::$(npm config get cache)"'
+      'run': 'echo "dir=$(npm config get cache)"' >> "$GITHUB_OUTPUT"
     - 'name': 'Set up npm cache'
       'uses': 'actions/cache@v2'
       'with':


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter