### PR TITLE
snap: set restart-delay to make service more reliable

### DIFF
--- a/snap/snap.tmpl.yaml
+++ b/snap/snap.tmpl.yaml
@@ -36,6 +36,7 @@
     - 'network-control'
     'daemon': 'simple'
     'restart-condition': 'always'
+    'restart-delay': '30s'
   'adguard-home-web':
     'command': 'adguard-home-web.sh'
     'plugs':


### PR DESCRIPTION
This makes the service more reliable to start at boot on slower devices where it takes longer for networking to properly come up. Should help fix issues like #6983
