### PR TITLE
Add bind-tools to container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ LABEL \
 	org.opencontainers.image.version=$VERSION
 
 # Update certificates.
-RUN apk --no-cache add ca-certificates libcap tzdata && \
+RUN apk --no-cache add ca-certificates libcap tzdata bind-tools && \
 	mkdir -p /opt/adguardhome/conf /opt/adguardhome/work && \
 	chown -R nobody: /opt/adguardhome
 


### PR DESCRIPTION
Bind tools would be very useful to have in a kubernetes setting where healthchecks could use `dig` or `nslookup` to check whether everything is still running as expected.
