### PR TITLE
fix: QueryLogItem.client_proto in openapi schema

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2209,6 +2209,7 @@
           - 'doq'
           - 'dnscrypt'
           - ''
+          'type': 'string'
         'ecs':
           'type': 'string'
           'example': '192.168.0.0/16'


### PR DESCRIPTION
This add the missing type to QueryLogItem.client_proto in the opanapi schema.

