### PR TITLE
fix: enforce Bing safe search from Edge sidebar

### DIFF
--- a/internal/filtering/safesearch/rules/bing.txt
+++ b/internal/filtering/safesearch/rules/bing.txt
@@ -1,1 +1,2 @@
 |www.bing.com^$dnsrewrite=NOERROR;CNAME;strict.bing.com
+|edgeservices.bing.com^$dnsrewrite=NOERROR;CNAME;strict.bing.com


### PR DESCRIPTION
Edge sidebar uses a different search endpoint, as per https://support.microsoft.com/en-us/topic/blocking-adult-content-with-safesearch-or-blocking-chat-946059ed-992b-46a0-944a-28e8fb8f1814