### PR TITLE
Make header sticky for better UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Changed
 
+- The mobile and tablet header now stays sticky while scrolling ([#7840]).
+
 - The `edge` channel has been switched to the new UI and versioning scheme.
 
 ### Deprecated
@@ -47,6 +49,7 @@ NOTE: Add new changes BELOW THIS COMMENT.
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
 [#7514]: https://github.com/AdguardTeam/AdGuardHome/issues/7514
+[#7840]: https://github.com/AdguardTeam/AdGuardHome/pull/7840
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/client/src/components/Header/Header.css
+++ b/client/src/components/Header/Header.css
@@ -33,7 +33,8 @@
 }
 
 .header {
-    position: relative;
+    position: sticky;
+    top: 0;
     padding: 5px 0;
     z-index: 102;
 }

--- a/client_v2/src/common/ui/Header/Header.module.pcss
+++ b/client_v2/src/common/ui/Header/Header.module.pcss
@@ -1,4 +1,6 @@
 .header {
+    position: sticky;
+    top: 0;
     z-index: 1049;
     background: var(--default-page-background);
     height: 64px;

--- a/client_v2/tests/e2e/header.spec.ts
+++ b/client_v2/tests/e2e/header.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect, type Page } from '@playwright/test';
+
+import { login } from '../helpers/login';
+
+const VIEWPORTS = [
+    { name: 'mobile', width: 390, height: 844 },
+    { name: 'tablet', width: 1024, height: 600 },
+] as const;
+
+async function ensureScrollablePage(page: Page) {
+    await page.evaluate(() => {
+        const existing = document.getElementById('e2e-header-scroll-spacer');
+        if (existing) {
+            return;
+        }
+
+        const spacer = document.createElement('div');
+        spacer.id = 'e2e-header-scroll-spacer';
+        spacer.style.height = '2000px';
+        document.body.appendChild(spacer);
+    });
+}
+
+async function expectHeaderStickyAtTop(page: Page) {
+    const header = page.locator('#header');
+
+    await expect(header).toBeVisible();
+
+    await ensureScrollablePage(page);
+    await page.evaluate(() => window.scrollTo(0, 800));
+
+    await expect
+        .poll(async () => {
+            const box = await header.boundingBox();
+            return box?.y ?? -1;
+        })
+        .toBe(0);
+}
+
+test.describe('Header sticky behavior', () => {
+    for (const viewport of VIEWPORTS) {
+        test(`stays at the top while scrolling on ${viewport.name}`, async ({ page }) => {
+            await page.setViewportSize({
+                width: viewport.width,
+                height: viewport.height,
+            });
+            await login(page);
+            await page.goto('/#');
+            await expectHeaderStickyAtTop(page);
+        });
+    }
+});


### PR DESCRIPTION
## Summary

Keeps the AdGuard Home mobile/tablet header visible while scrolling so navigation stays reachable without scrolling back to the top.

## Changes

- Add `position: sticky` / `top: 0` to the active `client_v2` header (`.header` in `Header.module.pcss`).
- Add Playwright coverage that scrolls the page at `390×844` and `1024×600` and asserts `#header` remains at `y = 0`.
- Document the UX change in `CHANGELOG.md`.

Desktop widths ≥ 1200px intentionally hide this header in favor of the sidebar, so those viewports are out of scope.

## Notes

This replaces the earlier legacy-only change under `client/…/Header.css`. Production UI now lives in `client_v2`.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (with Node localStorage bootstrap when needed)
- [x] `npm run build-dev`
- [x] `go build`
- [x] `npx playwright test tests/e2e/header.spec.ts --project=chromium`
- [x] Manual check on mobile/tablet: header stays pinned while scrolling