### PR TITLE
chore: update Google DNS list

### DIFF
--- a/internal/filtering/safesearch/rules/google.txt
+++ b/internal/filtering/safesearch/rules/google.txt
@@ -46,6 +46,9 @@
 |www.google.co.uz^$dnsrewrite=NOERROR;CNAME;forcesafesearch.google.com
 |www.google.co.ve^$dnsrewrite=NOERROR;CNAME;forcesafesearch.google.com
 |www.google.co.vi^$dnsrewrite=NOERROR;CNAME;forcesafesearch.google.com
+|www.google.co.za^$dnsrewrite=NOERROR;CNAME;forcesafesearch.google.com
+|www.google.co.zm^$dnsrewrite=NOERROR;CNAME;forcesafesearch.google.com
+|www.google.co.zw^$dnsrewrite=NOERROR;CNAME;forcesafesearch.google.com
 |www.google.com.af^$dnsrewrite=NOERROR;CNAME;forcesafesearch.google.com
 |www.google.com.ag^$dnsrewrite=NOERROR;CNAME;forcesafesearch.google.com
 |www.google.com.ai^$dnsrewrite=NOERROR;CNAME;forcesafesearch.google.com


### PR DESCRIPTION
Add 3 new domains that appear in https://www.google.com/supported_domains but not in this list.  
For the technically minded, generate your own list with: `curl -fsSL https://www.google.com/supported_domains | sort | sed -E 's%^(.*)$%|www\1^$dnsrewrite=NOERROR;CNAME;forcesafesearch.google.com%'` :-)