### PR TITLE
add riscv64 to install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -254,7 +254,7 @@ set_cpu() {
 
 			cpu="${cpu}_softfloat"
 			;;
-      		'riscv64')
+		'riscv64')
 			cpu='riscv64'
 			;;
 		*)


### PR DESCRIPTION
Before submitting a PR please make sure that:

1.  You have discussed your solution in an issue and have got an
    approval from a maintainer.  See our
    [contribution guide](https://github.com/AdguardTeam/AdGuardHome/blob/master/CONTRIBUTING.md).

2.  This isn't a localization fix; please send those to our
    [CrowdIn](https://crowdin.com/project/adguard-applications/en#/adguard-home)
    page.

3.  Your code follows our
    [code guidelines](https://github.com/AdguardTeam/CodeGuidelines/blob/master/Go/Go.md).

Add a short description here.  The description should include:
AdGuard is build for riscv64 but it is not included in the install.sh script. This PR adds riscv64 to install.sh.
