### PR TITLE
Prevent continuous connection rebuilding in custom upstreams

### DIFF
--- a/internal/client/upstreammanager.go
+++ b/internal/client/upstreammanager.go
@@ -139,6 +139,7 @@ func (m *upstreamManager) customUpstreamConfig(uid UID) (proxyConf *proxy.Custom
 	proxyConf = newCustomUpstreamConfig(cliConf, m.commonConf)
 	cliConf.proxyConf = proxyConf
 	cliConf.isChanged = false
+	cliConf.commonConfUpdate = m.confUpdate
 
 	return proxyConf
 }


### PR DESCRIPTION
This commit fixes a critical performance issue with custom encrypted DNS upstreams configured for persistent clients. The bug caused connections to be unnecessarily closed and rebuilt on every DNS request, making custom DoH/DoT/DoQ upstreams 4-5 times slower than global upstreams.

The root cause was that after rebuilding a client's upstream connection, the timestamp `commonConfUpdate` used for detecting configuration changes was never updated. This resulted in an endless cycle of detecting "changes" and rebuilding connections on every request, particularly impacting encryption protocols with expensive connection establishment.

This PR updates the client's configuration timestamp after rebuilding the connection in `upstreamManager.customUpstreamConfig()`.

Fixes: #7739, #7769

Disclaimer: I have yet to test this. I don't have the time right now but will do later. If anyone else want to give this a try, please do.

edit: I've actually tested it now and I have not encountered the issue since then.
