### PR TITLE
Fix time placement in `enable_protection_timer` text

### DIFF
--- a/client/src/components/Dashboard/index.tsx
+++ b/client/src/components/Dashboard/index.tsx
@@ -154,7 +154,7 @@ const Dashboard = ({
                         }}
                         disabled={processingProtection}>
                         {protectionDisabledDuration
-                            ? `${t('enable_protection_timer')} ${getRemaningTimeText(protectionDisabledDuration)}`
+                            ? `${t('enable_protection_timer', { time: getRemaningTimeText(protectionDisabledDuration) })}`
                             : getProtectionBtnText(protectionEnabled)}
                     </button>
 


### PR DESCRIPTION
Closes #7599

This change should in theory fix the incorrect time placement like described in the linked issue.

**WARNING:** I wasn't able to run `make js-lint` etc. because I am missing the required tools... Someone needs to check this for me.