### PR TITLE
Link version number in footer to release page

### DIFF
--- a/client/src/components/ui/Version.tsx
+++ b/client/src/components/ui/Version.tsx
@@ -28,9 +28,15 @@ const Version = () => {
                 {version && (
                     <>
                         <Trans>version</Trans>:&nbsp;
-                        <span className="version__value" title={version}>
+                        <a
+                            className="version__value"
+                            title={version}
+                            href={`https://github.com/AdguardTeam/AdGuardHome/releases/tag/v${version}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
                             {version}
-                        </span>
+                        </a>
                     </>
                 )}
 


### PR DESCRIPTION
This PR updates the version number in the footer to link to the associated release page on GitHub. Fixes https://github.com/AdguardTeam/AdGuardHome/issues/7004.

Thanks for maintaining a great project. ✨ 