### PR TITLE
DNSCloak is outdated. DNSecure works fine under IOS.

### DIFF
--- a/client/src/__locales/ar.json
+++ b/client/src/__locales/ar.json
@@ -498,7 +498,7 @@
     "setup_dns_privacy_android_1": "يدعم Android 9 DNS-over-TLS أصلاً. لتكوينه ، انتقل إلى الإعدادات → الشبكة والإنترنت → متقدم → DNS الخاص وأدخل اسم المجال الخاص بك هناك.",
     "setup_dns_privacy_android_2": "<0> AdGuard لنظام Android </0> يدعم <1> DNS-over-HTTPS </1> و <1> DNS-over-TLS </1>.",
     "setup_dns_privacy_android_3": "<0> Intra </0> يضيف دعم <1> DNS-over-HTTPS </1> إلى Android.",
-    "setup_dns_privacy_ios_1": "<0> DNSCloak </0> يدعم <1> DNS-over-HTTPS </1> ، ولكن من أجل تكوينه لاستخدام الخادم الخاص بك ، ستحتاج إلى إنشاء <2> DNS Stamp </2> لذلك.",
+    "setup_dns_privacy_ios_1": "<0> DNSecure </0> يدعم <1> DNS-over-HTTPS </1> و <1> DNS-over-TLS </1>.",
     "setup_dns_privacy_ios_2": "<0> AdGuard لنظام iOS </0> يدعم إعداد <1> DNS-over-HTTPS </1> و <1> DNS-over-TLS </1> الإعداد.",
     "setup_dns_privacy_other_title": "تطبيقات أخرى",
     "setup_dns_privacy_other_1": "يمكن أن يكون AdGuard Home نفسه عميل DNS آمنًا على أي نظام أساسي.",

--- a/client/src/__locales/be.json
+++ b/client/src/__locales/be.json
@@ -495,7 +495,7 @@
     "setup_dns_privacy_android_1": "Android 9 натыўна падтрымвае DNS-over-TLS. Для налады, перайдзіце ў Налады → Сеціва і Інтэрнэт → Дадаткова → Персанальны DNS сервер, і ўвядзіце туды ваша даменавае імя.",
     "setup_dns_privacy_android_2": "<0>AdGuard для Android</0> падтрымвае <1>DNS-over-HTTPS</1> і <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_android_3": "<0>Intra</0> дадае падтрымка <1>DNS-over-HTTPS</1> на Android.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> падтрымвае <1>DNS-over-HTTPS</1>, але для налады яго, вам будзе трэба згенераваць для яго <2>DNS-адбітак</2>.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> падтрымвае <1>DNS-over-HTTPS</1> і <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_ios_2": "<0>AdGuard для iOS</0> падтрымвае <1>DNS-over-HTTPS</1> і <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_other_title": "Іншыя развязкі",
     "setup_dns_privacy_other_1": "AdGuard Home сам можа быць кліентам зашыфраванага DNS на любай платформе.",

--- a/client/src/__locales/cs.json
+++ b/client/src/__locales/cs.json
@@ -501,7 +501,7 @@
     "setup_dns_privacy_android_1": "Android 9 podporuje DNS skrze TLS nativně. Pokud ho chcete konfigurovat, přejděte na Nastavení → Síť & internet → Pokročilé → Soukromé DNS a tam zadejte název vaší domény.",
     "setup_dns_privacy_android_2": "<0>AdGuard pro Android</0> podporuje <1>DNS skrze HTTPS</1> a <1>DNS skrze LS</1>.",
     "setup_dns_privacy_android_3": "<0>Intra</0> přidává podporu <1>DNS skrze HTTPS</1> pro Android.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> podporuje funkci <1>DNS skrze HTTPS</1>, ale abyste ji mohli nakonfigurovat pro používání vlastního serveru, musíte vygenerovat značku <2>DNS Stamp</2>.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> podporuje funkci <1>DNS skrze HTTPS</1> a <1>DNS skrze LS</1>.",
     "setup_dns_privacy_ios_2": "<0>AdGuard pro iOS</0> podporuje nastavení <1>DNS skrze HTTPS</1> a <1>DNS skrze TLS</1>.",
     "setup_dns_privacy_other_title": "Další implementace",
     "setup_dns_privacy_other_1": "Samotný AdGuard Home může být bezpečným klientem DNS na jakékoli platformě.",

--- a/client/src/__locales/da.json
+++ b/client/src/__locales/da.json
@@ -501,7 +501,7 @@
     "setup_dns_privacy_android_1": "Android 9 har indbygget understøttelse af DNS-over-TLS. For at opsætte den, gå til Indstillinger → Netværk og Internet → Avanceret → Privat DNS og angiv dit domænenavn.",
     "setup_dns_privacy_android_2": "<0>AdGuard til Android</0> understøtter <1>DNS-over-HTTPS</1> og <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_android_3": "<0>Intra</0> føjer <1>DNS-over-HTTPS</1> understøttelse til Android.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> understøtter <1>DNS-over-HTTPS</1>, men for at opsætte den til brug af din egen server, skal du generere et <2>DNS Stamp</2> til den.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> understøtter <1>DNS-over-HTTPS</1> og <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_ios_2": "<0>AdGuard til iOS</0> understøtter <1>DNS-over-HTTPS</1> og <1>DNS-over-TLS</1> opsætning.",
     "setup_dns_privacy_other_title": "Andre implementeringer",
     "setup_dns_privacy_other_1": "AdGuard Home kan være en sikker DNS-klient på enhver platform.",

--- a/client/src/__locales/de.json
+++ b/client/src/__locales/de.json
@@ -501,7 +501,7 @@
     "setup_dns_privacy_android_1": "Android 9 unterstützt DNS-over-TLS nativ. Um es zu konfigurieren, gehen Sie zu „Einstellungen“ → „Netzwerk & Internet“ → „Erweitert“ → „Privater DNS“ und geben Sie dort Ihren Domainnamen ein.",
     "setup_dns_privacy_android_2": "<0>AdGuard für Android</0> unterstützt <1>DNS-over-HTTTPS</1> und <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_android_3": "„<0>Intra</0>“ fügt <1>DNS-over-HTTPS</1>-Unterstützung zu Android hinzu.",
-    "setup_dns_privacy_ios_1": "„<0>DNSCloak</0>“ unterstützt <1>DNS-over-HTTPS</1>, aber um es so zu konfigurieren, dass es Ihren eigenen Server verwendet, müssen Sie einen <2>DNS-Stempel</2> dafür generieren.",
+    "setup_dns_privacy_ios_1": "„<0>DNSecure</0>“ unterstützt <1>DNS-over-HTTPS</1>und <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_ios_2": "<0>AdGuard für iOS</0> unterstützt die Einrichtung von <1>DNS-over-HTTTPS</1> und <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_other_title": "Weitere Implementierungen",
     "setup_dns_privacy_other_1": "AdGuard Home selbst kann ein sicherer DNS-Client auf jeder Plattform sein.",

--- a/client/src/__locales/de.json
+++ b/client/src/__locales/de.json
@@ -501,7 +501,7 @@
     "setup_dns_privacy_android_1": "Android 9 unterstützt DNS-over-TLS nativ. Um es zu konfigurieren, gehen Sie zu „Einstellungen“ → „Netzwerk & Internet“ → „Erweitert“ → „Privater DNS“ und geben Sie dort Ihren Domainnamen ein.",
     "setup_dns_privacy_android_2": "<0>AdGuard für Android</0> unterstützt <1>DNS-over-HTTTPS</1> und <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_android_3": "„<0>Intra</0>“ fügt <1>DNS-over-HTTPS</1>-Unterstützung zu Android hinzu.",
-    "setup_dns_privacy_ios_1": "„<0>DNSecure</0>“ unterstützt <1>DNS-over-HTTPS</1>und <1>DNS-over-TLS</1>.",
+    "setup_dns_privacy_ios_1": "„<0>DNSecure</0>“ unterstützt <1>DNS-over-HTTPS</1> und <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_ios_2": "<0>AdGuard für iOS</0> unterstützt die Einrichtung von <1>DNS-over-HTTTPS</1> und <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_other_title": "Weitere Implementierungen",
     "setup_dns_privacy_other_1": "AdGuard Home selbst kann ein sicherer DNS-Client auf jeder Plattform sein.",

--- a/client/src/__locales/en.json
+++ b/client/src/__locales/en.json
@@ -501,7 +501,7 @@
     "setup_dns_privacy_android_1": "Android 9 supports DNS-over-TLS natively. To configure it, go to Settings → Network & internet → Advanced → Private DNS and enter your domain name there.",
     "setup_dns_privacy_android_2": "<0>AdGuard for Android</0> supports <1>DNS-over-HTTPS</1> and <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_android_3": "<0>Intra</0> adds <1>DNS-over-HTTPS</1> support to Android.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> supports <1>DNS-over-HTTPS</1>, but in order to configure it to use your own server, you'll need to generate a <2>DNS Stamp</2> for it.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> supports <1>DNS-over-HTTPS</1> and <1>DNS-over-TLS</1>."
     "setup_dns_privacy_ios_2": "<0>AdGuard for iOS</0> supports <1>DNS-over-HTTPS</1> and <1>DNS-over-TLS</1> setup.",
     "setup_dns_privacy_other_title": "Other implementations",
     "setup_dns_privacy_other_1": "AdGuard Home itself can be a secure DNS client on any platform.",

--- a/client/src/__locales/es.json
+++ b/client/src/__locales/es.json
@@ -501,7 +501,7 @@
     "setup_dns_privacy_android_1": "Android 9 soporta DNS mediante TLS de forma nativa. Para configurarlo, ve a Configuración → Red e Internet → Avanzado → DNS privado e ingresa el nombre del dominio allí.",
     "setup_dns_privacy_android_2": "<0>AdGuard para Android</0> soporta <1>DNS mediante HTTPS</1> y <1>DNS mediante TLS</1>.",
     "setup_dns_privacy_android_3": "<0>Intra</0> añade soporte a Android para <1>DNS mediante HTTPS</1>.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> soporta <1>DNS mediante HTTPS</1>, pero para configurarlo y que uses tu propio servidor, necesitarás generar un <2>DNS Stamp</2> para ello.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> soporta <1>DNS mediante HTTPS</1> y <1>DNS mediante TLS</1>.",
     "setup_dns_privacy_ios_2": "<0>AdGuard para iOS</0> soporta la configuración <1>DNS mediante HTTPS</1> y <1>DNS mediante TLS</1>.",
     "setup_dns_privacy_other_title": "Otras implementaciones",
     "setup_dns_privacy_other_1": "AdGuard Home en sí mismo puede ser un cliente DNS seguro en cualquier plataforma.",

--- a/client/src/__locales/fa.json
+++ b/client/src/__locales/fa.json
@@ -451,7 +451,7 @@
     "setup_dns_privacy_android_1": "آندروئید 9 بطور پیش فرض از  DNS-over-TLS پشتیبانی می کند. برای پیکربندی آن، بروید به تنظیمات → شبکه & اینترنت → پیشرفته → DNS خصوصی و نام دامنه را آنجا وارد کنید.",
     "setup_dns_privacy_android_2": "<0>AdGuard for Android</0> پشتیبانی از <1>DNS-over-HTTPS</1> و <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_android_3": "<0>Intra</0> قابلیت <1>DNS-over-HTTPS</1> را به آندروئید اضافه می کند.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> پشتیبانی از <1>DNS-over-HTTPS</1>, اما بمنظور پیکربندی آن برای استفاده بعنوان سرور خود،شما نیاز دارید که <2>DNS Stamp</2> برای آن تولید کنید.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> پشتیبانی از <1>DNS-over-HTTPS</1>  و <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_ios_2": "<0>AdGuard for iOS</0> پشتیبانی از <1>DNS-over-HTTPS</1> و راه اندازی <1>DNS-over-TLS</1> .",
     "setup_dns_privacy_other_title": "سایر راه کارها",
     "setup_dns_privacy_other_1": "AdGuard Home خودش میتواند کلاینت DNS اَمن را در هر سیستم عاملی پیاده کند.",

--- a/client/src/__locales/fi.json
+++ b/client/src/__locales/fi.json
@@ -498,7 +498,7 @@
     "setup_dns_privacy_android_1": "Android 9 tukee DNS-over-TLS -toteutusta natiivisti. Se määritetään syöttämällä oma verkkotunnus kohtaan \"Asetukset\" → \"Yhteydet\" → \"Lisää yhteysasetuksia\" → \"Yksityinen DNS\".",
     "setup_dns_privacy_android_2": "<0>AdGuard Androidille</0> tukee <1>DNS-over-HTTPS</1> ja <1>DNS-over-TLS</1> -toteutuksia.",
     "setup_dns_privacy_android_3": "<0>Intra</0> lisää <1>DNS-over-HTTPS</1> tuen Androidiin.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> tukee <1>DNS-over-HTTPS</1>, mutta oman palvelimen käyttö' varten sille on luotava <2>DNS Stamp</2> -merkintä.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> tukee <1>DNS-over-HTTPS</1>  ja <1>DNS-over-TLS</1> -toteutuksia.",
     "setup_dns_privacy_ios_2": "<0>AdGuard iOS:lle</0> tukee <1>DNS-over-HTTPS</1> ja <1>DNS-over-TLS</1> -toteutuksia.",
     "setup_dns_privacy_other_title": "Muita toteutuksia",
     "setup_dns_privacy_other_1": "AdGuard Home voi itse olla suojattu DNS -pääte millä tahansa alustalla.",

--- a/client/src/__locales/fr.json
+++ b/client/src/__locales/fr.json
@@ -501,7 +501,7 @@
     "setup_dns_privacy_android_1": "Android 9 supporte nativement le DNS-over-TLS. Pour le configurer, allez dans Paramètres → Réseau et Internet → Avancés → DNS privé et saisissez votre nom de domaine ici.",
     "setup_dns_privacy_android_2": "<0>AdGuard pour Android</0> supporte le <1>DNS-over-HTTPS</1> et le <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_android_3": "<0>Intra</0> ajoute le support <1>DNS-over-HTTPS</1> sur Android.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> supporte le <1>DNS-over-HTTPS</1> mais pour le configurer pour utiliser votre propre serveur, vous devrez générer un <2>DNS Stamp</2> pour lui.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> supporte le <1>DNS-over-HTTPS</1> et le <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_ios_2": "<0>AdGuard pour iOS</0> supporte les configurations <1>DNS-over-HTTPS</1> et <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_other_title": "Autres implémentations",
     "setup_dns_privacy_other_1": "AdGuard Home lui-même peut être un client DNS sécurisé sur n'importe quelle plateforme.",

--- a/client/src/__locales/hr.json
+++ b/client/src/__locales/hr.json
@@ -498,7 +498,7 @@
     "setup_dns_privacy_android_1": "Android 9 nativno podržava DNS-over-TLS. Da biste ga postavili, idite na Postavke → Mreža i internet → Napredno → Privatni DNS i tamo unesite svoje naziv domene.",
     "setup_dns_privacy_android_2": "<0>AdGuard za Android</0> podržava <1>DNS-over-HTTPS</1> i <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_android_3": "<0>Intra</0> dodaje <1>DNS-over-HTTPS</1> podršku za Android.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> podržava <1>DNS-over-HTTPS</1>, ali da biste ga postavili za upotrebu vašeg vlastitog poslužitelja, trebati će te generirati <2>DNS Stamp</2> za njega.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> podržava <1>DNS-over-HTTPS</1> i <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_ios_2": "<0>AdGuard za iOS</0> podržava <1>DNS-over-HTTPS</1> i <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_other_title": "Ostale implementacije",
     "setup_dns_privacy_other_1": "AdGuard Home može poslužiti kao sigurni DNS klijent na svim platformama.",

--- a/client/src/__locales/hu.json
+++ b/client/src/__locales/hu.json
@@ -495,7 +495,7 @@
     "setup_dns_privacy_android_1": "Az Android 9 natív módon támogatja a DNS-over-TLS-t. A beállításához menjen a Beállítások → Hálózat & internet → Speciális → Privát DNS menübe, és adja meg itt a domaint.",
     "setup_dns_privacy_android_2": "Az <0>AdGuard for Android</0> támogatja a <1>DNS-over-HTTPS</1>-t és a <1>DNS-over-TLS</1>-t.",
     "setup_dns_privacy_android_3": "Az <0>Intra</0> hozzáadja a <1>DNS-over-HTTPS</1> támogatást az Androidhoz.",
-    "setup_dns_privacy_ios_1": "A <0>DNSCloak</0> támogatja a <1>DNS-over-HTTPS</1>-t, de ahhoz, hogy a saját szerverhez konfigurálhassa, létre kell hoznia egy <2>DNS bélyeget</2> hozzá.",
+    "setup_dns_privacy_ios_1": "A <0>DNSecure</0> támogatja a <1>DNS-over-HTTPS</1>-t és a <1>DNS-over-TLS</1>-t.",
     "setup_dns_privacy_ios_2": "Az <0>AdGuard for iOS</0> támogatja a <1>DNS-over-HTTPS</1> és a <1>DNS-over-TLS</1> beállításokat.",
     "setup_dns_privacy_other_title": "Egyéb megvalósítások",
     "setup_dns_privacy_other_1": "Maga az AdGuard Home bármilyen platformon biztonságos DNS-kliens lehet.",

--- a/client/src/__locales/id.json
+++ b/client/src/__locales/id.json
@@ -498,7 +498,7 @@
     "setup_dns_privacy_android_1": "Android 9 mendukung DNS-over-TLS secara asli. Untuk mengkonfigurasinya, buka Pengaturan → Jaringan & internet → Tingkat Lanjut → DNS Pribadi dan masukkan nama domain Anda di sana.",
     "setup_dns_privacy_android_2": "<0>AdGuard untuk Android</0> mendukung <1>DNS-over-HTTPS</1> dan <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_android_3": "<0>Intra</0> menambahkan dukungan <1>DNS-over-HTTPS</1> untuk Android.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> mendukung <1>DNS-over-HTTPS</1>, tetapi untuk mengkonfigurasinya untuk menggunakan server Anda sendiri, Anda harus membuat <2>DNS Stamp</2> untuk itu.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> mendukung <1>DNS-over-HTTPS</1> dan <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_ios_2": "<0>AdGuard untuk iOS</0> mendukung <1>DNS-over-HTTPS</1> dan pengaturan <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_other_title": "Implementasi lain",
     "setup_dns_privacy_other_1": "AdGuard Home sendiri dapat menjadi klien DNS aman di platform apa pun.",

--- a/client/src/__locales/it.json
+++ b/client/src/__locales/it.json
@@ -501,7 +501,7 @@
     "setup_dns_privacy_android_1": "Android 9 supporta DNS su TLS in modo nativo. Per configurarlo, vai su Impostazioni → Rete e Internet → Avanzate → DNS privato e inserisci qui il tuo nome di dominio.",
     "setup_dns_privacy_android_2": "<0>AdGuard per Android</0> supporta <1>DNS su HTTPS</1> e <1>DNS su TLS</1>.",
     "setup_dns_privacy_android_3": "<0>Intra</0> aggiunge <1>DNS su HTTPS</1> il supporto ad Android.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> supporta <1>DNS su HTTPS</1>, ma per configurarlo per l'utilizzo del proprio server, è necessario generare un <2> DNS Stamp</2> apposito.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> supporta <1>DNS su HTTPS</1> e <1>DNS su TLS</1>.",
     "setup_dns_privacy_ios_2": "<0>AdGuard per iOS</0>supporta l'impostazione <1>DNS su HTTPS</1> e <1>DNS su TLS</1>.",
     "setup_dns_privacy_other_title": "Altre implementazion",
     "setup_dns_privacy_other_1": "AdGuard Home può essere un client DNS sicuro su qualsiasi piattaforma.",

--- a/client/src/__locales/ja.json
+++ b/client/src/__locales/ja.json
@@ -501,7 +501,7 @@
     "setup_dns_privacy_android_1": "Android 9はDNS-over-TLSをネイティブにサポートします。設定するには、設定 → ネットワークとインターネット → 詳細設定 → プライベートDNS へ遷移し、そこにドメイン名を入力してください。",
     "setup_dns_privacy_android_2": "<0>AdGuard for Android</0>は、<1>DNS-over-HTTPS</1>と<1>DNS-over-TLS</1>をサポートしています。",
     "setup_dns_privacy_android_3": "<0>Intra</0>は、Androidに<1>DNS-over-HTTPS</1>サポートを追加します。",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0>は<1>DNS-over-HTTPS</1>をサポートしますが、自身のサーバで使用するように設定するには、<2>DNS Stamp</2>を生成する必要があります。",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0>は<1>DNS-over-HTTPS</1>と<1>DNS-over-TLS</1>をサポートしています。",
     "setup_dns_privacy_ios_2": "<0>AdGuard for iOS</0>は、<1>DNS-over-HTTPS</1>と<1>DNS-over-TLS</1>の設定をサポートしています。",
     "setup_dns_privacy_other_title": "その他の機能",
     "setup_dns_privacy_other_1": "AdGuard Home 自身は、どのプラットフォームでも安全なDNSクライアントになることができます。",

--- a/client/src/__locales/ko.json
+++ b/client/src/__locales/ko.json
@@ -501,7 +501,7 @@
     "setup_dns_privacy_android_1": "Android 9는 기본적으로 DNS-over-TLS를 지원합니다. 구성하려면 설정 → 네트워크 및 인터넷 → 고급 → 개인 DNS로 이동하여 도메인 이름을 입력하세요.",
     "setup_dns_privacy_android_2": "<0>Android용 AdGuard</0>DNS-over-HTTPS <1>및</1> DNS-over-TLS <1>지원합니다</1>",
     "setup_dns_privacy_android_3": "<0>인트라</0> 안드로이드에 <1>DNS-over-HTTPS </1>지원 추가합니다.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak은</0> <1>DNS-over-HTTPS를</1> 지원하지만, 자신의 서버를 사용하도록 구성하려면 <2>DNS 스탬프를</2> 생성해야 합니다.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure은</0> <1>DNS-over-HTTPS<1>및</1> DNS-over-TLS <1>지원합니다</1>",
     "setup_dns_privacy_ios_2": "<0>iOS용 AdGuard는</0> <1>DNS-over-HTTPS </1>및 <1>DNS-over-TLS</1> 설정을 지원합니다.",
     "setup_dns_privacy_other_title": "기타 구현",
     "setup_dns_privacy_other_1": "AdGuard Home 모든 플랫폼에서 안전한 DNS 클라이언트가 될 수 있습니다.",

--- a/client/src/__locales/nl.json
+++ b/client/src/__locales/nl.json
@@ -501,7 +501,7 @@
     "setup_dns_privacy_android_1": "Android 9 ondersteunt native DNS-via-TLS. Om het te configureren, ga naar Instellingen → Netwerk & internet → Geavanceerd → Privé-DNS en voer daar je domeinnaam in.",
     "setup_dns_privacy_android_2": "<0>AdGuard voor Android</0>ondersteunt<1>DNS-via-HTTPS </1>en<1>DNS-via-TLS</1>.",
     "setup_dns_privacy_android_3": "<0> Intra </0> voegt <1> DNS-via-HTTPS</1> ondersteuning toe aan Android.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> ondersteunt <1> DNS-via-HTTPS </1>, maar om het te configureren op jouw eigen server moet er een <2> DNS-stempel </2> gegenereerd worden.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> ondersteunt <1> DNS-via-HTTPS </1>en<1>DNS-via-TLS</1>.",
     "setup_dns_privacy_ios_2": "<0> AdGuard voor iOS </0> ondersteunt de instellingen <1> DNS-via-HTTPS </1> en <1> DNS-via-TLS </1>.",
     "setup_dns_privacy_other_title": "Overig gebruik",
     "setup_dns_privacy_other_1": "AdGuard Home kan op elk platform een ​​veilige DNS-client zijn.",

--- a/client/src/__locales/no.json
+++ b/client/src/__locales/no.json
@@ -453,7 +453,7 @@
     "setup_dns_privacy_android_1": "Android 9 har innebygd støtte for DNS-over-TLS. For å sette det opp, gå til Innstillinger → Nettverk og internett → Avansert → Privat DNS, og skriv inn domenenavnet ditt der.",
     "setup_dns_privacy_android_2": "<0>AdGuard for Android</0> støtter <1>DNS-over-HTTPS</1> og <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_android_3": "<0>Intra</0> legger til <1>DNS-over-HTTPS</1>-støtte i Android.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> støtter <1>DNS-over-HTTPS</1>, men for å sette det opp til å bruke din egen tjener, vil du måtte generere et <2>DNS-stempel</2> for det.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> støtter <1>DNS-over-HTTPS</1> og <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_ios_2": "<0>AdGuard for iOS</0> støtter <1>DNS-over-HTTPS</1>- og <1>DNS-over-TLS</1>-oppsett.",
     "setup_dns_privacy_other_title": "Andre implementeringer",
     "setup_dns_privacy_other_1": "AdGuard Home i seg selv kan brukes som en sikker DNS-klient for enhver plattform.",

--- a/client/src/__locales/pl.json
+++ b/client/src/__locales/pl.json
@@ -498,7 +498,7 @@
     "setup_dns_privacy_android_1": "System Android 9 obsługuje natywnie DNS-over-TLS. Aby go skonfigurować, przejdź do Ustawienia → Sieć i Internet → Zaawansowane → Prywatny DNS i wpisz tam swoją nazwę domeny.",
     "setup_dns_privacy_android_2": "Aplikacja <0>AdGuard dla Androida</0> obsługuje <1>DNS-over-HTTPS</1> i <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_android_3": "Aplikacja <0>Intra</0> dodaje obsługę <1>DNS-over-HTTPS</1> dla Androida.",
-    "setup_dns_privacy_ios_1": "Aplikacja <0>DNSCloak</0> obsługuje <1>DNS-over-HTTPS</1>, ale musisz wygenerować znacznik, aby skonfigurować go do używania własnego serwera <2>DNS Stamp</2>.",
+    "setup_dns_privacy_ios_1": "Aplikacja <0>DNSecure</0> obsługuje <1>DNS-over-HTTPS</1> i <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_ios_2": "Aplikacja <0>AdGuard dla iOS</0> obsługuje <1>DNS-over-HTTPS</1> i <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_other_title": "Inne implementacje",
     "setup_dns_privacy_other_1": "Sam AdGuard Home może być bezpiecznym klientem DNS na dowolnej platformie.",

--- a/client/src/__locales/pt-br.json
+++ b/client/src/__locales/pt-br.json
@@ -501,7 +501,7 @@
     "setup_dns_privacy_android_1": "O Android 9 suporta o DNS-sobre-TLS de forma nativa. Para configurá-lo, vá para Configurações → Rede e internet → Avançado → DNS privado e digite seu nome de domínio lá.",
     "setup_dns_privacy_android_2": "O <0>AdGuard para Android</0> suporta <1>DNS-sobre-HTTPS</1> e <1>DNS-sobre-TLS</1>.",
     "setup_dns_privacy_android_3": "<0>Intra</0> adiciona o suporte <1>DNS-sobre-HTTPS</1> para o Android.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> suporta <1>DNS-sobre-HTTPS</1>, mas para configurá-lo para usar seu próprio servidor, você precisará gerar um <2>DNS Stamp</2>.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> suporta <1>DNS-sobre-HTTPS</1> e <1>DNS-sobre-TLS</1>.",
     "setup_dns_privacy_ios_2": "O <0>AdGuard para iOS</0> suporta a configuração do <1>DNS-sobre-HTTPS</1> e <1>DNS-sobre-TLS</1>.",
     "setup_dns_privacy_other_title": "Outras implementações",
     "setup_dns_privacy_other_1": "O próprio AdGuard Home pode ser usado como um cliente DNS seguro em qualquer plataforma.",

--- a/client/src/__locales/pt-pt.json
+++ b/client/src/__locales/pt-pt.json
@@ -501,7 +501,7 @@
     "setup_dns_privacy_android_1": "O Android 9 suporta o DNS-sobre-TLS de forma nativa. Para o configurar, vá a Definições → Rede e internet → Avançado → DNS privado e digite o seu nome de domínio.",
     "setup_dns_privacy_android_2": "O <0>AdGuard para Android</0> suporta <1>DNS-sobre-HTTPS</1> e <1>DNS-sobre-TLS</1>.",
     "setup_dns_privacy_android_3": "<0>Intra</0> adiciona o suporte <1>DNS-sobre-HTTPS</1> para o Android.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> suporta <1>DNS-sobre-HTTPS</1>, mas para o configurar para usar o seu próprio servidor, precisará de gerar um <2>DNS Stamp</2>.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> suporta <1>DNS-sobre-HTTPS</1> e <1>DNS-sobre-TLS</1>.",
     "setup_dns_privacy_ios_2": "O <0>AdGuard para iOS</0> suporta a definição do <1>DNS-sobre-HTTPS</1> e <1>DNS-sobre-TLS</1>.",
     "setup_dns_privacy_other_title": "Outras implementações",
     "setup_dns_privacy_other_1": "O próprio AdGuard Home pode ser usado como um cliente DNS seguro em qualquer plataforma.",

--- a/client/src/__locales/ro.json
+++ b/client/src/__locales/ro.json
@@ -495,7 +495,7 @@
     "setup_dns_privacy_android_1": "Android 9 acceptă DNS-over-TLS nativ. Pentru a-l configura, accesați Setări → Rețea și internet → Advanced → Private DNS și introduceți numele de domeniu acolo.",
     "setup_dns_privacy_android_2": "<0>AdGuard pentru Android</0> acceptă <1>DNS-over-HTTPS</1> și <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_android_3": "<0>Intra</0> adaugă <1>DNS-over-HTTPS</1> suport pentru Android.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> acceptă <1>DNS-over-HTTPS</1>, dar pentru a-l configura pentru a utiliza propriul server, va trebui să generați un <2>DNS Stamp</2> pentru aceasta.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> acceptă <1>DNS-over-HTTPS</1> și <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_ios_2": "<0>AdGuard pentru iOS</0> acceptă instalarea <1>DNS-over-HTTPS</1> și <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_other_title": "Alte implementări",
     "setup_dns_privacy_other_1": "AdGuard Home poate fi un client DNS sigur pe orice platformă.",

--- a/client/src/__locales/ru.json
+++ b/client/src/__locales/ru.json
@@ -501,7 +501,7 @@
     "setup_dns_privacy_android_1": "Android 9 нативно поддерживает DNS-over-TLS. Для настройки, перейдите в Настройки → Сеть и Интернет → Дополнительно → Персональный DNS сервер, и введите туда ваше доменное имя.",
     "setup_dns_privacy_android_2": "<0>AdGuard для Android</0> поддерживает <1>DNS-over-HTTPS</1> и <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_android_3": "<0>Intra</0> добавляет поддержка <1>DNS-over-HTTPS</1> на Android.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> поддерживает <1>DNS-over-HTTPS</1>, но для настройки его, вам будет нужно сгенерировать для него <2>DNS-отпечаток</2>.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> поддерживает <1>DNS-over-HTTPS</1> и <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_ios_2": "<0>AdGuard для iOS</0> поддерживает <1>DNS-over-HTTPS</1> и <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_other_title": "Другие решения",
     "setup_dns_privacy_other_1": "AdGuard Home сам может быть клиентом зашифрованного DNS на любой платформе.",

--- a/client/src/__locales/sk.json
+++ b/client/src/__locales/sk.json
@@ -501,7 +501,7 @@
     "setup_dns_privacy_android_1": "Android 9 podporuje DNS-over-TLS natívne. Ak ho chcete konfigurovať, prejdite na Nastavenia → Sieť a internet → Pokročilé → Súkromné DNS a zadajte tam meno Vašej domény.",
     "setup_dns_privacy_android_2": "<0>AdGuard pre Android</0> podporuje <1>DNS-over-HTTPS</1> a <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_android_3": "<0>Intra</0> pridáva <1>DNS-over-HTTPS</1> podporu pre Android.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> podporuje funkciu <1>DNS-over-HTTPS</1>, ale aby ste ju mohli nakonfigurovať na používanie vlastného servera, musíte kvôli tomu vygenerovať značku <2>DNS Stamp</2>.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> podporuje funkciu <1>DNS-over-HTTPS</1> a <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_ios_2": "<0>AdGuard pre  iOS</0> podporuje <1>DNS-over-HTTPS</1> a <1>DNS-over-TLS</1> nastavenie.",
     "setup_dns_privacy_other_title": "Ostatné implementácie",
     "setup_dns_privacy_other_1": "Samotný AdGuard Home môže byť bezpečným DNS klientom na ľubovoľnej platforme.",

--- a/client/src/__locales/sl.json
+++ b/client/src/__locales/sl.json
@@ -498,7 +498,7 @@
     "setup_dns_privacy_android_1": "Android 9 izvirno podpira DNS-prek-TLS. Če ga želite konfigurirati, pojdite v Nastavitve → Omrežje in internet → Napredno → Zasebni DNS, in tam vnesite svoje ime domene.",
     "setup_dns_privacy_android_2": "<0>AdGuard za Android</0> podpira <1>DNS-prek-HTTPS</1> in <1>DNS-prek-TLS</1>.",
     "setup_dns_privacy_android_3": "<0>Intra</0> doda podporo <1>DNS-prek-HTTPS</1> za Android.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> podpira <1>DNS-prek-HTTPS</1> vendar za njegovo konfiguracijo, da bo uporabljal svoj strežnik, morate zanj ustvariti <2>DNS Stamp</2>.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> podpira <1>DNS-prek-HTTPS</1> in <1>DNS-prek-TLS</1>.",
     "setup_dns_privacy_ios_2": "<0>AdGuard za iOS</0> podpira nastavitev <1>DNS-prek-HTTPS</1> in <1>DNS-prek-TLS</1>.",
     "setup_dns_privacy_other_title": "Druge izvedbe",
     "setup_dns_privacy_other_1": "Sam AdGuard Home je lahko varen odjemalec DNS na kateri koli platformi.",

--- a/client/src/__locales/sr-cs.json
+++ b/client/src/__locales/sr-cs.json
@@ -495,7 +495,7 @@
     "setup_dns_privacy_android_1": "Android 9 podržava DNS-over-TLS. Za konfiguraciju, idite u postavke → mreža i internet → Napredno → Privatni DNS i tamo unesite ime vašeg domena.",
     "setup_dns_privacy_android_2": "<0>AdGuard for Android</0> podržava <1>DNS-over-HTTPS</1> i <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_android_3": "<0>Intra</0> dodaje <1>DNS-over-HTTPS</1> podršku za Android.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> podržava <1>DNS-over-HTTPS</1>, ali da biste mogli da ga konfigurišete da koristi vaš lični server, biće potrebno da generišete a <2>DNS Stamp</2> za njega.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> podržava <1>DNS-over-HTTPS</1> i <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_ios_2": "<0>AdGuard za iOS</0> podržava <1>DNS-over-HTTPS</1> i <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_other_title": "Druge implementacije",
     "setup_dns_privacy_other_1": "AdGuard home može biti bezbedan DNS server na bilo kojoj platformi.",

--- a/client/src/__locales/sv.json
+++ b/client/src/__locales/sv.json
@@ -494,7 +494,7 @@
     "setup_dns_privacy_android_1": "Android 9 har inbyggt stöd för DNS-över-TLS. Konfigurera och uppge domännamn under Inställningar → Nätverk & Internet → Avancerat → Privat DNS.",
     "setup_dns_privacy_android_2": "<0>AdGuard för Android</0> stödjer <1>DNS-över-HTTPS</1> samt <1>DNS-över-TLS</1>.",
     "setup_dns_privacy_android_3": "<0>Intra</0> lägger till stöd för <1>DNS-ÖVER-HTTPS</1> till Android.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> stödjer <1>DNS-ÖVER-HTTPS</1>, men för konfigurering krävs att du använder dig egen server. Du behöver generera en <2>DNS-Stämpel</2> till programmet.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> stödjer <1>DNS-ÖVER-HTTPS</1> samt <1>DNS-över-TLS</1>.",
     "setup_dns_privacy_ios_2": "<0>AdGuard för iOS</0> stödjer <1>DNS-över-HTTPS</1> samt <1>DNS-över-TLS</1>.",
     "setup_dns_privacy_other_title": "Andra implementeringar",
     "setup_dns_privacy_other_1": "AdGuard Home kan själv vara en säker DNS-klient på alla plattformar.",

--- a/client/src/__locales/tr.json
+++ b/client/src/__locales/tr.json
@@ -501,7 +501,7 @@
     "setup_dns_privacy_android_1": "Android 9, yerel olarak DNS-over-TLS protokolünü destekler. Yapılandırmak için Ayarlar → Ağ ve İnternet → Gelişmiş → Özel DNS öğesine gidin ve alan adınızı girin.",
     "setup_dns_privacy_android_2": "<0>Android için AdGuard</0>, <1>DNS-over-HTTPS</1> ve <1>DNS-over-TLS</1> protokolünü destekler.",
     "setup_dns_privacy_android_3": "<0>Intra</0> Android'e <1>DNS-over-HTTPS</1> protokol desteğini ekler.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0>, <1>DNS-over-HTTPS</1> protokolünü destekler, ancak kendi sunucunuzu kullanacak şekilde yapılandırmak için bir <2>DNS Damgası</2> oluşturmanız gerekir.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0>, <1>DNS-over-HTTPS</1> ve <1>DNS-over-TLS</1> protokolünü destekler.",
     "setup_dns_privacy_ios_2": "<0>iOS için AdGuard</0>, <1>DNS-over-HTTPS</1> ve <1>DNS-over-TLS</1> protokolünü destekler.",
     "setup_dns_privacy_other_title": "Diğer kullanım alanları",
     "setup_dns_privacy_other_1": "AdGuard Home, herhangi bir platformda güvenli bir DNS istemcisi olabilir.",

--- a/client/src/__locales/uk.json
+++ b/client/src/__locales/uk.json
@@ -498,7 +498,7 @@
     "setup_dns_privacy_android_1": "Android 9 підтримує DNS-over-TLS. Щоб його налаштувати, перейдіть у Налаштування → Мережа та Інтернет → Додатково → Приватний DNS і введіть там свій домен.",
     "setup_dns_privacy_android_2": "<0>AdGuard для Android</0> підтримує <1>DNS-over-HTTPS</1> і <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_android_3": "<0>Intra</0> додає підтримку <1>DNS-over-HTTPS</1> для Android.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> підтримує <1>DNS-over-HTTPS</1>, але для того, щоб налаштувати його на використання власного сервера, вам потрібно буде створити для нього <2>штамп DNS</2>.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> підтримує <1>DNS-over-HTTPS</1> і <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_ios_2": "<0>AdGuard для iOS</0> підтримує налаштування <1>DNS over-HTTPS</1> і <1>DNS over over TLS</1>.",
     "setup_dns_privacy_other_title": "Інші реалізації",
     "setup_dns_privacy_other_1": "Сам AdGuard Home може слугувати захищеним клієнтом DNS на будь-якій платформі.",

--- a/client/src/__locales/vi.json
+++ b/client/src/__locales/vi.json
@@ -498,7 +498,7 @@
     "setup_dns_privacy_android_1": "Android 9 hỗ trợ DNS trên TLS nguyên bản. Để định cấu hình, hãy đi tới Cài đặt → Mạng & internet → Nâng cao → DNS Riêng Tư và nhập tên miền của bạn vào đó.",
     "setup_dns_privacy_android_2": "<0>AdGuard for Android</0> hỗ trợ <1>DNS-over-HTTPS</1> và <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_android_3": "<0>Intra</0> thêm <1>DNS-over-HTTPS</1> hỗ trợ cho Android.",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> hỗ trợ <1>DNS-over-HTTPS</1>, nhưng để định cấu hình nó để sử dụng máy chủ của riêng bạn, bạn sẽ cần phải tạo một <2>DNS Stamp</2> cho nó.",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> hỗ trợ <1>DNS-over-HTTPS</1> và <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_ios_2": "<0>AdGuard for iOS</0> hỗ trợ thiết lập <1>DNS-over-HTTPS</1> và <1>DNS-over-TLS</1>.",
     "setup_dns_privacy_other_title": "Triển khai khác",
     "setup_dns_privacy_other_1": "Bản thân AdGuard Home có thể là máy khách DNS an toàn trên mọi nền tảng.",

--- a/client/src/__locales/zh-cn.json
+++ b/client/src/__locales/zh-cn.json
@@ -501,7 +501,7 @@
     "setup_dns_privacy_android_1": "Android 9 原生支持 DNS-over-TLS。 要进行配置，请转到 设置 → 网络和互联网 → 高级 → 私有 DNS，然后在那里输入您的域名。",
     "setup_dns_privacy_android_2": "<0>AdGuard for Android</0> 支持 <1>DNS-over-HTTPS</1> 和 <1>DNS-over-TLS</1>。",
     "setup_dns_privacy_android_3": "<0>Intra</0> 为 Android 提供了 <1>DNS-over-HTTPS</1> 的支持。",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> 支持 <1>DNS-over-HTTPS</1> ，但为了设置使用您自己的服务器，您需要为了它生成一个 <2>DNS Stamp</2> 。",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> 支持 <1>DNS-over-HTTPS</1> 和 <1>DNS-over-TLS</1>。",
     "setup_dns_privacy_ios_2": "<0>AdGuard for iOS</0> 支持 <1>DNS-over-HTTPS</1> 和 <1>DNS-over-TLS</1>。",
     "setup_dns_privacy_other_title": "其他实施方案",
     "setup_dns_privacy_other_1": "AdGuard Home 本身可以作为任何平台上的安全 DNS 客户端。",

--- a/client/src/__locales/zh-hk.json
+++ b/client/src/__locales/zh-hk.json
@@ -498,7 +498,7 @@
     "setup_dns_privacy_android_1": "Android 9 原生支援 DNS-over-TLS。前往「設定」→「網路 & 網際網路」→「進階」→「私人 DNS」設定。",
     "setup_dns_privacy_android_2": "<0>AdGuard for Android</0> 支援  <1>DNS-over-HTTPS</1> 與 <1>DNS-over-TLS</1>。",
     "setup_dns_privacy_android_3": "<0>Intra</0> 對 Android 新增支援 <1>DNS-over-HTTPS</1>。",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> 支援 <1>DNS-over-HTTPS</1>，若要使用您必須先產生 <2>DNS Stamp</2>。",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> 支援 <1>DNS-over-HTTPS</1> 與 <1>DNS-over-TLS</1>。",
     "setup_dns_privacy_ios_2": "<0>AdGuard for iOS</0> 支援 <1>DNS-over-HTTPS</1> 與 <1>DNS-over-TLS</1> 設定。",
     "setup_dns_privacy_other_title": "其他實作方式",
     "setup_dns_privacy_other_1": "AdGuard Home 本身在任何平台都是安全的 DNS 用戶端。",

--- a/client/src/__locales/zh-tw.json
+++ b/client/src/__locales/zh-tw.json
@@ -501,7 +501,7 @@
     "setup_dns_privacy_android_1": "Android 9 原生地支援 DNS-over-TLS。為了配置它，去設定 → 網路 & 網際網路 → 進階 → 私人 DNS 並在那輸入您的域名。",
     "setup_dns_privacy_android_2": "<0>AdGuard for Android</0> 支援 <1>DNS-over-HTTPS</1> 和 <1>DNS-over-TLS</1>。",
     "setup_dns_privacy_android_3": "<0>Intra</0> 對 Android 新增 <1>DNS-over-HTTPS</1> 支援。",
-    "setup_dns_privacy_ios_1": "<0>DNSCloak</0> 支援 <1>DNS-over-HTTPS</1>，但為了配置它以使用您自己的伺服器，您將需要為它產生一個 <2>DNS 戳記</2>。",
+    "setup_dns_privacy_ios_1": "<0>DNSecure</0> 支援 <1>DNS-over-HTTPS</1> 和 <1>DNS-over-TLS</1>。",
     "setup_dns_privacy_ios_2": "<0>AdGuard for iOS</0> 支援 <1>DNS-over-HTTPS</1> 和 <1>DNS-over-TLS</1> 設置。",
     "setup_dns_privacy_other_title": "其它的執行",
     "setup_dns_privacy_other_1": "於任何的平台上，AdGuard Home 它本身可以是安全的 DNS 用戶端。",

--- a/client/src/components/ui/Guide/Guide.tsx
+++ b/client/src/components/ui/Guide/Guide.tsx
@@ -91,7 +91,7 @@ const getDnsPrivacyList = () => [
                 components: [
                     {
                         key: 0,
-                        href: 'https://itunes.apple.com/app/id1452162351',
+                        href: 'https://itunes.apple.com/app/id1533413232',
                     },
 
                     <code key="1">text</code>,


### PR DESCRIPTION
Before submitting a PR please make sure that:

1.  You have discussed your solution in an issue and have got an
    approval from a maintainer.  See our
    [contribution guide](https://github.com/AdguardTeam/AdGuardHome/blob/master/CONTRIBUTING.md).

2.  This isn't a localization fix; please send those to our
    [CrowdIn](https://crowdin.com/project/adguard-applications/en#/adguard-home)
    page.

3.  Your code follows our
    [code guidelines](https://github.com/AdguardTeam/CodeGuidelines/blob/master/Go/Go.md).

Add a short description here.  The description should include:

1.  Which issue this PR closes (`Closes #NNNN.`) or updates (`Updates
    #NNNN.`).  Please do not open PRs without filing an issue first.

2.  A short description of how the change achieves that.

Do not forget to remove these instructions!
