### PR TITLE
Update SSL Cert Expiration Warning

### DIFF
--- a/client/src/__locales/en.json
+++ b/client/src/__locales/en.json
@@ -431,7 +431,7 @@
     "encryption_plain_dns_enable": "Enable plain DNS",
     "encryption_plain_dns_desc": "Plain DNS is enabled by default. You can disable it to force all devices to use encrypted DNS. To do this, you must enable at least one encrypted DNS protocol",
     "encryption_plain_dns_error": "To disable plain DNS, enable at least one encrypted DNS protocol",
-    "topline_expiring_certificate": "Your SSL certificate is about to expire. Update <0>Encryption settings</0>.",
+    "topline_expiring_certificate": "Your SSL certificate is due for renewal. Update <0>Encryption settings</0>.",
     "topline_expired_certificate": "Your SSL certificate is expired. Update <0>Encryption settings</0>.",
     "form_error_port_range": "Enter port number in the range of 80-65535",
     "form_error_port_unsafe": "Unsafe port",

--- a/client/src/components/ui/EncryptionTopline.tsx
+++ b/client/src/components/ui/EncryptionTopline.tsx
@@ -33,8 +33,8 @@ const getExpirationFlags = (not_before: any, not_after: any) => {
 
     const certLifetimeHours = differenceInHours(not_after, not_before);
     const expiringThreshold = certLifetimeHours < SHORT_LIVED_HOURS ?
-     certLifetimeHours * (1 - SHORT_MIN_RATIO_VALIDITY_REMAINING) :
-     certLifetimeHours * (1 - REG_MIN_RATIO_VALIDITY_REMAINING);
+        certLifetimeHours * (1 - SHORT_MIN_RATIO_VALIDITY_REMAINING) :
+        certLifetimeHours * (1 - REG_MIN_RATIO_VALIDITY_REMAINING);
      
     const now = Date.now();
 

--- a/client/src/components/ui/EncryptionTopline.tsx
+++ b/client/src/components/ui/EncryptionTopline.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Trans } from 'react-i18next';
 import isAfter from 'date-fns/is_after';
-import addDays from 'date-fns/add_days';
+import addHours from 'date-fns/add_hours';
+import differenceInHours from 'date-fns/difference_in_hours';
 import { useSelector } from 'react-redux';
 
 import Topline from './Topline';
@@ -25,11 +26,19 @@ const EXPIRATION_STATE = {
     },
 };
 
-const getExpirationFlags = (not_after: any) => {
-    const DAYS_BEFORE_EXPIRATION = 5;
+const getExpirationFlags = (not_before: any, not_after: any) => {
+    const REG_MIN_RATIO_VALIDITY_REMAINING = 0.333;
+    const SHORT_MIN_RATIO_VALIDITY_REMAINING = 0.5;
+    const SHORT_LIVED_HOURS = 10 * 24;
 
+    const certLifetimeHours = differenceInHours(not_after, not_before);
+    const expiringThreshold = certLifetimeHours < SHORT_LIVED_HOURS ?
+     certLifetimeHours * (1 - SHORT_MIN_RATIO_VALIDITY_REMAINING) :
+     certLifetimeHours * (1 - REG_MIN_RATIO_VALIDITY_REMAINING);
+     
     const now = Date.now();
-    const isExpiring = isAfter(addDays(now, DAYS_BEFORE_EXPIRATION), not_after);
+
+    const isExpiring = isAfter(now, addHours(not_before, expiringThreshold));
     const isExpired = isAfter(now, not_after);
 
     return {
@@ -38,8 +47,8 @@ const getExpirationFlags = (not_after: any) => {
     };
 };
 
-const getExpirationEnumKey = (not_after: any) => {
-    const { isExpiring, isExpired } = getExpirationFlags(not_after);
+const getExpirationEnumKey = (not_before: any, not_after: any) => {
+    const { isExpiring, isExpired } = getExpirationFlags(not_before, not_after);
 
     if (isExpired) {
         return EXPIRATION_ENUM.EXPIRED;
@@ -53,13 +62,14 @@ const getExpirationEnumKey = (not_after: any) => {
 };
 
 const EncryptionTopline = () => {
+    const not_before = useSelector((state: RootState) => state.encryption.not_before);
     const not_after = useSelector((state: RootState) => state.encryption.not_after);
 
-    if (not_after === EMPTY_DATE) {
+    if (not_before === EMPTY_DATE || not_after === EMPTY_DATE) {
         return null;
     }
 
-    const expirationStateKey = getExpirationEnumKey(not_after);
+    const expirationStateKey = getExpirationEnumKey(not_before, not_after);
 
     if (expirationStateKey === EXPIRATION_ENUM.VALID) {
         return null;


### PR DESCRIPTION
Closes https://github.com/AdguardTeam/AdGuardHome/issues/8196

Over the coming years, the Browser CA Baseline Requirements require shorter and shorter certificate validity periods. see:  https://cabforum.org/working-groups/server/baseline-requirements/requirements/ s.6.3.2.

As such, expiration warnings should not be static in length. Instead they should adapt based on a certificate's overall validity. Let's Encrypt has published guidance on this issue: https://letsencrypt.org/docs/integration-guide/#when-to-renew

This PR changes the certificate expiration warning to a "due for renewal" warning and implements logic that applies Let's Encrypts guidance. i.e.,

For short lived certificates (< 10 days of validity) the warning is issued after 50% of the validity has lapsed.
For all other certificates (>= 10 days of validity) the warning is issued after 66.6% of the validity has lapsed.

TODO: Translations needed to be updated.