### PR TITLE
chore: Docker SemVer tags

### DIFF
--- a/scripts/make/build-docker.sh
+++ b/scripts/make/build-docker.sh
@@ -59,7 +59,14 @@ readonly docker_output
 
 case "$channel" in
 'release')
-	docker_version_tag="--tag=${docker_image_name}:${version}"
+	V_MAJOR=$(echo "${version}" | awk -F'[. +-]' -vOFS='.' '{ print $1 }')
+	V_MINOR=$(echo "${version}" | awk -F'[. +-]' -vOFS='.' '{ print $1, $2 }')
+	V_PATCH=$(echo "${version}" | awk -F'[. +-]' -vOFS='.' '{ print $1, $2, $3 }')
+	docker_version_tag="\
+		--tag=${docker_image_name}:${version} \
+		--tag=${docker_image_name}:${V_PATCH} \
+		--tag=${docker_image_name}:${V_MINOR} \
+		--tag=${docker_image_name}:${V_MAJOR}"
 	docker_channel_tag="--tag=${docker_image_name}:latest"
 	;;
 'beta')


### PR DESCRIPTION
This PR Closes #7226.

When releasing new Docker images, additional [SemVer tags](https://medium.com/@mccode/using-semantic-versioning-for-docker-image-tags-dfde8be06699) are created providing users with more freedom of pinning their AdGuardHome instance to e.g. a specific `minor` version, while still being able to automatically pull in `patch` releases.

![](https://miro.medium.com/v2/resize:fit:4800/format:webp/1*crt6mWe_B_I1WpQEAOndUQ@2x.jpeg)
