### PR TITLE
client: identify persistent clients via IPv6 NDP neighbor table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 - The user is able to remove the static lease's hostname via the HTTP API.
 
+- On Linux, persistent clients identified by MAC address are now also matched against the IPv6 neighbor table, so they are recognized when their requests come from addresses that have no DHCP lease, e.g. the ones configured via SLAAC ([#961]).
+
 ### Changed
 
 - The `edge` channel has been switched to the new UI and versioning scheme.
@@ -44,6 +46,7 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#961]:  https://github.com/AdguardTeam/AdGuardHome/issues/961
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--
@@ -277,8 +280,6 @@ See also the [v0.107.72 GitHub milestone][ms-v0.107.72].
 
 - New field `"ignored_enabled"` in `GetStatsConfigResponse` or `GetQueryLogConfigResponse`.  See `openapi/openapi.yaml` for details.
 
-- On Linux, persistent clients identified by MAC address are now also matched against the IPv6 neighbor table, so they are recognized when their requests come from addresses that have no DHCP lease, e.g. the ones configured via SLAAC ([#961]).
-
 ### Changed
 
 - In addition to modifying the contents of a hosts file, deleting or renaming the file now also updates runtime clients and DNS filtering results.
@@ -321,7 +322,6 @@ In this release, the schema version has changed from 32 to 33.
 
 - Unknown blocked services from both global and client configuration now logged instead of causing server crash.
 
-[#961]:  https://github.com/AdguardTeam/AdGuardHome/issues/961
 [#3962]: https://github.com/AdguardTeam/AdGuardHome/issues/3962
 [#8237]: https://github.com/AdguardTeam/AdGuardHome/issues/8237
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,6 +277,8 @@ See also the [v0.107.72 GitHub milestone][ms-v0.107.72].
 
 - New field `"ignored_enabled"` in `GetStatsConfigResponse` or `GetQueryLogConfigResponse`.  See `openapi/openapi.yaml` for details.
 
+- On Linux, persistent clients identified by MAC address are now also matched against the IPv6 neighbor table, so they are recognized when their requests come from addresses that have no DHCP lease, e.g. the ones configured via SLAAC ([#961]).
+
 ### Changed
 
 - In addition to modifying the contents of a hosts file, deleting or renaming the file now also updates runtime clients and DNS filtering results.
@@ -319,6 +321,7 @@ In this release, the schema version has changed from 32 to 33.
 
 - Unknown blocked services from both global and client configuration now logged instead of causing server crash.
 
+[#961]:  https://github.com/AdguardTeam/AdGuardHome/issues/961
 [#3962]: https://github.com/AdguardTeam/AdGuardHome/issues/3962
 [#8237]: https://github.com/AdguardTeam/AdGuardHome/issues/8237
 

--- a/internal/client/index.go
+++ b/internal/client/index.go
@@ -306,6 +306,11 @@ func (ci *index) findByMAC(mac net.HardwareAddr) (c *Persistent, found bool) {
 	return nil, false
 }
 
+// hasMACs returns true if at least one client is identified by a MAC address.
+func (ci *index) hasMACs() (ok bool) {
+	return len(ci.macToUID) > 0
+}
+
 // findByIPWithoutZone finds a persistent client by IP address without zone.  It
 // strips the IPv6 zone index from the stored IP addresses before comparing,
 // because querylog entries don't have it.  See TODO on [querylog.logEntry.IP].

--- a/internal/client/ndp.go
+++ b/internal/client/ndp.go
@@ -1,0 +1,297 @@
+package client
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/netip"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/AdguardTeam/golibs/errors"
+	"github.com/AdguardTeam/golibs/logutil/slogutil"
+	"github.com/AdguardTeam/golibs/osutil/executil"
+	"github.com/AdguardTeam/golibs/timeutil"
+)
+
+const (
+	// ndpDataTTL is the time after which the data read from the IPv6 neighbor
+	// table is considered outdated.  It's also the minimum interval between two
+	// reads of the table, which limits the number of the processes spawned on
+	// the DNS request path.
+	ndpDataTTL = 30 * time.Second
+
+	// ndpReadTimeout is the maximum time to spend reading the IPv6 neighbor
+	// table.
+	ndpReadTimeout = 5 * time.Second
+)
+
+// ndpNeighbors maps the IPv6 addresses of the network neighbors to their MAC
+// addresses, as reported by NDP (Neighbor Discovery Protocol).  It's used to
+// identify persistent clients by MAC address when their requests come from IPv6
+// addresses that have no DHCP lease, e.g. the ones configured via SLAAC.
+//
+// A nil *ndpNeighbors reports no neighbors, which is the case on the platforms
+// where reading the neighbor table isn't supported.
+type ndpNeighbors struct {
+	// logger is used for logging the operation of the reader.  It must not be
+	// nil.
+	logger *slog.Logger
+
+	// clock is used to check how long ago the neighbor table was read.  It must
+	// not be nil.
+	clock timeutil.Clock
+
+	// cmdCons is used to run the command that prints the neighbor table.  It
+	// must not be nil.
+	cmdCons executil.CommandConstructor
+
+	// mu protects all the fields below.
+	mu *sync.RWMutex
+
+	// neighbors maps the IPv6 addresses of the known neighbors to their MAC
+	// addresses.  Link-local addresses include their zone.
+	neighbors map[netip.Addr]net.HardwareAddr
+
+	// updated is the time of the last successful read of the neighbor table.
+	updated time.Time
+
+	// attempted is the time of the last read of the neighbor table, successful
+	// or not.
+	attempted time.Time
+
+	// isReading is true while the neighbor table is being read, so that only a
+	// single read runs at a time.
+	isReading bool
+}
+
+// newNDPNeighbors returns a new properly initialized *ndpNeighbors.  logger,
+// clock, and cmdCons must not be nil.  It returns nil if reading the IPv6
+// neighbor table isn't supported on the current platform.
+//
+// TODO(AndyHazz):  Support "ndp -an" on BSD and Darwin, and "netsh interface
+// ipv6 show neighbors" on Windows.
+func newNDPNeighbors(
+	logger *slog.Logger,
+	clock timeutil.Clock,
+	cmdCons executil.CommandConstructor,
+) (n *ndpNeighbors) {
+	if runtime.GOOS != "linux" {
+		return nil
+	}
+
+	return &ndpNeighbors{
+		logger:    logger,
+		clock:     clock,
+		cmdCons:   cmdCons,
+		mu:        &sync.RWMutex{},
+		neighbors: map[netip.Addr]net.HardwareAddr{},
+	}
+}
+
+// macFor returns the MAC address of the neighbor with the IPv6 address ip, if
+// it's known.  ip must contain the zone, if it's a link-local address.
+//
+// If ip is unknown or the data has become outdated, macFor schedules a read of
+// the neighbor table and returns the data that it currently has, if any.  It
+// doesn't wait for the read to finish, since it's called on the DNS request
+// path, where the callers may hold their locks.
+func (n *ndpNeighbors) macFor(ip netip.Addr) (mac net.HardwareAddr) {
+	if n == nil || !ip.Is6() || ip.Is4In6() {
+		return nil
+	}
+
+	n.mu.RLock()
+	mac = n.neighbors[ip]
+	isOutdated := n.clock.Now().Sub(n.updated) >= ndpDataTTL
+	n.mu.RUnlock()
+
+	if mac == nil || isOutdated {
+		n.scheduleRead()
+	}
+
+	return mac
+}
+
+// refresh reads the IPv6 neighbor table and replaces the known neighbors with
+// the data from it.  It does nothing if the table is already being read, and
+// keeps the previously known neighbors if the read fails.
+func (n *ndpNeighbors) refresh(ctx context.Context) {
+	if n == nil || !n.beginRead(true) {
+		return
+	}
+
+	defer n.endRead()
+
+	n.read(ctx)
+}
+
+// scheduleRead reads the IPv6 neighbor table in a separate goroutine, unless
+// it's being read right now or has been read within [ndpDataTTL].
+//
+// TODO(AndyHazz):  Pass the context once the client lookup methods accept it.
+func (n *ndpNeighbors) scheduleRead() {
+	if !n.beginRead(false) {
+		return
+	}
+
+	go func() {
+		ctx := context.TODO()
+
+		defer slogutil.RecoverAndLog(ctx, n.logger)
+		defer n.endRead()
+
+		n.read(ctx)
+	}()
+}
+
+// beginRead reports whether the caller should read the IPv6 neighbor table,
+// marking the read as started if it should.  Unless force is true, the read is
+// also skipped if the table has been read within [ndpDataTTL].  The caller must
+// call [ndpNeighbors.endRead] once the read is finished.
+func (n *ndpNeighbors) beginRead(force bool) (ok bool) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	now := n.clock.Now()
+	if n.isReading || (!force && now.Sub(n.attempted) < ndpDataTTL) {
+		return false
+	}
+
+	n.isReading = true
+	n.attempted = now
+
+	return true
+}
+
+// endRead marks the read of the IPv6 neighbor table as finished.
+func (n *ndpNeighbors) endRead() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	n.isReading = false
+}
+
+// read reads the IPv6 neighbor table and replaces the known neighbors with the
+// data from it.  On error, the previously known neighbors are kept, since they
+// are still more useful than nothing.
+func (n *ndpNeighbors) read(ctx context.Context) {
+	ctx, cancel := context.WithTimeout(ctx, ndpReadTimeout)
+	defer cancel()
+
+	data, err := n.readTable(ctx)
+	if err != nil {
+		n.logger.DebugContext(ctx, "reading ipv6 neighbors", slogutil.KeyError, err)
+
+		return
+	}
+
+	neighbors := parseNDPNeighbors(data)
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	n.neighbors = neighbors
+	n.updated = n.clock.Now()
+}
+
+// readTable returns the output of the command that prints the IPv6 neighbor
+// table.
+func (n *ndpNeighbors) readTable(ctx context.Context) (data []byte, err error) {
+	defer func() { err = errors.Annotate(err, "ip -6 neigh: %w") }()
+
+	var stdout bytes.Buffer
+	err = executil.Run(ctx, n.cmdCons, &executil.CommandConfig{
+		Path:   "ip",
+		Args:   []string{"-6", "neigh"},
+		Stdout: &stdout,
+	})
+	if err != nil {
+		if code, ok := executil.ExitCodeFromError(err); ok {
+			return nil, fmt.Errorf("unexpected exit code %d", code)
+		}
+
+		// Don't wrap the error, as it will get annotated.
+		return nil, err
+	}
+
+	return stdout.Bytes(), nil
+}
+
+// parseNDPNeighbors parses the output of the "ip -6 neigh" command.  The
+// expected input format:
+//
+//	2001:db8::1 dev eth0 lladdr aa:bb:cc:dd:ee:ff REACHABLE
+//	fe80::1 dev eth0 lladdr aa:bb:cc:dd:ee:ff router STALE
+//	2001:db8::2 dev eth0 FAILED
+func parseNDPNeighbors(data []byte) (ns map[netip.Addr]net.HardwareAddr) {
+	ns = map[netip.Addr]net.HardwareAddr{}
+	sc := bufio.NewScanner(bytes.NewReader(data))
+
+	for sc.Scan() {
+		ip, mac := parseNDPNeighbor(strings.Fields(sc.Text()))
+		if mac != nil {
+			ns[ip] = mac
+		}
+	}
+
+	return ns
+}
+
+// parseNDPNeighbor parses a single line of the "ip -6 neigh" output, split into
+// fields.  mac is nil if the line doesn't contain a valid pair of an IPv6
+// address and a link-layer address, which is the case for the incomplete
+// entries.
+//
+// Link-local addresses are only unique within their link, so they are returned
+// with the interface from the "dev" field as their zone, just like the addresses
+// of the incoming DNS requests.
+func parseNDPNeighbor(fields []string) (ip netip.Addr, mac net.HardwareAddr) {
+	// The address is followed by at least the "dev" and "lladdr" fields with
+	// their values.
+	if len(fields) < 5 {
+		return netip.Addr{}, nil
+	}
+
+	ip, err := netip.ParseAddr(fields[0])
+	if err != nil {
+		return netip.Addr{}, nil
+	}
+
+	dev, macStr := ndpNeighborFields(fields[1:])
+	if macStr == "" {
+		return netip.Addr{}, nil
+	}
+
+	mac, err = net.ParseMAC(macStr)
+	if err != nil {
+		return netip.Addr{}, nil
+	}
+
+	if dev != "" && ip.IsLinkLocalUnicast() {
+		ip = ip.WithZone(dev)
+	}
+
+	return ip, mac
+}
+
+// ndpNeighborFields returns the values of the "dev" and "lladdr" fields of a
+// single entry of the IPv6 neighbor table.  Those that aren't present are
+// returned empty.  fields must not be empty.
+func ndpNeighborFields(fields []string) (dev, mac string) {
+	for i, f := range fields[:len(fields)-1] {
+		switch f {
+		case "dev":
+			dev = fields[i+1]
+		case "lladdr":
+			mac = fields[i+1]
+		}
+	}
+
+	return dev, mac
+}

--- a/internal/client/ndp.go
+++ b/internal/client/ndp.go
@@ -20,11 +20,17 @@ import (
 )
 
 const (
-	// ndpDataTTL is the time after which the data read from the IPv6 neighbor
-	// table is considered outdated.  It's also the minimum interval between two
-	// reads of the table, which limits the number of the processes spawned on
-	// the DNS request path.
-	ndpDataTTL = 30 * time.Second
+	// ndpUpdateInterval is how often the IPv6 neighbor table is read.  It's also
+	// the minimum interval between two reads, successful or not, which limits
+	// the number of the processes spawned on behalf of the DNS requests.
+	ndpUpdateInterval = 30 * time.Second
+
+	// ndpDataTTL is how long the data read from the IPv6 neighbor table may be
+	// used to identify clients.  Data that no successful read has confirmed
+	// within this time isn't used at all: an address may have been reassigned to
+	// another device, and a wrong MAC address means the settings of a wrong
+	// client.
+	ndpDataTTL = 2 * ndpUpdateInterval
 
 	// ndpReadTimeout is the maximum time to spend reading the IPv6 neighbor
 	// table.
@@ -95,12 +101,12 @@ func newNDPNeighbors(
 }
 
 // macFor returns the MAC address of the neighbor with the IPv6 address ip, if
-// it's known.  ip must contain the zone, if it's a link-local address.
+// it's known and the data is still within [ndpDataTTL].  ip must contain the
+// zone, if it's a link-local address.
 //
-// If ip is unknown or the data has become outdated, macFor schedules a read of
-// the neighbor table and returns the data that it currently has, if any.  It
-// doesn't wait for the read to finish, since it's called on the DNS request
-// path, where the callers may hold their locks.
+// If ip is unknown or the data has expired, macFor schedules a read of the
+// neighbor table and returns nil.  It doesn't wait for the read to finish, since
+// it's called on the DNS request path, where the callers may hold their locks.
 func (n *ndpNeighbors) macFor(ip netip.Addr) (mac net.HardwareAddr) {
 	if n == nil || !ip.Is6() || ip.Is4In6() {
 		return nil
@@ -108,11 +114,13 @@ func (n *ndpNeighbors) macFor(ip netip.Addr) (mac net.HardwareAddr) {
 
 	n.mu.RLock()
 	mac = n.neighbors[ip]
-	isOutdated := n.clock.Now().Sub(n.updated) >= ndpDataTTL
+	isExpired := n.clock.Now().Sub(n.updated) >= ndpDataTTL
 	n.mu.RUnlock()
 
-	if mac == nil || isOutdated {
+	if mac == nil || isExpired {
 		n.scheduleRead()
+
+		return nil
 	}
 
 	return mac
@@ -132,7 +140,7 @@ func (n *ndpNeighbors) refresh(ctx context.Context) {
 }
 
 // scheduleRead reads the IPv6 neighbor table in a separate goroutine, unless
-// it's being read right now or has been read within [ndpDataTTL].
+// it's being read right now or has been read within [ndpUpdateInterval].
 //
 // TODO(AndyHazz):  Pass the context once the client lookup methods accept it.
 func (n *ndpNeighbors) scheduleRead() {
@@ -152,14 +160,14 @@ func (n *ndpNeighbors) scheduleRead() {
 
 // beginRead reports whether the caller should read the IPv6 neighbor table,
 // marking the read as started if it should.  Unless force is true, the read is
-// also skipped if the table has been read within [ndpDataTTL].  The caller must
-// call [ndpNeighbors.endRead] once the read is finished.
+// also skipped if the table has been read within [ndpUpdateInterval].  The
+// caller must call [ndpNeighbors.endRead] once the read is finished.
 func (n *ndpNeighbors) beginRead(force bool) (ok bool) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
 	now := n.clock.Now()
-	if n.isReading || (!force && now.Sub(n.attempted) < ndpDataTTL) {
+	if n.isReading || (!force && now.Sub(n.attempted) < ndpUpdateInterval) {
 		return false
 	}
 

--- a/internal/client/ndp_internal_test.go
+++ b/internal/client/ndp_internal_test.go
@@ -1,0 +1,80 @@
+package client
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseNDPNeigh(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		data string
+		want map[netip.Addr]net.HardwareAddr
+	}{{
+		name: "typical",
+		data: "fe80::1 dev eth0 lladdr aa:bb:cc:dd:ee:ff REACHABLE\n" +
+			"2001:db8::1 dev eth0 lladdr 11:22:33:44:55:66 STALE\n",
+		want: map[netip.Addr]net.HardwareAddr{
+			netip.MustParseAddr("fe80::1"):    {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF},
+			netip.MustParseAddr("2001:db8::1"): {0x11, 0x22, 0x33, 0x44, 0x55, 0x66},
+		},
+	}, {
+		name: "no_lladdr",
+		data: "fe80::1 dev eth0 FAILED\n",
+		want: map[netip.Addr]net.HardwareAddr{},
+	}, {
+		name: "short_line",
+		data: "fe80::1 dev eth0\n",
+		want: map[netip.Addr]net.HardwareAddr{},
+	}, {
+		name: "bad_ip",
+		data: "not-an-ip dev eth0 lladdr aa:bb:cc:dd:ee:ff REACHABLE\n",
+		want: map[netip.Addr]net.HardwareAddr{},
+	}, {
+		name: "bad_mac",
+		data: "fe80::1 dev eth0 lladdr not-a-mac REACHABLE\n",
+		want: map[netip.Addr]net.HardwareAddr{},
+	}, {
+		name: "router_flag",
+		data: "fe80::1 dev eth0 lladdr aa:bb:cc:dd:ee:ff router REACHABLE\n",
+		want: map[netip.Addr]net.HardwareAddr{
+			netip.MustParseAddr("fe80::1"): {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF},
+		},
+	}, {
+		name: "empty",
+		data: "",
+		want: map[netip.Addr]net.HardwareAddr{},
+	}, {
+		name: "mixed_valid_invalid",
+		data: "fe80::1 dev eth0 lladdr aa:bb:cc:dd:ee:ff REACHABLE\n" +
+			"bad line\n" +
+			"fe80::2 dev eth0 FAILED\n" +
+			"fe80::3 dev eth0 lladdr 11:22:33:44:55:66 DELAY\n",
+		want: map[netip.Addr]net.HardwareAddr{
+			netip.MustParseAddr("fe80::1"): {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF},
+			netip.MustParseAddr("fe80::3"): {0x11, 0x22, 0x33, 0x44, 0x55, 0x66},
+		},
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := parseNDPNeigh([]byte(tc.data))
+			require.Len(t, got, len(tc.want))
+
+			for addr, wantMAC := range tc.want {
+				gotMAC, ok := got[addr]
+				require.True(t, ok, "missing address %s", addr)
+
+				assert.Equal(t, wantMAC, gotMAC)
+			}
+		})
+	}
+}

--- a/internal/client/ndp_internal_test.go
+++ b/internal/client/ndp_internal_test.go
@@ -1,80 +1,352 @@
 package client
 
 import (
+	"context"
 	"net"
 	"net/netip"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/AdguardTeam/golibs/errors"
+	"github.com/AdguardTeam/golibs/logutil/slogutil"
+	"github.com/AdguardTeam/golibs/osutil/executil"
+	"github.com/AdguardTeam/golibs/testutil"
+	"github.com/AdguardTeam/golibs/testutil/fakeos/fakeexec"
+	"github.com/AdguardTeam/golibs/testutil/faketime"
+	"github.com/AdguardTeam/golibs/timeutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseNDPNeigh(t *testing.T) {
+// ndpTestTimeout is a timeout for tests of the IPv6 neighbor table reader.
+const ndpTestTimeout = 1 * time.Second
+
+// Neighbors used throughout the tests of the IPv6 neighbor table reader.
+var (
+	ndpTestIP     = netip.MustParseAddr("2001:db8::1")
+	ndpTestMAC    = errors.Must(net.ParseMAC("aa:bb:cc:dd:ee:ff"))
+	ndpTestOthMAC = errors.Must(net.ParseMAC("11:22:33:44:55:66"))
+)
+
+// ndpTestOutput is the output of the neighbor table command containing
+// [ndpTestIP] mapped to [ndpTestMAC].
+const ndpTestOutput = "2001:db8::1 dev eth0 lladdr aa:bb:cc:dd:ee:ff REACHABLE\n"
+
+func TestParseNDPNeighbors(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
+		want map[netip.Addr]net.HardwareAddr
 		name string
 		data string
-		want map[netip.Addr]net.HardwareAddr
 	}{{
-		name: "typical",
-		data: "fe80::1 dev eth0 lladdr aa:bb:cc:dd:ee:ff REACHABLE\n" +
-			"2001:db8::1 dev eth0 lladdr 11:22:33:44:55:66 STALE\n",
 		want: map[netip.Addr]net.HardwareAddr{
-			netip.MustParseAddr("fe80::1"):    {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF},
-			netip.MustParseAddr("2001:db8::1"): {0x11, 0x22, 0x33, 0x44, 0x55, 0x66},
+			ndpTestIP:                          ndpTestMAC,
+			netip.MustParseAddr("2001:db8::2"): ndpTestOthMAC,
 		},
+		name: "global",
+		data: ndpTestOutput +
+			"2001:db8::2 dev eth0 lladdr 11:22:33:44:55:66 STALE\n",
 	}, {
+		want: map[netip.Addr]net.HardwareAddr{
+			netip.MustParseAddr("fe80::1").WithZone("eth0"): ndpTestMAC,
+			netip.MustParseAddr("fe80::1").WithZone("eth1"): ndpTestOthMAC,
+		},
+		name: "link_local_zones",
+		data: "fe80::1 dev eth0 lladdr aa:bb:cc:dd:ee:ff router REACHABLE\n" +
+			"fe80::1 dev eth1 lladdr 11:22:33:44:55:66 REACHABLE\n",
+	}, {
+		want: map[netip.Addr]net.HardwareAddr{},
 		name: "no_lladdr",
-		data: "fe80::1 dev eth0 FAILED\n",
-		want: map[netip.Addr]net.HardwareAddr{},
+		data: "2001:db8::1 dev eth0 FAILED\n",
 	}, {
+		want: map[netip.Addr]net.HardwareAddr{},
 		name: "short_line",
-		data: "fe80::1 dev eth0\n",
-		want: map[netip.Addr]net.HardwareAddr{},
+		data: "2001:db8::1 dev eth0\n",
 	}, {
+		want: map[netip.Addr]net.HardwareAddr{},
 		name: "bad_ip",
 		data: "not-an-ip dev eth0 lladdr aa:bb:cc:dd:ee:ff REACHABLE\n",
-		want: map[netip.Addr]net.HardwareAddr{},
 	}, {
+		want: map[netip.Addr]net.HardwareAddr{},
 		name: "bad_mac",
-		data: "fe80::1 dev eth0 lladdr not-a-mac REACHABLE\n",
+		data: "2001:db8::1 dev eth0 lladdr not-a-mac REACHABLE\n",
+	}, {
 		want: map[netip.Addr]net.HardwareAddr{},
-	}, {
-		name: "router_flag",
-		data: "fe80::1 dev eth0 lladdr aa:bb:cc:dd:ee:ff router REACHABLE\n",
-		want: map[netip.Addr]net.HardwareAddr{
-			netip.MustParseAddr("fe80::1"): {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF},
-		},
-	}, {
 		name: "empty",
 		data: "",
-		want: map[netip.Addr]net.HardwareAddr{},
 	}, {
-		name: "mixed_valid_invalid",
-		data: "fe80::1 dev eth0 lladdr aa:bb:cc:dd:ee:ff REACHABLE\n" +
-			"bad line\n" +
-			"fe80::2 dev eth0 FAILED\n" +
-			"fe80::3 dev eth0 lladdr 11:22:33:44:55:66 DELAY\n",
 		want: map[netip.Addr]net.HardwareAddr{
-			netip.MustParseAddr("fe80::1"): {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF},
-			netip.MustParseAddr("fe80::3"): {0x11, 0x22, 0x33, 0x44, 0x55, 0x66},
+			ndpTestIP: ndpTestMAC,
 		},
+		name: "mixed",
+		data: "bad line\n" +
+			"2001:db8::2 dev eth0 INCOMPLETE\n" +
+			ndpTestOutput,
 	}}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := parseNDPNeigh([]byte(tc.data))
-			require.Len(t, got, len(tc.want))
-
-			for addr, wantMAC := range tc.want {
-				gotMAC, ok := got[addr]
-				require.True(t, ok, "missing address %s", addr)
-
-				assert.Equal(t, wantMAC, gotMAC)
-			}
+			assert.Equal(t, tc.want, parseNDPNeighbors([]byte(tc.data)))
 		})
+	}
+}
+
+func TestNDPNeighbors_refresh(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		n, cmd, _ := newTestNDPNeighbors(t, func(_ int64) (out string, err error) {
+			return ndpTestOutput, nil
+		})
+
+		n.refresh(testutil.ContextWithTimeout(t, ndpTestTimeout))
+
+		assert.Equal(t, int64(1), cmd.runs.Load())
+		assert.Equal(t, ndpTestMAC, n.macFor(ndpTestIP))
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		n, cmd, _ := newTestNDPNeighbors(t, func(_ int64) (out string, err error) {
+			return "", errors.Error("no such command")
+		})
+
+		n.refresh(testutil.ContextWithTimeout(t, ndpTestTimeout))
+
+		assert.Equal(t, int64(1), cmd.runs.Load())
+		assert.Nil(t, n.macFor(ndpTestIP))
+	})
+}
+
+func TestNDPNeighbors_macFor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("link_local_zone", func(t *testing.T) {
+		t.Parallel()
+
+		n, _, _ := newTestNDPNeighbors(t, func(_ int64) (out string, err error) {
+			return "fe80::1 dev eth0 lladdr aa:bb:cc:dd:ee:ff REACHABLE\n", nil
+		})
+
+		n.refresh(testutil.ContextWithTimeout(t, ndpTestTimeout))
+
+		linkLocal := netip.MustParseAddr("fe80::1")
+		assert.Equal(t, ndpTestMAC, n.macFor(linkLocal.WithZone("eth0")))
+
+		// The same address on another link must not match.
+		assert.Nil(t, n.macFor(linkLocal.WithZone("eth1")))
+	})
+
+	t.Run("ipv4_ignored", func(t *testing.T) {
+		t.Parallel()
+
+		n, cmd, _ := newTestNDPNeighbors(t, func(_ int64) (out string, err error) {
+			return ndpTestOutput, nil
+		})
+
+		assert.Nil(t, n.macFor(netip.MustParseAddr("192.0.2.1")))
+		assert.Nil(t, n.macFor(netip.MustParseAddr("::ffff:192.0.2.1")))
+
+		assert.Equal(t, int64(0), cmd.runs.Load())
+	})
+
+	// Make sure that a command that keeps failing is not run on each request,
+	// see https://github.com/AdguardTeam/AdGuardHome/pull/8248.
+	t.Run("failure_is_rate_limited", func(t *testing.T) {
+		t.Parallel()
+
+		n, cmd, advance := newTestNDPNeighbors(t, func(_ int64) (out string, err error) {
+			return "", errors.Error("no such command")
+		})
+
+		assert.Nil(t, n.macFor(ndpTestIP))
+		waitNDPRead(t, n, cmd, 1)
+
+		// Further requests within the TTL must not read the table again, even
+		// though the previous read has failed.
+		for range 3 {
+			assert.Nil(t, n.macFor(ndpTestIP))
+		}
+
+		assert.Equal(t, int64(1), cmd.runs.Load())
+
+		advance(ndpDataTTL)
+
+		assert.Nil(t, n.macFor(ndpTestIP))
+		waitNDPRead(t, n, cmd, 2)
+	})
+
+	t.Run("keeps_data_on_failure", func(t *testing.T) {
+		t.Parallel()
+
+		n, cmd, advance := newTestNDPNeighbors(t, func(num int64) (out string, err error) {
+			if num == 1 {
+				return ndpTestOutput, nil
+			}
+
+			return "", errors.Error("no such command")
+		})
+
+		n.refresh(testutil.ContextWithTimeout(t, ndpTestTimeout))
+		require.Equal(t, ndpTestMAC, n.macFor(ndpTestIP))
+
+		advance(ndpDataTTL)
+
+		// The failed read must not discard the previously known neighbors.
+		assert.Equal(t, ndpTestMAC, n.macFor(ndpTestIP))
+		waitNDPRead(t, n, cmd, 2)
+
+		assert.Equal(t, ndpTestMAC, n.macFor(ndpTestIP))
+	})
+
+	t.Run("outdated_data_is_replaced", func(t *testing.T) {
+		t.Parallel()
+
+		n, cmd, advance := newTestNDPNeighbors(t, func(num int64) (out string, err error) {
+			if num == 1 {
+				return ndpTestOutput, nil
+			}
+
+			return "2001:db8::1 dev eth0 lladdr 11:22:33:44:55:66 REACHABLE\n", nil
+		})
+
+		n.refresh(testutil.ContextWithTimeout(t, ndpTestTimeout))
+		require.Equal(t, ndpTestMAC, n.macFor(ndpTestIP))
+
+		advance(ndpDataTTL)
+
+		// The request that finds the data outdated still gets the previously
+		// known MAC address, but it also schedules a read, so the requests that
+		// follow get the current one.
+		assert.Equal(t, ndpTestMAC, n.macFor(ndpTestIP))
+		waitNDPRead(t, n, cmd, 2)
+
+		assert.Equal(t, ndpTestOthMAC, n.macFor(ndpTestIP))
+	})
+
+	t.Run("single_read_in_flight", func(t *testing.T) {
+		t.Parallel()
+
+		started, release := make(chan struct{}, 1), make(chan struct{})
+		n, cmd, _ := newTestNDPNeighbors(t, func(_ int64) (out string, err error) {
+			started <- struct{}{}
+			<-release
+
+			return ndpTestOutput, nil
+		})
+
+		assert.Nil(t, n.macFor(ndpTestIP))
+		testutil.RequireReceive(t, started, ndpTestTimeout)
+
+		// The requests arriving while the table is being read must neither wait
+		// for it nor start another read.
+		for range 5 {
+			assert.Nil(t, n.macFor(ndpTestIP))
+		}
+
+		assert.Equal(t, int64(1), cmd.runs.Load())
+
+		close(release)
+		waitNDPRead(t, n, cmd, 1)
+
+		assert.Equal(t, ndpTestMAC, n.macFor(ndpTestIP))
+	})
+}
+
+// waitNDPRead waits until cmd has been run wantRuns times and n has finished
+// reading the neighbor table.
+func waitNDPRead(tb testing.TB, n *ndpNeighbors, cmd *testNDPCmd, wantRuns int64) {
+	tb.Helper()
+
+	require.EventuallyWithT(tb, func(ct *assert.CollectT) {
+		n.mu.RLock()
+		defer n.mu.RUnlock()
+
+		assert.Equal(ct, wantRuns, cmd.runs.Load())
+		assert.False(ct, n.isReading)
+	}, ndpTestTimeout, ndpTestTimeout/100)
+}
+
+// newTestNDPNeighbors returns a neighbor table reader that runs onRun instead of
+// the actual command, along with the fake command and a function advancing the
+// clock of the reader.  onRun receives the number of the run, starting with one.
+func newTestNDPNeighbors(
+	tb testing.TB,
+	onRun func(num int64) (out string, err error),
+) (n *ndpNeighbors, cmd *testNDPCmd, advance func(d time.Duration)) {
+	tb.Helper()
+
+	cmd = &testNDPCmd{onRun: onRun}
+	clock, advance := newTestClock()
+
+	return &ndpNeighbors{
+		logger:    slogutil.NewDiscardLogger(),
+		clock:     clock,
+		cmdCons:   cmd.constructor(),
+		mu:        &sync.RWMutex{},
+		neighbors: map[netip.Addr]net.HardwareAddr{},
+	}, cmd, advance
+}
+
+// newTestClock returns a clock reporting the time that advance moves forward.
+// Both the clock and advance are safe for concurrent use.
+func newTestClock() (clock timeutil.Clock, advance func(d time.Duration)) {
+	mu := &sync.Mutex{}
+	now := time.Unix(0, 0)
+
+	return &faketime.Clock{
+			OnNow: func() (t time.Time) {
+				mu.Lock()
+				defer mu.Unlock()
+
+				return now
+			},
+		}, func(d time.Duration) {
+			mu.Lock()
+			defer mu.Unlock()
+
+			now = now.Add(d)
+		}
+}
+
+// testNDPCmd is a fake command printing the IPv6 neighbor table.
+type testNDPCmd struct {
+	// onRun returns the output and the error of a single run of the command.
+	onRun func(num int64) (out string, err error)
+
+	// runs is the number of times the command has been run.
+	runs atomic.Int64
+}
+
+// constructor returns a command constructor that runs c.
+func (c *testNDPCmd) constructor() (cons executil.CommandConstructor) {
+	return &fakeexec.CommandConstructor{
+		OnNew: func(
+			_ context.Context,
+			conf *executil.CommandConfig,
+		) (execCmd executil.Command, err error) {
+			out, runErr := c.onRun(c.runs.Add(1))
+
+			execCmd = &fakeexec.Command{
+				OnStart: func(_ context.Context) (startErr error) {
+					_, startErr = conf.Stdout.Write([]byte(out))
+
+					return startErr
+				},
+				OnWait: func(_ context.Context) (waitErr error) {
+					return runErr
+				},
+			}
+
+			return execCmd, nil
+		},
 	}
 }

--- a/internal/client/ndp_internal_test.go
+++ b/internal/client/ndp_internal_test.go
@@ -25,9 +25,10 @@ const ndpTestTimeout = 1 * time.Second
 
 // Neighbors used throughout the tests of the IPv6 neighbor table reader.
 var (
-	ndpTestIP     = netip.MustParseAddr("2001:db8::1")
-	ndpTestMAC    = errors.Must(net.ParseMAC("aa:bb:cc:dd:ee:ff"))
-	ndpTestOthMAC = errors.Must(net.ParseMAC("11:22:33:44:55:66"))
+	ndpTestIP        = netip.MustParseAddr("2001:db8::1")
+	ndpTestUnknownIP = netip.MustParseAddr("2001:db8::dead")
+	ndpTestMAC       = errors.Must(net.ParseMAC("aa:bb:cc:dd:ee:ff"))
+	ndpTestOthMAC    = errors.Must(net.ParseMAC("11:22:33:44:55:66"))
 )
 
 // ndpTestOutput is the output of the neighbor table command containing
@@ -178,13 +179,13 @@ func TestNDPNeighbors_macFor(t *testing.T) {
 
 		assert.Equal(t, int64(1), cmd.runs.Load())
 
-		advance(ndpDataTTL)
+		advance(ndpUpdateInterval)
 
 		assert.Nil(t, n.macFor(ndpTestIP))
 		waitNDPRead(t, n, cmd, 2)
 	})
 
-	t.Run("keeps_data_on_failure", func(t *testing.T) {
+	t.Run("failed_read_keeps_data", func(t *testing.T) {
 		t.Parallel()
 
 		n, cmd, advance := newTestNDPNeighbors(t, func(num int64) (out string, err error) {
@@ -198,16 +199,23 @@ func TestNDPNeighbors_macFor(t *testing.T) {
 		n.refresh(testutil.ContextWithTimeout(t, ndpTestTimeout))
 		require.Equal(t, ndpTestMAC, n.macFor(ndpTestIP))
 
-		advance(ndpDataTTL)
+		advance(ndpUpdateInterval)
 
-		// The failed read must not discard the previously known neighbors.
-		assert.Equal(t, ndpTestMAC, n.macFor(ndpTestIP))
+		// A request for an unknown address schedules a read, which fails.  It
+		// must not discard the data that is still within the TTL.
+		assert.Nil(t, n.macFor(ndpTestUnknownIP))
 		waitNDPRead(t, n, cmd, 2)
 
 		assert.Equal(t, ndpTestMAC, n.macFor(ndpTestIP))
+
+		// Once no successful read has confirmed the data within the TTL, it
+		// isn't used at all.
+		advance(ndpDataTTL)
+
+		assert.Nil(t, n.macFor(ndpTestIP))
 	})
 
-	t.Run("outdated_data_is_replaced", func(t *testing.T) {
+	t.Run("expired_data_is_replaced", func(t *testing.T) {
 		t.Parallel()
 
 		n, cmd, advance := newTestNDPNeighbors(t, func(num int64) (out string, err error) {
@@ -223,10 +231,11 @@ func TestNDPNeighbors_macFor(t *testing.T) {
 
 		advance(ndpDataTTL)
 
-		// The request that finds the data outdated still gets the previously
-		// known MAC address, but it also schedules a read, so the requests that
-		// follow get the current one.
-		assert.Equal(t, ndpTestMAC, n.macFor(ndpTestIP))
+		// The expired MAC address must not be returned, since the address may
+		// have been reassigned to another device.  The request that finds it
+		// expired schedules a read, so the requests that follow get the current
+		// one.
+		assert.Nil(t, n.macFor(ndpTestIP))
 		waitNDPRead(t, n, cmd, 2)
 
 		assert.Equal(t, ndpTestOthMAC, n.macFor(ndpTestIP))

--- a/internal/client/storage.go
+++ b/internal/client/storage.go
@@ -1,16 +1,12 @@
 package client
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
 	"net"
 	"net/netip"
-	"os/exec"
 	"slices"
-	"strings"
 	"sync"
 	"time"
 
@@ -23,6 +19,7 @@ import (
 	"github.com/AdguardTeam/golibs/hostsfile"
 	"github.com/AdguardTeam/golibs/logutil/slogutil"
 	"github.com/AdguardTeam/golibs/netutil"
+	"github.com/AdguardTeam/golibs/osutil/executil"
 	"github.com/AdguardTeam/golibs/timeutil"
 )
 
@@ -114,13 +111,13 @@ type StorageConfig struct {
 	// ARPDB is used to update [SourceARP] runtime client information.
 	ARPDB arpdb.Interface
 
+	// CmdCons is used to run the command that prints the IPv6 neighbor table.
+	// If nil, [executil.SystemCommandConstructor] is used.
+	CmdCons executil.CommandConstructor
+
 	// InitialClients is a list of persistent clients parsed from the
 	// configuration file.  Each client must not be nil.
 	InitialClients []*Persistent
-
-	// NDPData returns the raw output of the IPv6 neighbor table.  If nil,
-	// defaults to running "ip -6 neigh".
-	NDPData func() ([]byte, error)
 
 	// ARPClientsUpdatePeriod defines how often [SourceARP] runtime client
 	// information is updated.
@@ -158,14 +155,10 @@ type Storage struct {
 	// arpDB is used to update [SourceARP] runtime client information.
 	arpDB arpdb.Interface
 
-	// ndpData returns the raw output of the IPv6 neighbor table.
-	ndpData func() ([]byte, error)
-
-	// ndpCache maps IPv6 addresses to MAC addresses from the kernel NDP
-	// neighbor table.  Used to identify persistent clients querying over IPv6.
-	ndpCache   map[netip.Addr]net.HardwareAddr
-	ndpCacheMu sync.RWMutex
-	ndpCacheAt time.Time
+	// ndp is used to match the IPv6 addresses of the neighbors against the MACs
+	// of persistent clients.  It may be nil, in which case no neighbors are
+	// reported.
+	ndp *ndpNeighbors
 
 	// done is the shutdown signaling channel.
 	done chan struct{}
@@ -190,9 +183,9 @@ func NewStorage(ctx context.Context, conf *StorageConfig) (s *Storage, err error
 	tags := slices.Clone(allowedTags)
 	slices.Sort(tags)
 
-	ndpData := conf.NDPData
-	if ndpData == nil {
-		ndpData = defaultNDPData
+	cmdCons := conf.CmdCons
+	if cmdCons == nil {
+		cmdCons = executil.SystemCommandConstructor{}
 	}
 
 	s = &Storage{
@@ -204,8 +197,7 @@ func NewStorage(ctx context.Context, conf *StorageConfig) (s *Storage, err error
 		dhcp:                   conf.DHCP,
 		etcHosts:               conf.EtcHosts,
 		arpDB:                  conf.ARPDB,
-		ndpData:                ndpData,
-		ndpCache:               make(map[netip.Addr]net.HardwareAddr),
+		ndp:                    newNDPNeighbors(conf.Logger, conf.Clock, cmdCons),
 		done:                   make(chan struct{}),
 		allowedTags:            tags,
 		arpClientsUpdatePeriod: conf.ARPClientsUpdatePeriod,
@@ -260,96 +252,25 @@ func (s *Storage) periodicARPUpdate(ctx context.Context) {
 	}
 }
 
-// ReloadARP reloads runtime clients from ARP, if configured.
+// ReloadARP reloads runtime clients from ARP, if configured, as well as the
+// IPv6 neighbor table, if there is anything to match against it.
 func (s *Storage) ReloadARP(ctx context.Context) {
 	if s.arpDB != nil {
 		s.addFromSystemARP(ctx)
 	}
 
-	s.refreshNDP()
+	if s.hasMACs() {
+		s.ndp.refresh(ctx)
+	}
 }
 
-// defaultNDPData returns the output of "ip -6 neigh".
-func defaultNDPData() ([]byte, error) {
-	return exec.Command("ip", "-6", "neigh").Output()
-}
+// hasMACs returns true if at least one persistent client is identified by a MAC
+// address.
+func (s *Storage) hasMACs() (ok bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-// refreshNDP reads the IPv6 neighbor table and caches the IPv6 address to MAC
-// address mappings.
-func (s *Storage) refreshNDP() {
-	out, err := s.ndpData()
-	if err != nil {
-		return
-	}
-
-	cache := parseNDPNeigh(out)
-
-	s.ndpCacheMu.Lock()
-	s.ndpCache = cache
-	s.ndpCacheAt = time.Now()
-	s.ndpCacheMu.Unlock()
-}
-
-// parseNDPNeigh parses the output of "ip -6 neigh" and returns a map of IPv6
-// addresses to MAC addresses.  The expected input format:
-//
-//	fe80::1 dev eth0 lladdr aa:bb:cc:dd:ee:ff REACHABLE
-func parseNDPNeigh(data []byte) (cache map[netip.Addr]net.HardwareAddr) {
-	cache = make(map[netip.Addr]net.HardwareAddr)
-	sc := bufio.NewScanner(bytes.NewReader(data))
-
-	for sc.Scan() {
-		fields := strings.Fields(sc.Text())
-		if len(fields) < 5 {
-			continue
-		}
-
-		ip, parseErr := netip.ParseAddr(fields[0])
-		if parseErr != nil {
-			continue
-		}
-
-		for i, f := range fields {
-			if f == "lladdr" && i+1 < len(fields) {
-				mac, macErr := net.ParseMAC(fields[i+1])
-				if macErr == nil {
-					cache[ip] = mac
-				}
-
-				break
-			}
-		}
-	}
-
-	return cache
-}
-
-// macFromNDP returns the MAC address for the given IPv6 address from the NDP
-// neighbor cache.  If the cache is stale (>30s) and the address is not found,
-// it refreshes the cache and retries once.
-func (s *Storage) macFromNDP(ip netip.Addr) net.HardwareAddr {
-	if !ip.Is6() {
-		return nil
-	}
-
-	s.ndpCacheMu.RLock()
-	mac := s.ndpCache[ip]
-	stale := time.Since(s.ndpCacheAt) > 30*time.Second
-	s.ndpCacheMu.RUnlock()
-
-	if mac != nil {
-		return mac
-	}
-
-	if stale {
-		s.refreshNDP()
-
-		s.ndpCacheMu.RLock()
-		mac = s.ndpCache[ip]
-		s.ndpCacheMu.RUnlock()
-	}
-
-	return mac
+	return s.index.hasMACs()
 }
 
 // addFromSystemARP adds the IP-hostname pairings from the output of the arp -a
@@ -677,10 +598,10 @@ func (s *Storage) findByIP(addr netip.Addr) (p *Persistent, ok bool) {
 	}
 
 	foundMAC := s.dhcp.MACByIP(addr)
-	if foundMAC == nil {
-		// Fall back to the NDP neighbor table for IPv6 addresses that
-		// don't have a corresponding DHCPv4 lease.
-		foundMAC = s.macFromNDP(addr)
+	if foundMAC == nil && s.index.hasMACs() {
+		// Fall back to the IPv6 neighbor table, since the addresses configured
+		// via SLAAC have no DHCP lease.
+		foundMAC = s.ndp.macFor(addr)
 	}
 
 	if foundMAC != nil {
@@ -709,8 +630,8 @@ func (s *Storage) FindLoose(ip netip.Addr, id string) (p *Persistent, ok bool) {
 	}
 
 	foundMAC := s.dhcp.MACByIP(ip)
-	if foundMAC == nil {
-		foundMAC = s.macFromNDP(ip)
+	if foundMAC == nil && s.index.hasMACs() {
+		foundMAC = s.ndp.macFor(ip)
 	}
 
 	if foundMAC != nil {
@@ -894,8 +815,8 @@ func (s *Storage) ApplyClientFiltering(id string, addr netip.Addr, setts *filter
 
 	if !ok {
 		foundMAC := s.dhcp.MACByIP(addr)
-		if foundMAC == nil {
-			foundMAC = s.macFromNDP(addr)
+		if foundMAC == nil && s.index.hasMACs() {
+			foundMAC = s.ndp.macFor(addr)
 		}
 
 		if foundMAC != nil {

--- a/internal/client/storage.go
+++ b/internal/client/storage.go
@@ -212,6 +212,7 @@ func NewStorage(ctx context.Context, conf *StorageConfig) (s *Storage, err error
 	}
 
 	s.ReloadARP(ctx)
+	s.reloadNDP(ctx)
 
 	return s, nil
 }
@@ -221,6 +222,7 @@ func NewStorage(ctx context.Context, conf *StorageConfig) (s *Storage, err error
 // TODO(s.chzhen):  Pass context.
 func (s *Storage) Start(ctx context.Context) (err error) {
 	go s.periodicARPUpdate(ctx)
+	go s.periodicNDPUpdate(ctx)
 	go s.handleHostsUpdates(ctx)
 
 	return nil
@@ -252,13 +254,35 @@ func (s *Storage) periodicARPUpdate(ctx context.Context) {
 	}
 }
 
-// ReloadARP reloads runtime clients from ARP, if configured, as well as the
-// IPv6 neighbor table, if there is anything to match against it.
+// ReloadARP reloads runtime clients from ARP, if configured.
 func (s *Storage) ReloadARP(ctx context.Context) {
 	if s.arpDB != nil {
 		s.addFromSystemARP(ctx)
 	}
+}
 
+// periodicNDPUpdate periodically rereads the IPv6 neighbor table, so that the
+// clients identified by MAC address keep being recognized without reading it on
+// the DNS request path.  It is intended to be used as a goroutine.
+func (s *Storage) periodicNDPUpdate(ctx context.Context) {
+	defer slogutil.RecoverAndLog(ctx, s.logger)
+
+	t := time.NewTicker(ndpUpdateInterval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-t.C:
+			s.reloadNDP(ctx)
+		case <-s.done:
+			return
+		}
+	}
+}
+
+// reloadNDP rereads the IPv6 neighbor table, unless there is nothing to match
+// against it.
+func (s *Storage) reloadNDP(ctx context.Context) {
 	if s.hasMACs() {
 		s.ndp.refresh(ctx)
 	}

--- a/internal/client/storage_test.go
+++ b/internal/client/storage_test.go
@@ -10,15 +10,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AdguardTeam/AdGuardHome/internal/agh"
 	"github.com/AdguardTeam/AdGuardHome/internal/arpdb"
 	"github.com/AdguardTeam/AdGuardHome/internal/client"
 	"github.com/AdguardTeam/AdGuardHome/internal/dhcpd"
 	"github.com/AdguardTeam/AdGuardHome/internal/dhcpsvc"
 	"github.com/AdguardTeam/AdGuardHome/internal/dnsforward"
+	"github.com/AdguardTeam/AdGuardHome/internal/filtering"
 	"github.com/AdguardTeam/AdGuardHome/internal/whois"
 	"github.com/AdguardTeam/golibs/errors"
 	"github.com/AdguardTeam/golibs/hostsfile"
 	"github.com/AdguardTeam/golibs/logutil/slogutil"
+	"github.com/AdguardTeam/golibs/osutil/executil"
 	"github.com/AdguardTeam/golibs/service"
 	"github.com/AdguardTeam/golibs/testutil"
 	"github.com/AdguardTeam/golibs/testutil/faketime"
@@ -1018,25 +1021,30 @@ func TestStorage_FindLoose(t *testing.T) {
 }
 
 func TestStorage_NDP(t *testing.T) {
-	const prsCliName = "ndp-client"
+	if runtime.GOOS != "linux" {
+		t.Skip("skipping ipv6 neighbor table test on " + runtime.GOOS)
+	}
 
-	var (
-		// IPv6 address that is NOT in the DHCP lease table.
-		cliIPv6 = netip.MustParseAddr("2001:db8::1")
+	const (
+		prsCliName = "ndp-client"
 
-		// MAC that the NDP table maps the IPv6 address to.
-		cliMAC = errors.Must(net.ParseMAC("AA:BB:CC:DD:EE:FF"))
-
-		// An IPv4 address that is not known via any mechanism.
-		unknownIPv4 = netip.MustParseAddr("10.0.0.99")
-
-		// An IPv6 address that is not in the NDP table.
-		unknownIPv6 = netip.MustParseAddr("2001:db8::dead")
+		// ndpOutput maps cliIPv6 to cliMAC.
+		ndpOutput = "2001:db8::1 dev eth0 lladdr aa:bb:cc:dd:ee:ff REACHABLE\n"
 	)
 
-	ndpOutput := []byte(
-		"2001:db8::1 dev eth0 lladdr aa:bb:cc:dd:ee:ff REACHABLE\n" +
-			"fe80::1 dev eth0 lladdr 11:22:33:44:55:66 STALE\n",
+	var (
+		// cliIPv6 is an IPv6 address that has no DHCP lease, e.g. the one
+		// configured via SLAAC.
+		cliIPv6 = netip.MustParseAddr("2001:db8::1")
+
+		// cliMAC is the MAC address that the neighbor table maps cliIPv6 to.
+		cliMAC = errors.Must(net.ParseMAC("AA:BB:CC:DD:EE:FF"))
+
+		// unknownIPv4 is an address that isn't known via any mechanism.
+		unknownIPv4 = netip.MustParseAddr("192.0.2.99")
+
+		// unknownIPv6 is an address that isn't in the neighbor table.
+		unknownIPv6 = netip.MustParseAddr("2001:db8::dead")
 	)
 
 	dhcp := &testDHCP{
@@ -1045,30 +1053,35 @@ func TestStorage_NDP(t *testing.T) {
 		OnMACBy:  func(_ netip.Addr) (mac net.HardwareAddr) { return nil },
 	}
 
-	ctx := testutil.ContextWithTimeout(t, testTimeout)
-	storage, err := client.NewStorage(ctx, &client.StorageConfig{
-		BaseLogger:             testLogger,
-		Logger:                 testLogger,
-		DHCP:                   dhcp,
-		NDPData:                func() ([]byte, error) { return ndpOutput, nil },
-		ARPClientsUpdatePeriod: testTimeout / 10,
-	})
-	require.NoError(t, err)
+	newStorage := func(t *testing.T, cmdCons executil.CommandConstructor) (s *client.Storage) {
+		t.Helper()
 
-	// Add a persistent client identified by MAC address.
-	err = storage.Add(ctx, &client.Persistent{
-		Name: prsCliName,
-		UID:  client.MustNewUID(),
-		MACs: []net.HardwareAddr{cliMAC},
-	})
-	require.NoError(t, err)
+		ctx := testutil.ContextWithTimeout(t, testTimeout)
+		s, err := client.NewStorage(ctx, &client.StorageConfig{
+			BaseLogger: testLogger,
+			Logger:     testLogger,
+			Clock:      timeutil.SystemClock{},
+			DHCP:       dhcp,
+			CmdCons:    cmdCons,
+			InitialClients: []*client.Persistent{{
+				Name: prsCliName,
+				UID:  client.MustNewUID(),
+				MACs: []net.HardwareAddr{cliMAC},
+			}},
+			ARPClientsUpdatePeriod: testTimeout / 10,
+		})
+		require.NoError(t, err)
 
-	// Trigger NDP cache population.
-	storage.ReloadARP(ctx)
+		return s
+	}
+
+	// The neighbor table is read within [client.NewStorage], since the initial
+	// clients contain a MAC address.
+	storage := newStorage(t, agh.NewCommandConstructor("ip", 0, ndpOutput, nil))
 
 	t.Run("find_by_ipv6", func(t *testing.T) {
 		params := &client.FindParams{}
-		err = params.Set(cliIPv6.String())
+		err := params.Set(cliIPv6.String())
 		require.NoError(t, err)
 
 		p, ok := storage.Find(params)
@@ -1084,9 +1097,16 @@ func TestStorage_NDP(t *testing.T) {
 		assert.Equal(t, prsCliName, p.Name)
 	})
 
+	t.Run("apply_client_filtering", func(t *testing.T) {
+		setts := &filtering.Settings{}
+		storage.ApplyClientFiltering("", cliIPv6, setts)
+
+		assert.Equal(t, prsCliName, setts.ClientName)
+	})
+
 	t.Run("ipv4_not_in_ndp", func(t *testing.T) {
 		params := &client.FindParams{}
-		err = params.Set(unknownIPv4.String())
+		err := params.Set(unknownIPv4.String())
 		require.NoError(t, err)
 
 		_, ok := storage.Find(params)
@@ -1095,38 +1115,20 @@ func TestStorage_NDP(t *testing.T) {
 
 	t.Run("unknown_ipv6_not_found", func(t *testing.T) {
 		params := &client.FindParams{}
-		err = params.Set(unknownIPv6.String())
+		err := params.Set(unknownIPv6.String())
 		require.NoError(t, err)
 
 		_, ok := storage.Find(params)
 		assert.False(t, ok)
 	})
 
-	t.Run("ndp_error_graceful", func(t *testing.T) {
-		ctx2 := testutil.ContextWithTimeout(t, testTimeout)
-		errStorage, err2 := client.NewStorage(ctx2, &client.StorageConfig{
-			BaseLogger: testLogger,
-			Logger:     testLogger,
-			DHCP:       dhcp,
-			NDPData: func() ([]byte, error) {
-				return nil, errors.Error("no ip command")
-			},
-			ARPClientsUpdatePeriod: testTimeout / 10,
-		})
-		require.NoError(t, err2)
-
-		err2 = errStorage.Add(ctx2, &client.Persistent{
-			Name: prsCliName,
-			UID:  client.MustNewUID(),
-			MACs: []net.HardwareAddr{cliMAC},
-		})
-		require.NoError(t, err2)
-
-		errStorage.ReloadARP(ctx2)
+	t.Run("command_error", func(t *testing.T) {
+		cmdCons := agh.NewCommandConstructor("ip", 0, "", errors.Error("no such command"))
+		errStorage := newStorage(t, cmdCons)
 
 		params := &client.FindParams{}
-		err2 = params.Set(cliIPv6.String())
-		require.NoError(t, err2)
+		err := params.Set(cliIPv6.String())
+		require.NoError(t, err)
 
 		_, ok := errStorage.Find(params)
 		assert.False(t, ok)

--- a/internal/client/storage_test.go
+++ b/internal/client/storage_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/AdguardTeam/golibs/osutil/executil"
 	"github.com/AdguardTeam/golibs/service"
 	"github.com/AdguardTeam/golibs/testutil"
+	"github.com/AdguardTeam/golibs/testutil/fakeos/fakeexec"
 	"github.com/AdguardTeam/golibs/testutil/faketime"
 	"github.com/AdguardTeam/golibs/testutil/servicetest"
 	"github.com/AdguardTeam/golibs/timeutil"
@@ -1053,14 +1055,18 @@ func TestStorage_NDP(t *testing.T) {
 		OnMACBy:  func(_ netip.Addr) (mac net.HardwareAddr) { return nil },
 	}
 
-	newStorage := func(t *testing.T, cmdCons executil.CommandConstructor) (s *client.Storage) {
+	newStorage := func(
+		t *testing.T,
+		clock timeutil.Clock,
+		cmdCons executil.CommandConstructor,
+	) (s *client.Storage) {
 		t.Helper()
 
 		ctx := testutil.ContextWithTimeout(t, testTimeout)
 		s, err := client.NewStorage(ctx, &client.StorageConfig{
 			BaseLogger: testLogger,
 			Logger:     testLogger,
-			Clock:      timeutil.SystemClock{},
+			Clock:      clock,
 			DHCP:       dhcp,
 			CmdCons:    cmdCons,
 			InitialClients: []*client.Persistent{{
@@ -1077,7 +1083,11 @@ func TestStorage_NDP(t *testing.T) {
 
 	// The neighbor table is read within [client.NewStorage], since the initial
 	// clients contain a MAC address.
-	storage := newStorage(t, agh.NewCommandConstructor("ip", 0, ndpOutput, nil))
+	storage := newStorage(
+		t,
+		timeutil.SystemClock{},
+		agh.NewCommandConstructor("ip", 0, ndpOutput, nil),
+	)
 
 	t.Run("find_by_ipv6", func(t *testing.T) {
 		params := &client.FindParams{}
@@ -1124,7 +1134,7 @@ func TestStorage_NDP(t *testing.T) {
 
 	t.Run("command_error", func(t *testing.T) {
 		cmdCons := agh.NewCommandConstructor("ip", 0, "", errors.Error("no such command"))
-		errStorage := newStorage(t, cmdCons)
+		errStorage := newStorage(t, timeutil.SystemClock{}, cmdCons)
 
 		params := &client.FindParams{}
 		err := params.Set(cliIPv6.String())
@@ -1133,6 +1143,119 @@ func TestStorage_NDP(t *testing.T) {
 		_, ok := errStorage.Find(params)
 		assert.False(t, ok)
 	})
+
+	// expiration is a time span certainly exceeding the lifetime of the data
+	// read from the neighbor table.
+	const expiration = 1 * time.Hour
+
+	t.Run("expired_data_not_applied", func(t *testing.T) {
+		cmdCons, fail, runs := newTestNDPCmdCons(ndpOutput)
+		clock, advance := newTestClock()
+		expStorage := newStorage(t, clock, cmdCons)
+
+		setts := &filtering.Settings{}
+		expStorage.ApplyClientFiltering("", cliIPv6, setts)
+		require.Equal(t, prsCliName, setts.ClientName)
+
+		// Once the table can no longer be read, the data must stop being used
+		// for identifying clients, since the address may have been reassigned.
+		fail.Store(true)
+		advance(expiration)
+
+		prevRuns := runs.Load()
+		setts = &filtering.Settings{}
+		expStorage.ApplyClientFiltering("", cliIPv6, setts)
+		assert.Empty(t, setts.ClientName)
+
+		// The request above has scheduled a read, which fails, so the data
+		// remains unused.
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			assert.Greater(ct, runs.Load(), prevRuns)
+		}, testTimeout, testTimeout/100)
+
+		setts = &filtering.Settings{}
+		expStorage.ApplyClientFiltering("", cliIPv6, setts)
+		assert.Empty(t, setts.ClientName)
+	})
+
+	t.Run("refreshed_data_applied", func(t *testing.T) {
+		cmdCons, _, _ := newTestNDPCmdCons(ndpOutput)
+		clock, advance := newTestClock()
+		refStorage := newStorage(t, clock, cmdCons)
+
+		advance(expiration)
+
+		// The request that finds the data expired schedules a read, after which
+		// the client is identified again.
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			setts := &filtering.Settings{}
+			refStorage.ApplyClientFiltering("", cliIPv6, setts)
+
+			assert.Equal(ct, prsCliName, setts.ClientName)
+		}, testTimeout, testTimeout/100)
+	})
+}
+
+// newTestNDPCmdCons returns a command constructor printing out as the IPv6
+// neighbor table, along with the switch making the command fail and the counter
+// of its runs.
+func newTestNDPCmdCons(out string) (
+	cons executil.CommandConstructor,
+	fail *atomic.Bool,
+	runs *atomic.Int64,
+) {
+	fail, runs = &atomic.Bool{}, &atomic.Int64{}
+	cons = &fakeexec.CommandConstructor{
+		OnNew: func(
+			_ context.Context,
+			conf *executil.CommandConfig,
+		) (cmd executil.Command, err error) {
+			runs.Add(1)
+			isFailing := fail.Load()
+
+			return &fakeexec.Command{
+				OnStart: func(_ context.Context) (startErr error) {
+					if isFailing {
+						return nil
+					}
+
+					_, startErr = conf.Stdout.Write([]byte(out))
+
+					return startErr
+				},
+				OnWait: func(_ context.Context) (waitErr error) {
+					if isFailing {
+						return errors.Error("no such command")
+					}
+
+					return nil
+				},
+			}, nil
+		},
+	}
+
+	return cons, fail, runs
+}
+
+// newTestClock returns a clock reporting the time that advance moves forward.
+// Both the clock and advance are safe for concurrent use.
+func newTestClock() (clock timeutil.Clock, advance func(d time.Duration)) {
+	mu := &sync.Mutex{}
+	now := time.Now()
+
+	return &faketime.Clock{
+			OnNow: func() (t time.Time) {
+				mu.Lock()
+				defer mu.Unlock()
+
+				return now
+			},
+		}, func(d time.Duration) {
+			mu.Lock()
+			defer mu.Unlock()
+
+			now = now.Add(d)
+		}
 }
 
 func TestStorage_Update(t *testing.T) {


### PR DESCRIPTION
## Summary

- Persistent clients configured with a MAC address are only matched when they query over IPv4, because `MACByIP()` only knows about DHCPv4 leases.  Over IPv6 the same device shows up as an unidentified client, so per-client filtering doesn't apply to it.
- This adds the kernel's IPv6 neighbor table (NDP) as a fallback for the IP-to-MAC lookup in `findByIP()`, `FindLoose()`, and `ApplyClientFiltering()`.
- It also covers part of #961 for IPv6: no DHCP server is needed, only that the device is a neighbor on the local link.

## Motivation

On home networks where AdGuard Home is the DNS server, per-client rules (e.g. blocking a service on a child's device) are usually keyed on MAC address, since that's the only identifier that survives address changes.  With IPv6 enabled, devices send queries from SLAAC addresses that have no DHCPv4 lease, so those queries arrive as unidentified clients and the rules are skipped.

The kernel's neighbor table already holds the IPv6-to-MAC mapping, populated when it processes the incoming packets, but nothing consults it.  `internal/arpdb` can parse `ip neigh` output, but on Linux its first source, `/proc/net/arp`, succeeds and is IPv4-only, so the `ip neigh` fallback is never reached.

## Implementation

`internal/client/ndp.go` keeps a `map[netip.Addr]net.HardwareAddr` read from `ip -6 neigh`, run through `executil` with a deadline.

- The table is read at startup and every 30s after that.  A lookup that finds its address missing, or the data expired, additionally schedules a single background read.  Nothing on the DNS request path runs or waits for a command, and no command runs while the client index lock is held.
- Reads are limited to one per 30s, counted on failure as well as success, and only one read runs at a time.  A failed read keeps the previously known neighbors, which stay usable until they expire.
- Data that no successful read has confirmed within 60s isn't used for identifying clients at all: an address may have been reassigned to another device, and a wrong MAC address means the settings of a wrong client.  With the periodic reread, this only comes up when the reads themselves are failing.
- Link-local entries are keyed with the interface from the `dev` field, e.g. `fe80::1%eth0`, since the same link-local address can be in use on several links and request addresses carry their zone.
- Nothing is read unless at least one persistent client is identified by a MAC address.
- Linux only, as `ip -6 neigh` is Linux-specific.  `ndp -an` on BSD/Darwin and `netsh interface ipv6 show neighbors` on Windows are left as a TODO.

## Test plan

- [x] `go test -race -count=1 ./...` and `make go-lint`, also against a merge with current `master`.
- [x] Unit tests for the parser, including entries with no `lladdr`, malformed addresses, and the same link-local address on two interfaces.
- [x] Behavior tests for the reader: rate limiting across failed reads, one read in flight, data kept but no longer used once expired, expired data replaced after a read, IPv4 and IPv4-in-IPv6 addresses ignored.
- [x] Integration tests for `Find`, `FindLoose`, and `ApplyClientFiltering` identifying an IPv6 client through the neighbor table, plus unknown addresses, a failing command, expired data not applying a client's settings, and the settings applying again after a successful read.
- [x] Manual: Raspberry Pi (armv7l) running AGH as DNS + DHCP server; a laptop querying over IPv6 is matched to its persistent client, IPv4 queries unchanged.

## Question for maintainers

Would you rather have this in `internal/arpdb`?  Adding the IPv6 neighbors to the Linux implementation there and building the IP-to-MAC index from `Neighbors()` would drop the separate command and cache from `internal/client` entirely, and would extend MAC matching to IPv4 without DHCP as well.  The cost is that the data would only be as fresh as the 10-minute ARP cycle, which is too slow for filtering a device that has just joined, so it would need its own refresh policy anyway.  Happy to rework it that way if you prefer.
