### PR TITLE
Support customizing session cookie name.

### DIFF
--- a/internal/home/authhttp.go
+++ b/internal/home/authhttp.go
@@ -22,8 +22,11 @@ import (
 // cookieTTL is the time-to-live of the session cookie.
 const cookieTTL = 365 * timeutil.Day
 
+// defaultSessionCookieName is the default name of the session cookie.
+const defaultSessionCookieName = "agh_session"
+
 // sessionCookieName is the name of the session cookie.
-const sessionCookieName = "agh_session"
+var sessionCookieName = defaultSessionCookieName
 
 // loginJSON is the JSON structure for authentication.
 type loginJSON struct {

--- a/internal/home/home.go
+++ b/internal/home/home.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -268,6 +269,14 @@ func setupOpts(opts options) (err error) {
 	}
 
 	return nil
+}
+
+// setupAghUISettings sets up some AdGuard Home UI settings.
+func setupAghUISettings(opts options) {
+	cookieName := strings.TrimSpace(opts.sessionCookieName)
+	if cookieName != "" {
+		sessionCookieName = cookieName
+	}
 }
 
 // initContextClients initializes Context clients and related fields.
@@ -572,6 +581,8 @@ func run(opts options, clientBuildFS fs.FS, done chan struct{}) {
 
 	err = setupOpts(opts)
 	fatalOnError(err)
+
+	setupAghUISettings(opts)
 
 	execPath, err := os.Executable()
 	fatalOnError(errors.Annotate(err, "getting executable path: %w"))

--- a/internal/home/options.go
+++ b/internal/home/options.go
@@ -48,6 +48,10 @@ type options struct {
 	// bindAddr is the address to serve the web UI on.
 	bindAddr netip.AddrPort
 
+	// sessionCookieName is the name of the session cookie for the web UI.
+    // Customizing this value can prevent cookie key conflict for multiple AdGuardHome instances that have the same domain.
+    sessionCookieName string
+
 	// checkConfig is true if the current invocation is only required to check
 	// the configuration file and exit.
 	checkConfig bool
@@ -196,6 +200,18 @@ var cmdLineOpts = []cmdLineOpt{{
 	description: "Address to serve the web UI on, in the host:port format.",
 	longName:    "web-addr",
 	shortName:   "",
+}, {
+    updateWithValue: func(o options, v string) (oo options, err error) {
+        o.sessionCookieName = v
+
+        return o, nil
+    },
+    updateNoValue:   nil,
+    effect:          nil,
+    serialize:       func(o options) (val string, ok bool) { return o.sessionCookieName, o.sessionCookieName != "" },
+    description:     "Customize the session cookie name for the web UI.",
+    longName:        "session-cookie-name",
+    shortName:       "",
 }, {
 	updateWithValue: func(o options, v string) (options, error) {
 		o.serviceControlAction = v


### PR DESCRIPTION
What scenarios require custom session cookie names?

When multiple AdGuard Home instances are running on a host, having the same IP or domain name, only the port is different, you cannot log in to the web UI of two instances at the same time, because they use the same session cookie name. . After logging into instance A, logging in to instance B will cause the login status on instance A to be invalid.

#4680 and #1196 also mentioned this problem.