### PR TITLE
Format values in Setting clients

### DIFF
--- a/client/src/components/Settings/Clients/AutoClients.tsx
+++ b/client/src/components/Settings/Clients/AutoClients.tsx
@@ -12,7 +12,7 @@ import whoisCell from './whoisCell';
 
 import LogsSearchLink from '../../ui/LogsSearchLink';
 
-import { sortIp } from '../../../helpers/helpers';
+import { sortIp, formatNumber } from '../../../helpers/helpers';
 import { LocalStorageHelper, LOCAL_STORAGE_KEYS } from '../../../helpers/localStorageHelper';
 import { TABLES_MIN_ROWS } from '../../../helpers/constants';
 
@@ -66,7 +66,7 @@ class AutoClients extends Component<AutoClientsProps> {
                     return (
                         <div className="logs__row">
                             <div className="logs__text" title={clientStats}>
-                                <LogsSearchLink search={row.original.ip}>{clientStats}</LogsSearchLink>
+                                <LogsSearchLink search={row.original.ip}>{formatNumber(clientStats)}</LogsSearchLink>
                             </div>
                         </div>
                     );

--- a/client/src/components/Settings/Clients/ClientsTable/ClientsTable.tsx
+++ b/client/src/components/Settings/Clients/ClientsTable/ClientsTable.tsx
@@ -300,12 +300,15 @@ const ClientsTable = ({
             sortMethod: (a: any, b: any) => b - a,
             minWidth: 120,
             Cell: (row: any) => {
-                let content = CellWrap(row);
-
-                if (!row.value) {
-                    return content;
+                let content = row.value;
+                if (typeof content === "number") {
+                    content = formatNumber(content);
+                } else {
+                    content = CellWrap(row);
                 }
-                content = typeof content === "number" ? formatNumber(content) : content;
+                if (!content) {
+                    return content;
+                }    
                 return <LogsSearchLink search={row.original.name}>{content}</LogsSearchLink>;
             },
         },

--- a/client/src/components/Settings/Clients/ClientsTable/ClientsTable.tsx
+++ b/client/src/components/Settings/Clients/ClientsTable/ClientsTable.tsx
@@ -12,7 +12,7 @@ import ReactTable from 'react-table';
 import { getAllBlockedServices, getBlockedServices } from '../../../../actions/services';
 
 import { initSettings } from '../../../../actions';
-import { splitByNewLine, countClientsStatistics, sortIp, getService } from '../../../../helpers/helpers';
+import { splitByNewLine, countClientsStatistics, sortIp, getService, formatNumber } from '../../../../helpers/helpers';
 import { MODAL_TYPE, LOCAL_TIMEZONE_VALUE, TABLES_MIN_ROWS } from '../../../../helpers/constants';
 
 import Card from '../../../ui/Card';
@@ -300,12 +300,12 @@ const ClientsTable = ({
             sortMethod: (a: any, b: any) => b - a,
             minWidth: 120,
             Cell: (row: any) => {
-                const content = CellWrap(row);
+                let content = CellWrap(row);
 
                 if (!row.value) {
                     return content;
                 }
-
+                content = typeof content === "number" ? formatNumber(content) : content;
                 return <LogsSearchLink search={row.original.name}>{content}</LogsSearchLink>;
             },
         },


### PR DESCRIPTION
# Description
This PR updates the content displayed in AutoClient.tsx and ClientsTable.tsx  to use a formatted number.

# Changes:
1. Applied formatNumber to clientStats before rendering it as content in <LogsSearchLink>.
2.Applied formatNumber to numeric values in the Cell method to ensure consistent formatting.

Since I noticed that this PR https://github.com/AdguardTeam/AdGuardHome/pull/7505 introduces a function for formatting numeric display and applies it only to the homepage, I’ve extended its usage to also format numbers in the Setting Clients section to improve readability.

Thank you.
