### PR TITLE
docs(readme): fix Home Assistant integration terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ See our [Wiki][wiki].
 
 ### <a href="#api" id="api" name="api">API</a>
 
-If you want to integrate with AdGuard Home, you can use our [REST API][openapi]. Alternatively, you can use this [python client][pyclient], which is used to build the [AdGuard Home Hass.io Add-on][hassio].
+If you want to integrate with AdGuard Home, you can use our [REST API][openapi]. Alternatively, you can use this [python client][pyclient], which is used to build the [Home Assistant AdGuard integration][ha-integration].
 
-[hassio]:   https://www.home-assistant.io/integrations/adguard/
+[ha-integration]: https://www.home-assistant.io/integrations/adguard/
 [openapi]:  https://github.com/AdguardTeam/AdGuardHome/tree/master/openapi
 [pyclient]: https://pypi.org/project/adguardhome/
 


### PR DESCRIPTION
## Summary

Fixes incorrect terminology in the README regarding the Home Assistant integration.

## Changes

- Changed `AdGuard Home Hass.io Add-on` to `Home Assistant AdGuard integration`
- Renamed reference label from `hassio` to `ha-integration` for clarity

## Context

The previous text incorrectly referred to the Home Assistant integration as "Hass.io Add-on", which is confusing since:

1. **Home Assistant integration** ([link](https://www.home-assistant.io/integrations/adguard/)) - This is the integration that uses the Python client mentioned in the README
2. **Home Assistant Add-on** ([link](https://github.com/hassio-addons/addon-adguard-home)) - This is a separate project that runs AdGuard Home as a Home Assistant add-on

The README was linking to the integration but calling it an "Add-on", which could confuse users.

Fixes #8137