### PR TITLE
Fixes #1709: Per Client Blocking Mode configuration 

### DIFF
--- a/client/src/components/Settings/Clients/Form/components/MainSettings.tsx
+++ b/client/src/components/Settings/Clients/Form/components/MainSettings.tsx
@@ -166,7 +166,9 @@ export const MainSettings = ({ processingAdding, processingUpdating, safeSearchS
                         name="blocking_mode"
                         control={control}
                         render={({ field }) => (
-                            <Radio {...field} options={blockingModeOptions} disabled={processingAdding || processingUpdating} />
+                            <Radio {...field}
+                                options={blockingModeOptions}
+                                disabled={processingAdding || processingUpdating} />
                         )}
                     />
                 </div>
@@ -174,28 +176,30 @@ export const MainSettings = ({ processingAdding, processingUpdating, safeSearchS
             {blockingMode === BLOCKING_MODES.custom_ip && (
                 <>
                     {customIps.map(({ label, description, name, validateIp }) => (
-                        <div className="form__group">
-                            <Controller
-                                name={name}
-                                control={control}
-                                rules={{
-                                    validate: {
-                                        required: validateRequiredValue,
-                                        ip: validateIp,
-                                    },
-                                }}
-                                render={({ field, fieldState }) => (
-                                    <Input
-                                        {...field}
-                                        data-testid="dns_config_blocked_response_ttl"
-                                        type="text"
-                                        label={label}
-                                        desc={description}
-                                        error={fieldState.error?.message}
-                                        disabled={processingAdding || processingUpdating}
-                                    />
-                                )}
-                            />
+                        <div className="col-12 col-sm-6" key={name}>
+                            <div className="form__group">
+                                <Controller
+                                    name={name}
+                                    control={control}
+                                    rules={{
+                                        validate: {
+                                            required: validateRequiredValue,
+                                            ip: validateIp,
+                                        },
+                                    }}
+                                    render={({ field, fieldState }) => (
+                                        <Input
+                                            {...field}
+                                            data-testid="dns_config_blocked_response_ttl"
+                                            type="text"
+                                            label={label}
+                                            desc={description}
+                                            error={fieldState.error?.message}
+                                            disabled={processingAdding || processingUpdating}
+                                        />
+                                    )}
+                                />
+                            </div>
                         </div>
                     ))}
                 </>

--- a/client/src/components/Settings/Clients/Form/index.tsx
+++ b/client/src/components/Settings/Clients/Form/index.tsx
@@ -5,7 +5,7 @@ import { Controller, FormProvider, useForm } from 'react-hook-form';
 import Select from 'react-select';
 
 import Tabs from '../../../ui/Tabs';
-import { CLIENT_ID_LINK, LOCAL_TIMEZONE_VALUE } from '../../../../helpers/constants';
+import { CLIENT_ID_LINK, LOCAL_TIMEZONE_VALUE, BLOCKING_MODES } from '../../../../helpers/constants';
 import { RootState } from '../../../../initialState';
 import { Input } from '../../../ui/Controls/Input';
 import { validateRequiredValue } from '../../../../helpers/validators';
@@ -33,6 +33,9 @@ const defaultFormValues: ClientForm = {
     blocked_services_schedule: {
         time_zone: LOCAL_TIMEZONE_VALUE,
     },
+    blocking_mode: BLOCKING_MODES.default,
+    blocking_ipv4: '',
+    blocking_ipv6: '',
 };
 
 type Props = {
@@ -83,7 +86,7 @@ export const Form = ({
     const tabs = {
         settings: {
             title: 'settings',
-            component: <MainSettings safeSearchServices={safeSearchServices} />,
+            component: <MainSettings processingAdding={processingAdding} processingUpdating={processingUpdating} safeSearchServices={safeSearchServices} />,
         },
         block_services: {
             title: 'block_services',

--- a/client/src/components/Settings/Clients/Form/index.tsx
+++ b/client/src/components/Settings/Clients/Form/index.tsx
@@ -86,7 +86,10 @@ export const Form = ({
     const tabs = {
         settings: {
             title: 'settings',
-            component: <MainSettings processingAdding={processingAdding} processingUpdating={processingUpdating} safeSearchServices={safeSearchServices} />,
+            component: <MainSettings
+                processingAdding={processingAdding}
+                processingUpdating={processingUpdating}
+                safeSearchServices={safeSearchServices} />,
         },
         block_services: {
             title: 'block_services',

--- a/client/src/components/Settings/Clients/Form/types.ts
+++ b/client/src/components/Settings/Clients/Form/types.ts
@@ -20,6 +20,9 @@ export type ClientForm = {
     parental_enabled: boolean;
     ignore_querylog: boolean;
     ignore_statistics: boolean;
+    blocking_mode: string;
+    blocking_ipv4: string;
+    blocking_ipv6: string;
 };
 
 export type SubmitClientForm = Omit<ClientForm, 'ids' | 'tags'> & {

--- a/internal/client/persistent.go
+++ b/internal/client/persistent.go
@@ -193,7 +193,8 @@ func (c *Persistent) validateBlockingMode() error {
 		}
 	}
 
-	return fmt.Errorf("unknown blocking_mode: %s", c.BlockingMode)
+	// Assumed to default to the default blocking mode
+	return nil
 }
 
 // SetIDs parses a list of strings into typed fields and returns an error if

--- a/internal/client/persistent.go
+++ b/internal/client/persistent.go
@@ -65,6 +65,15 @@ type Persistent struct {
 	// must not be nil after initialization.
 	BlockedServices *filtering.BlockedServices
 
+	// BlockingMode is the blocking mode override for a client
+	BlockingMode filtering.BlockingMode
+
+	// BlockingIPv4 is the IP address to be returned for a blocked A request.
+	BlockingIPv4 netip.Addr
+
+	// BlockingIPv6 is the IP address to be returned for a blocked AAAA request.
+	BlockingIPv6 netip.Addr
+
 	// Name of the persistent client.  Must not be empty.
 	Name string
 
@@ -138,6 +147,24 @@ func (c *Persistent) validate(ctx context.Context, l *slog.Logger, allTags []str
 		return errors.Error("id required")
 	case c.UID == UID{}:
 		return errors.Error("uid required")
+	}
+
+	switch c.BlockingMode {
+	case
+		filtering.BlockingModeDefault,
+		filtering.BlockingModeNXDOMAIN,
+		filtering.BlockingModeREFUSED,
+		filtering.BlockingModeNullIP:
+		break
+	case filtering.BlockingModeCustomIP:
+		if !c.BlockingIPv4.Is4() {
+			return fmt.Errorf("blocking_ipv4 must be valid ipv4 on custom_ip blocking_mode")
+		}
+		if !c.BlockingIPv6.Is6() {
+			return fmt.Errorf("blocking_ipv6 must be valid ipv6 on custom_ip blocking_mode")
+		}
+	default:
+		return fmt.Errorf("unknown blocking_mode: %s", c.BlockingMode)
 	}
 
 	conf, err := proxy.ParseUpstreamsConfig(c.Upstreams, &upstream.Options{})
@@ -294,6 +321,10 @@ func (c *Persistent) EqualIDs(prev *Persistent) (equal bool) {
 func (c *Persistent) ShallowClone() (clone *Persistent) {
 	clone = &Persistent{}
 	*clone = *c
+
+	clone.BlockingMode = c.BlockingMode
+	clone.BlockingIPv4 = c.BlockingIPv4
+	clone.BlockingIPv6 = c.BlockingIPv6
 
 	clone.BlockedServices = c.BlockedServices.Clone()
 	clone.Tags = slices.Clone(c.Tags)

--- a/internal/client/storage.go
+++ b/internal/client/storage.go
@@ -705,4 +705,7 @@ func (s *Storage) ApplyClientFiltering(id string, addr netip.Addr, setts *filter
 	setts.ClientSafeSearch = c.SafeSearch
 	setts.SafeBrowsingEnabled = c.SafeBrowsingEnabled
 	setts.ParentalEnabled = c.ParentalEnabled
+	setts.BlockingMode = c.BlockingMode
+	setts.BlockingIPv4 = c.BlockingIPv4
+	setts.BlockingIPv6 = c.BlockingIPv6
 }

--- a/internal/dnsforward/filter.go
+++ b/internal/dnsforward/filter.go
@@ -45,7 +45,7 @@ func (s *Server) filterDNSRequest(dctx *dnsContext) (res *filtering.Result, err 
 		req.Question[0].Name = dns.Fqdn(res.CanonName)
 	case res.IsFiltered:
 		log.Debug("dnsforward: host %q is filtered, reason: %q", host, res.Reason)
-		pctx.Res = s.genDNSFilterMessage(pctx, res)
+		pctx.Res = s.genDNSFilterMessage(dctx, pctx, res)
 	case res.Reason.In(filtering.Rewritten, filtering.FilteredSafeSearch):
 		pctx.Res = s.getCNAMEWithIPs(req, res.IPList, res.CanonName)
 	case res.Reason.In(filtering.RewrittenRule, filtering.RewrittenAutoHosts):
@@ -130,7 +130,7 @@ func (s *Server) filterDNSResponse(dctx *dnsContext) (err error) {
 		} else if res != nil && res.IsFiltered {
 			dctx.result = res
 			dctx.origResp = pctx.Res
-			pctx.Res = s.genDNSFilterMessage(pctx, res)
+			pctx.Res = s.genDNSFilterMessage(dctx, pctx, res)
 
 			log.Debug("dnsforward: matched %q by response: %q", pctx.Req.Question[0].Name, host)
 

--- a/internal/dnsforward/process.go
+++ b/internal/dnsforward/process.go
@@ -621,6 +621,12 @@ func (s *Server) processFilteringAfterResponse(dctx *dnsContext) (rc resultCode)
 	}
 }
 
+// blockingMode fetches the blocking mode for the specific client from the context
+func (s *Server) blockingMode(dctx *dnsContext) (filtering.BlockingMode, netip.Addr, netip.Addr) {
+
+	return dctx.setts.BlockingMode, dctx.setts.BlockingIPv4, dctx.setts.BlockingIPv6
+}
+
 // filterAfterResponse returns the result of filtering the response that wasn't
 // explicitly allowed or rewritten.
 func (s *Server) filterAfterResponse(dctx *dnsContext) (res resultCode) {

--- a/internal/dnsforward/process.go
+++ b/internal/dnsforward/process.go
@@ -623,7 +623,6 @@ func (s *Server) processFilteringAfterResponse(dctx *dnsContext) (rc resultCode)
 
 // blockingMode fetches the blocking mode for the specific client from the context
 func (s *Server) blockingMode(dctx *dnsContext) (filtering.BlockingMode, netip.Addr, netip.Addr) {
-
 	return dctx.setts.BlockingMode, dctx.setts.BlockingIPv4, dctx.setts.BlockingIPv6
 }
 

--- a/internal/filtering/filter.go
+++ b/internal/filtering/filter.go
@@ -638,6 +638,7 @@ func (d *DNSFilter) ApplyAdditionalFiltering(cliAddr netip.Addr, clientID string
 
 	d.ApplyBlockedServices(setts)
 	d.applyClientFiltering(clientID, cliAddr, setts)
+
 	if setts.BlockedServices != nil {
 		// TODO(e.burkov):  Get rid of this crutch.
 		setts.ServicesRules = nil

--- a/internal/filtering/filtering.go
+++ b/internal/filtering/filtering.go
@@ -53,6 +53,10 @@ type Settings struct {
 	// is nil if the client does not have any blocked services.
 	BlockedServices *BlockedServices
 
+	BlockingMode BlockingMode
+	BlockingIPv4 netip.Addr
+	BlockingIPv6 netip.Addr
+
 	ProtectionEnabled   bool
 	FilteringEnabled    bool
 	SafeSearchEnabled   bool
@@ -387,6 +391,9 @@ func (d *DNSFilter) Settings() (s *Settings) {
 		SafeSearchEnabled:   d.conf.SafeSearchConf.Enabled,
 		SafeBrowsingEnabled: d.conf.SafeBrowsingEnabled,
 		ParentalEnabled:     d.conf.ParentalEnabled,
+		BlockingMode:        d.conf.BlockingMode,
+		BlockingIPv4:        d.conf.BlockingIPv4,
+		BlockingIPv6:        d.conf.BlockingIPv6,
 	}
 }
 

--- a/internal/home/clients.go
+++ b/internal/home/clients.go
@@ -159,6 +159,10 @@ type clientObject struct {
 	Tags      []string `yaml:"tags"`
 	Upstreams []string `yaml:"upstreams"`
 
+	BlockingMode filtering.BlockingMode `yaml:"blocking_mode"`
+	BlockingIPv4 netip.Addr             `yaml:"blocking_ipv4"`
+	BlockingIPv6 netip.Addr             `yaml:"blocking_ipv6"`
+
 	// UID is the unique identifier of the persistent client.
 	UID client.UID `yaml:"uid"`
 
@@ -193,6 +197,10 @@ func (o *clientObject) toPersistent(
 		Upstreams: o.Upstreams,
 
 		UID: o.UID,
+
+		BlockingMode: o.BlockingMode,
+		BlockingIPv4: o.BlockingIPv4,
+		BlockingIPv6: o.BlockingIPv6,
 
 		UseOwnSettings:        !o.UseGlobalSettings,
 		FilteringEnabled:      o.FilteringEnabled,
@@ -272,6 +280,10 @@ func (clients *clientsContainer) forConfig() (objs []*clientObject) {
 			IDs:       cli.IDs(),
 			Tags:      slices.Clone(cli.Tags),
 			Upstreams: slices.Clone(cli.Upstreams),
+
+			BlockingMode: cli.BlockingMode,
+			BlockingIPv4: cli.BlockingIPv4,
+			BlockingIPv6: cli.BlockingIPv6,
 
 			UID: cli.UID,
 

--- a/internal/home/clientshttp.go
+++ b/internal/home/clientshttp.go
@@ -216,7 +216,7 @@ func copyBlockingMode(blockingMode filtering.BlockingMode, ipv4, ipv6 string) (f
 		return blockingMode, addrIpv4, addrIpv6, nil
 	}
 
-	return "", netip.Addr{}, netip.Addr{}, fmt.Errorf("unknown blocking mode: %s", blockingMode)
+	return filtering.BlockingModeDefault, netip.Addr{}, netip.Addr{}, nil
 }
 
 // jsonToClient converts JSON object to persistent client object if there are no

--- a/internal/home/config.go
+++ b/internal/home/config.go
@@ -567,8 +567,22 @@ func parseConfig() (err error) {
 		config.DNS.UpstreamTimeout = timeutil.Duration(dnsforward.DefaultTimeout)
 	}
 
+	setDefaultsForPersistentClients()
+
 	// Do not wrap the error because it's informative enough as is.
 	return validateTLSCipherIDs(config.TLS.OverrideTLSCiphers)
+}
+
+// setDefaultsForPersistentClients sets some default values for persistent clients
+// derived from global defaults
+func setDefaultsForPersistentClients() {
+	for i, o := range config.Clients.Persistent {
+		if o.BlockingMode == "" {
+			config.Clients.Persistent[i].BlockingMode = config.Filtering.BlockingMode
+			config.Clients.Persistent[i].BlockingIPv4 = config.Filtering.BlockingIPv4
+			config.Clients.Persistent[i].BlockingIPv6 = config.Filtering.BlockingIPv6
+		}
+	}
 }
 
 // validateConfig returns error if the configuration is invalid.


### PR DESCRIPTION
This PR closes https://github.com/AdguardTeam/AdGuardHome/issues/1709

This PR adds the following.


1. In the backend side, It adds per client `blocking_mode` configuration. 
2. On the frontend, It adds the UI to configure Blocking Mode for a client. 


Notes: 
* The default value of `blocking_mode`, `blocking_ipv4`, `blocking_ipv6` for a client is derived from the global values. 
* Previously, The blocking mode configuration was looked up in `*Server.DnsContext.BlockingMode` which returns the global values. Now, These values are looked up in the client context. 

