### PR TITLE
Automatic Filter Title Fetching

### DIFF
--- a/client/src/__locales/en.json
+++ b/client/src/__locales/en.json
@@ -198,6 +198,8 @@
     "add_allowlist": "Add allowlist",
     "cancel_btn": "Cancel",
     "enter_name_hint": "Enter name",
+    "name_auto_fetch_hint": "Name will be fetched automatically from URL",
+    "fetching_name_from_url": "Fetching name from URL...",
     "enter_url_or_path_hint": "Enter a URL or an absolute path of the list",
     "check_updates_btn": "Check for updates",
     "new_blocklist": "New blocklist",

--- a/client/src/actions/filtering.ts
+++ b/client/src/actions/filtering.ts
@@ -205,3 +205,28 @@ export const checkHost = (host: any) => async (dispatch: any) => {
         dispatch(checkHostFailure());
     }
 };
+
+export const fetchFilterTitleRequest = createAction('FETCH_FILTER_TITLE_REQUEST');
+export const fetchFilterTitleFailure = createAction('FETCH_FILTER_TITLE_FAILURE');
+export const fetchFilterTitleSuccess = createAction('FETCH_FILTER_TITLE_SUCCESS');
+
+/**
+ * Fetches the title from a filter URL without adding it to the list.
+ * @param {string} url - The URL to fetch the title from
+ * @returns {Promise<string>} - The title extracted from the filter
+ */
+export const fetchFilterTitle = (url: string) => async (dispatch: any) => {
+    dispatch(fetchFilterTitleRequest());
+    try {
+        const data = await apiClient.fetchFilterTitle(url);
+        dispatch(fetchFilterTitleSuccess(data));
+        return data.title || '';
+    } catch (error) {
+        // Silent failure for UX - fetching title is optional
+        dispatch(fetchFilterTitleFailure());
+        if (process.env.NODE_ENV === 'development') {
+            console.debug('Failed to fetch filter title:', error);
+        }
+        return '';
+    }
+};

--- a/client/src/api/Api.ts
+++ b/client/src/api/Api.ts
@@ -100,6 +100,8 @@ class Api {
 
     FILTERING_CHECK_HOST = { path: 'filtering/check_host', method: 'GET' };
 
+    FILTERING_FETCH_TITLE = { path: 'filtering/fetch_title', method: 'POST' };
+
     getFilteringStatus() {
         const { path, method } = this.FILTERING_STATUS;
 
@@ -162,6 +164,15 @@ class Api {
         const url = getPathWithQueryString(path, params);
 
         return this.makeRequest(url, method);
+    }
+
+    fetchFilterTitle(url: string) {
+        const { path, method } = this.FILTERING_FETCH_TITLE;
+        const parameters = {
+            data: { url },
+        };
+
+        return this.makeRequest(path, method, parameters);
     }
 
     // Parental


### PR DESCRIPTION
Closes #8101.

## Overview

This PR adds automatic filter name fetching when users add custom blocklists or allowlists. Instead of manually typing both URL and name, users can now paste the filter URL and have the name auto-populated from the filter's metadata.

## Implementation

**Backend:**

- New endpoint: `POST /control/filtering/fetch_title`
- Validates URLs with permissive rules (allows extension-less paths like `/hosts`)
- Extracts title from filter metadata using existing `rulelist.Parser`
- Downloads only first 4KB for performance

**Frontend:**

- Monitors URL field changes with 800ms debounce
- Shows loading state while fetching
- Auto-populates name field only when empty (never overwrites user input)
- Silent error handling (no intrusive messages)

**Testing:**

- ✅ 13 backend test cases covering validation and extraction
- ✅ All linters pass
- ✅ Manual testing completed

## Screenshots

![AdGuard Home - Google Chrome 2025-11-14 08-19-03](https://github.com/user-attachments/assets/0266ec78-7883-4cad-bfd7-8b9a43a978f3)

## Breaking Changes

None. This is a purely additive feature with graceful degradation.
