### PR TITLE
Fix: allow nonroot startup with linux file caps by removing redundant pre-check

### DIFF
--- a/internal/home/home.go
+++ b/internal/home/home.go
@@ -1102,15 +1102,6 @@ https://github.com/AdguardTeam/AdGuardHome/wiki/Getting-Started#running-without-
 func checkNetworkPermissions(ctx context.Context, l *slog.Logger) {
 	l.InfoContext(ctx, "checking if adguard home has the necessary permissions")
 
-	if ok, err := aghnet.CanBindPrivilegedPorts(ctx, l); !ok || err != nil {
-		l.ErrorContext(
-			ctx,
-			"this is the first launch of adguard home; you must run it as administrator.",
-		)
-
-		os.Exit(osutil.ExitCodeFailure)
-	}
-
 	// We should check if AdGuard Home is able to bind to port 53
 	err := aghnet.CheckPort("tcp", netip.AddrPortFrom(netutil.IPv4Localhost(), defaultPortDNS))
 	if err != nil {


### PR DESCRIPTION
Closes #4714
Supersedes #4728

This issue has been open since 2022. The previous attempt to fix it stalled because of complexity involved in correctly detecting Linux capabilities via `prctl` (checking Ambient vs Bounding sets).

I propose a simpler, more robust approach: remove the predictive check entirely during startup.

* Users running with `setcap 'cap_net_bind_service=+ep'` currently get a fatal error, even though the OS allows binding. This change fixes it.
* The Linux networking stack is complex. Permission to bind can be granted via Capabilities, sysctl (`net.ipv4.ip_unprivileged_port_start`), or `authbind`. Conversely, it can be blocked by LSMs (SELinux/AppArmor), Landlock sandboxing, or eBPF policies, even if the process has root privileges. Predicting the outcome via `prctl` is impossible to do accurately. The only reliable check is the `bind()` syscall itself.
* The code immediately follows up with `aghnet.CheckPort`. This function attempts the actual bind and correctly handles `os.ErrPermission` by printing the relevant help message and exiting.
* The Windows implementation of this check already returns `true` unconditionally, relying on `CheckPort` for validation.
* I have purposefully left `internal/aghnet/net_linux.go` untouched. This ensures that `controlupdate.go` still sees `false` for file-based capabilities (which is correct, as updating the binary wipes file caps), preventing broken auto-updates.
