### PR TITLE
Update wiki-start in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ If you're running **Linux,** there's a secure and easy way to install AdGuard Ho
 
 [Docker Hub]: https://hub.docker.com/r/adguard/adguardhome
 [Snap Store]: https://snapcraft.io/adguard-home
-[wiki-start]: https://github.com/AdguardTeam/AdGuardHome/wiki/Getting-Started
+[wiki-start]: https://adguard-dns.io/kb/adguard-home/getting-started/
 
 ### <a href="#guides" id="guides" name="guides">Guides</a>
 


### PR DESCRIPTION
Closes #7477 by replacing the outdated link with the correct, updated link.

When I clicked the link aliased as wiki-start, the article had a banner at the top redirecting readers to a newer version on the wiki. This commit replaces the link to the outdated version with the link it redirects to, to save future visitors a click.