### PR TITLE
all: add per-client filter list assignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ node_modules/
 tmp/
 
 !/build/gitkeep
+AdGuardHome_*

--- a/internal/client/persistent.go
+++ b/internal/client/persistent.go
@@ -16,6 +16,7 @@ import (
 	"github.com/AdguardTeam/dnsproxy/upstream"
 	"github.com/AdguardTeam/golibs/errors"
 	"github.com/AdguardTeam/golibs/logutil/slogutil"
+	"github.com/AdguardTeam/urlfilter/rules"
 	"github.com/google/uuid"
 )
 
@@ -118,6 +119,18 @@ type Persistent struct {
 
 	// UseOwnBlockedServices specifies whether custom services are blocked.
 	UseOwnBlockedServices bool
+
+	// UseOwnFilterLists signals whether the client has its own filter list
+	// configuration.  If false, the global filter lists are used.
+	UseOwnFilterLists bool
+
+	// FilterListIDs is the set of blocking filter list IDs assigned to this
+	// client.  Only used when UseOwnFilterLists is true.
+	FilterListIDs []rules.ListID
+
+	// AllowFilterListIDs is the set of allowing filter list IDs assigned to
+	// this client.  Only used when UseOwnFilterLists is true.
+	AllowFilterListIDs []rules.ListID
 
 	// IgnoreQueryLog specifies whether the client requests are logged.
 	IgnoreQueryLog bool
@@ -301,6 +314,8 @@ func (c *Persistent) ShallowClone() (clone *Persistent) {
 	clone.Subnets = slices.Clone(c.Subnets)
 	clone.MACs = slices.Clone(c.MACs)
 	clone.ClientIDs = slices.Clone(c.ClientIDs)
+	clone.FilterListIDs = slices.Clone(c.FilterListIDs)
+	clone.AllowFilterListIDs = slices.Clone(c.AllowFilterListIDs)
 
 	return clone
 }

--- a/internal/client/storage.go
+++ b/internal/client/storage.go
@@ -20,6 +20,7 @@ import (
 	"github.com/AdguardTeam/golibs/logutil/slogutil"
 	"github.com/AdguardTeam/golibs/netutil"
 	"github.com/AdguardTeam/golibs/timeutil"
+	"github.com/AdguardTeam/urlfilter/rules"
 )
 
 // allowedTags is the list of available client tags.
@@ -792,6 +793,11 @@ func (s *Storage) ApplyClientFiltering(id string, addr netip.Addr, setts *filter
 		setts.BlockedServices = c.BlockedServices.Clone()
 	}
 
+	if c.UseOwnFilterLists {
+		setts.ClientFilterListIDs = listIDsToMap(c.FilterListIDs)
+		setts.ClientAllowListIDs = listIDsToMap(c.AllowFilterListIDs)
+	}
+
 	setts.ClientName = c.Name
 	setts.ClientTags = slices.Clone(c.Tags)
 	if !c.UseOwnSettings {
@@ -803,4 +809,14 @@ func (s *Storage) ApplyClientFiltering(id string, addr netip.Addr, setts *filter
 	setts.ClientSafeSearch = c.SafeSearch
 	setts.SafeBrowsingEnabled = c.SafeBrowsingEnabled
 	setts.ParentalEnabled = c.ParentalEnabled
+}
+
+// listIDsToMap converts a slice of filter list IDs to a map for O(1) lookups.
+func listIDsToMap(ids []rules.ListID) map[rules.ListID]bool {
+	m := make(map[rules.ListID]bool, len(ids))
+	for _, id := range ids {
+		m[id] = true
+	}
+
+	return m
 }

--- a/internal/client/storage_test.go
+++ b/internal/client/storage_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/AdguardTeam/AdGuardHome/internal/dhcpd"
 	"github.com/AdguardTeam/AdGuardHome/internal/dhcpsvc"
 	"github.com/AdguardTeam/AdGuardHome/internal/dnsforward"
+	"github.com/AdguardTeam/AdGuardHome/internal/filtering"
 	"github.com/AdguardTeam/AdGuardHome/internal/whois"
 	"github.com/AdguardTeam/golibs/errors"
 	"github.com/AdguardTeam/golibs/hostsfile"
@@ -24,6 +25,7 @@ import (
 	"github.com/AdguardTeam/golibs/testutil/faketime"
 	"github.com/AdguardTeam/golibs/testutil/servicetest"
 	"github.com/AdguardTeam/golibs/timeutil"
+	"github.com/AdguardTeam/urlfilter/rules"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1289,6 +1291,65 @@ func TestStorage_CustomUpstreamConfig(t *testing.T) {
 		require.NotNil(t, secondConf)
 
 		assert.Same(t, firstConf, secondConf)
+	})
+}
+
+func TestStorage_ApplyClientFiltering_filterLists(t *testing.T) {
+	const (
+		cliName = "test_client"
+	)
+
+	cliIP := netip.MustParseAddr("1.1.1.1")
+
+	ctx := testutil.ContextWithTimeout(t, testTimeout)
+
+	t.Run("with_own_filter_lists", func(t *testing.T) {
+		s := newTestStorage(t, nil)
+		err := s.Add(ctx, &client.Persistent{
+			Name:               cliName,
+			IPs:                []netip.Addr{cliIP},
+			UID:                client.MustNewUID(),
+			UseOwnFilterLists:  true,
+			FilterListIDs:      []rules.ListID{1, 3},
+			AllowFilterListIDs: []rules.ListID{5},
+		})
+		require.NoError(t, err)
+
+		setts := &filtering.Settings{
+			ProtectionEnabled: true,
+			FilteringEnabled:  true,
+		}
+
+		s.ApplyClientFiltering("", cliIP, setts)
+
+		require.NotNil(t, setts.ClientFilterListIDs)
+		assert.True(t, setts.ClientFilterListIDs[1])
+		assert.True(t, setts.ClientFilterListIDs[3])
+		assert.False(t, setts.ClientFilterListIDs[2])
+
+		require.NotNil(t, setts.ClientAllowListIDs)
+		assert.True(t, setts.ClientAllowListIDs[5])
+	})
+
+	t.Run("without_own_filter_lists", func(t *testing.T) {
+		s := newTestStorage(t, nil)
+		err := s.Add(ctx, &client.Persistent{
+			Name:              cliName,
+			IPs:               []netip.Addr{cliIP},
+			UID:               client.MustNewUID(),
+			UseOwnFilterLists: false,
+		})
+		require.NoError(t, err)
+
+		setts := &filtering.Settings{
+			ProtectionEnabled: true,
+			FilteringEnabled:  true,
+		}
+
+		s.ApplyClientFiltering("", cliIP, setts)
+
+		assert.Nil(t, setts.ClientFilterListIDs)
+		assert.Nil(t, setts.ClientAllowListIDs)
 	})
 }
 

--- a/internal/filtering/filter.go
+++ b/internal/filtering/filter.go
@@ -20,6 +20,7 @@ import (
 	"github.com/AdguardTeam/golibs/container"
 	"github.com/AdguardTeam/golibs/errors"
 	"github.com/AdguardTeam/golibs/logutil/slogutil"
+	"github.com/AdguardTeam/urlfilter/rules"
 )
 
 // filterDir is the subdirectory of a data directory to store downloaded
@@ -146,17 +147,6 @@ func (d *DNSFilter) filterSetProperties(
 		shouldRestart = true
 	}
 
-	if !flt.Enabled {
-		// TODO(e.burkov):  The validation of the contents of the new URL is
-		// currently skipped if the rule list is disabled.  This makes it
-		// possible to set a bad rules source, but the validation should still
-		// kick in when the filter is enabled.  Consider changing this behavior
-		// to be stricter.
-		flt.unload()
-
-		return shouldRestart, err
-	}
-
 	if !shouldRestart {
 		return false, nil
 	}
@@ -228,11 +218,6 @@ func (d *DNSFilter) loadFilters(ctx context.Context, array []FilterYAML) {
 			filter.ID = newID
 		}
 
-		if !filter.Enabled {
-			// No need to load a filter that is not enabled
-			continue
-		}
-
 		err := d.load(ctx, filter)
 		if err != nil {
 			d.logger.ErrorContext(ctx, "loading filter", "id", filter.ID, slogutil.KeyError, err)
@@ -280,10 +265,6 @@ func (d *DNSFilter) listsToUpdate(filters *[]FilterYAML, force bool) (toUpd []Fi
 
 	for i := range *filters {
 		flt := &(*filters)[i] // otherwise we will be operating on a copy
-
-		if !flt.Enabled {
-			continue
-		}
 
 		if !force {
 			exp := flt.LastUpdated.Add(time.Duration(d.conf.FiltersUpdateIntervalHours) * time.Hour)
@@ -661,28 +642,31 @@ func (d *DNSFilter) enableFiltersLocked(ctx context.Context, async bool) {
 		Data: []byte(strings.Join(d.conf.UserRules, "\n")),
 	}
 
+	enabledBlockIDs := make(map[rules.ListID]bool, len(d.conf.Filters))
 	for _, filter := range d.conf.Filters {
-		if !filter.Enabled {
-			continue
-		}
-
 		filters = append(filters, Filter{
 			ID:       filter.ID,
 			FilePath: filter.Path(d.conf.DataDir),
 		})
+		if filter.Enabled {
+			enabledBlockIDs[filter.ID] = true
+		}
 	}
 
+	enabledAllowIDs := make(map[rules.ListID]bool, len(d.conf.WhitelistFilters))
 	var allowFilters []Filter
 	for _, filter := range d.conf.WhitelistFilters {
-		if !filter.Enabled {
-			continue
-		}
-
 		allowFilters = append(allowFilters, Filter{
 			ID:       filter.ID,
 			FilePath: filter.Path(d.conf.DataDir),
 		})
+		if filter.Enabled {
+			enabledAllowIDs[filter.ID] = true
+		}
 	}
+
+	d.enabledBlockFilterIDs = enabledBlockIDs
+	d.enabledAllowFilterIDs = enabledAllowIDs
 
 	err := d.setFilters(ctx, filters, allowFilters, async)
 	if err != nil {

--- a/internal/filtering/filtering.go
+++ b/internal/filtering/filtering.go
@@ -55,6 +55,14 @@ type Settings struct {
 	// is nil if the client does not have any blocked services.
 	BlockedServices *BlockedServices
 
+	// ClientFilterListIDs is the set of blocking filter list IDs that apply
+	// to this client.  Nil means use all global lists (default behavior).
+	ClientFilterListIDs map[rules.ListID]bool
+
+	// ClientAllowListIDs is the set of allowing filter list IDs that apply
+	// to this client.  Nil means use all global allowlists (default behavior).
+	ClientAllowListIDs map[rules.ListID]bool
+
 	ProtectionEnabled   bool
 	FilteringEnabled    bool
 	SafeSearchEnabled   bool
@@ -260,6 +268,15 @@ type DNSFilter struct {
 
 	rulesStorageAllow    *filterlist.RuleStorage
 	filteringEngineAllow *urlfilter.DNSEngine
+
+	// enabledBlockFilterIDs is the set of globally enabled blocking filter
+	// list IDs.  Used to filter out results from disabled lists when no
+	// per-client configuration is active.  Protected by engineLock.
+	enabledBlockFilterIDs map[rules.ListID]bool
+
+	// enabledAllowFilterIDs is the set of globally enabled allowing filter
+	// list IDs.  Protected by engineLock.
+	enabledAllowFilterIDs map[rules.ListID]bool
 
 	safeSearch SafeSearch
 
@@ -874,6 +891,87 @@ func hostResultForOtherQType(dnsres *urlfilter.DNSResult) (res Result) {
 	return Result{}
 }
 
+// filterDNSResultByListIDs filters dnsres in-place to only keep rules from the
+// allowed filter list IDs.  IDCustom (user rules) is always allowed when
+// keepCustom is true.  Returns true if any rules remain after filtering.
+func filterDNSResultByListIDs(
+	dnsres *urlfilter.DNSResult,
+	allowed map[rules.ListID]bool,
+	keepCustom bool,
+) (hasMatch bool) {
+	isAllowed := func(id rules.ListID) bool {
+		if keepCustom && id == rulelist.IDCustom {
+			return true
+		}
+
+		return allowed[id]
+	}
+
+	// Filter NetworkRules (includes DNS rewrites).
+	filtered := make([]*rules.NetworkRule, 0, len(dnsres.NetworkRules))
+	for _, r := range dnsres.NetworkRules {
+		if isAllowed(r.GetFilterListID()) {
+			filtered = append(filtered, r)
+		}
+	}
+	dnsres.NetworkRules = filtered
+
+	// Recompute NetworkRule (the "best" non-dnsrewrite rule).
+	if dnsres.NetworkRule != nil && !isAllowed(dnsres.NetworkRule.GetFilterListID()) {
+		dnsres.NetworkRule = nil
+		// Find replacement: whitelist (exception) rules take priority.
+		var bestBlock *rules.NetworkRule
+		for _, r := range dnsres.NetworkRules {
+			if r.DNSRewrite != nil {
+				continue
+			}
+			if r.Whitelist {
+				dnsres.NetworkRule = r
+				break
+			}
+			if bestBlock == nil {
+				bestBlock = r
+			}
+		}
+		if dnsres.NetworkRule == nil {
+			dnsres.NetworkRule = bestBlock
+		}
+	}
+
+	// Filter HostRules.
+	dnsres.HostRulesV4 = filterHostRulesByListIDs(dnsres.HostRulesV4, isAllowed)
+	dnsres.HostRulesV6 = filterHostRulesByListIDs(dnsres.HostRulesV6, isAllowed)
+
+	return dnsres.NetworkRule != nil ||
+		len(dnsres.HostRulesV4) > 0 ||
+		len(dnsres.HostRulesV6) > 0 ||
+		len(dnsres.NetworkRules) > 0
+}
+
+// filterHostRulesByListIDs filters host rules in-place, keeping only rules from
+// filter lists accepted by isAllowed.
+func filterHostRulesByListIDs(
+	hrs []*rules.HostRule,
+	isAllowed func(rules.ListID) bool,
+) []*rules.HostRule {
+	if len(hrs) == 0 {
+		return nil
+	}
+
+	filtered := make([]*rules.HostRule, 0, len(hrs))
+	for _, hr := range hrs {
+		if isAllowed(hr.GetFilterListID()) {
+			filtered = append(filtered, hr)
+		}
+	}
+
+	if len(filtered) == 0 {
+		return nil
+	}
+
+	return filtered
+}
+
 // matchHost is a low-level way to check only if host is filtered by rules,
 // skipping expensive safebrowsing and parental lookups.
 func (d *DNSFilter) matchHost(
@@ -906,6 +1004,15 @@ func (d *DNSFilter) matchHost(
 	if setts.ProtectionEnabled && d.filteringEngineAllow != nil {
 		dnsres, ok := d.filteringEngineAllow.MatchRequest(ufReq)
 		if ok {
+			if setts.ClientAllowListIDs != nil {
+				// Per-client: keep only client-assigned allowlists.
+				ok = filterDNSResultByListIDs(dnsres, setts.ClientAllowListIDs, false)
+			} else if d.enabledAllowFilterIDs != nil {
+				// Global: keep only globally enabled allowlists.
+				ok = filterDNSResultByListIDs(dnsres, d.enabledAllowFilterIDs, false)
+			}
+		}
+		if ok {
 			return d.matchHostProcessAllowList(ctx, host, dnsres)
 		}
 	}
@@ -915,6 +1022,13 @@ func (d *DNSFilter) matchHost(
 	}
 
 	dnsres, matchedEngine := d.filteringEngine.MatchRequest(ufReq)
+	if setts.ClientFilterListIDs != nil {
+		// Per-client: keep only client-assigned blocklists + user rules.
+		matchedEngine = filterDNSResultByListIDs(dnsres, setts.ClientFilterListIDs, true)
+	} else if d.enabledBlockFilterIDs != nil {
+		// Global: keep only globally enabled blocklists + user rules.
+		matchedEngine = filterDNSResultByListIDs(dnsres, d.enabledBlockFilterIDs, true)
+	}
 
 	// Check DNS rewrites first, because the API there is a bit awkward.
 	dnsRWRes := d.processDNSResultRewrites(dnsres, host)

--- a/internal/filtering/filtering_internal_test.go
+++ b/internal/filtering/filtering_internal_test.go
@@ -10,9 +10,11 @@ import (
 
 	"github.com/AdguardTeam/AdGuardHome/internal/aghtest"
 	"github.com/AdguardTeam/AdGuardHome/internal/filtering/hashprefix"
+	"github.com/AdguardTeam/AdGuardHome/internal/filtering/rulelist"
 	"github.com/AdguardTeam/golibs/logutil/slogutil"
 	"github.com/AdguardTeam/golibs/netutil"
 	"github.com/AdguardTeam/golibs/testutil"
+	"github.com/AdguardTeam/urlfilter"
 	"github.com/AdguardTeam/urlfilter/rules"
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
@@ -729,4 +731,169 @@ func BenchmarkSafeBrowsing_parallel(b *testing.B) {
 	//	pkg: github.com/AdguardTeam/AdGuardHome/internal/filtering
 	//	cpu: Apple M3
 	//	BenchmarkSafeBrowsing_parallel-8   	 1040792	      1076 ns/op	    1472 B/op	      43 allocs/op
+}
+
+func TestFilterDNSResultByListIDs(t *testing.T) {
+	const (
+		listID1 rules.ListID = 1
+		listID2 rules.ListID = 2
+		listID3 rules.ListID = 3
+	)
+
+	newRule := func(tb testing.TB, text string, id rules.ListID) *rules.NetworkRule {
+		tb.Helper()
+
+		r, err := rules.NewNetworkRule(text, id)
+		require.NoError(tb, err)
+
+		return r
+	}
+
+	t.Run("allowed_list_kept", func(t *testing.T) {
+		r := newRule(t, "||example.org^", listID1)
+		dnsres := &urlfilter.DNSResult{
+			NetworkRule:  r,
+			NetworkRules: []*rules.NetworkRule{r},
+		}
+		allowed := map[rules.ListID]bool{listID1: true}
+
+		ok := filterDNSResultByListIDs(dnsres, allowed, false)
+		assert.True(t, ok)
+		assert.Equal(t, r, dnsres.NetworkRule)
+		assert.Len(t, dnsres.NetworkRules, 1)
+	})
+
+	t.Run("disallowed_list_removed", func(t *testing.T) {
+		r := newRule(t, "||example.org^", listID2)
+		dnsres := &urlfilter.DNSResult{
+			NetworkRule:  r,
+			NetworkRules: []*rules.NetworkRule{r},
+		}
+		allowed := map[rules.ListID]bool{listID1: true}
+
+		ok := filterDNSResultByListIDs(dnsres, allowed, false)
+		assert.False(t, ok)
+		assert.Nil(t, dnsres.NetworkRule)
+		assert.Empty(t, dnsres.NetworkRules)
+	})
+
+	t.Run("user_rules_always_kept", func(t *testing.T) {
+		r := newRule(t, "||example.org^", rulelist.IDCustom)
+		dnsres := &urlfilter.DNSResult{
+			NetworkRule:  r,
+			NetworkRules: []*rules.NetworkRule{r},
+		}
+		allowed := map[rules.ListID]bool{listID1: true}
+
+		ok := filterDNSResultByListIDs(dnsres, allowed, true)
+		assert.True(t, ok)
+		assert.Equal(t, r, dnsres.NetworkRule)
+	})
+
+	t.Run("user_rules_not_kept_when_flag_false", func(t *testing.T) {
+		r := newRule(t, "||example.org^", rulelist.IDCustom)
+		dnsres := &urlfilter.DNSResult{
+			NetworkRule:  r,
+			NetworkRules: []*rules.NetworkRule{r},
+		}
+		allowed := map[rules.ListID]bool{listID1: true}
+
+		ok := filterDNSResultByListIDs(dnsres, allowed, false)
+		assert.False(t, ok)
+	})
+
+	t.Run("mixed_rules", func(t *testing.T) {
+		r1 := newRule(t, "||disallowed.org^", listID2)
+		r2 := newRule(t, "||allowed.org^", listID1)
+		dnsres := &urlfilter.DNSResult{
+			NetworkRule:  r1,
+			NetworkRules: []*rules.NetworkRule{r1, r2},
+		}
+		allowed := map[rules.ListID]bool{listID1: true}
+
+		ok := filterDNSResultByListIDs(dnsres, allowed, false)
+		assert.True(t, ok)
+		assert.Equal(t, r2, dnsres.NetworkRule)
+		assert.Len(t, dnsres.NetworkRules, 1)
+		assert.Equal(t, r2, dnsres.NetworkRules[0])
+	})
+
+	t.Run("empty_result", func(t *testing.T) {
+		dnsres := &urlfilter.DNSResult{}
+		allowed := map[rules.ListID]bool{listID1: true}
+
+		ok := filterDNSResultByListIDs(dnsres, allowed, false)
+		assert.False(t, ok)
+	})
+}
+
+func TestDNSFilter_CheckHost_clientFilterLists(t *testing.T) {
+	const (
+		listID1 rules.ListID = 1
+		listID2 rules.ListID = 2
+	)
+
+	d, setts := newForTest(t, nil, []Filter{
+		{ID: listID1, Data: []byte("||blocked-by-list1.org^\n")},
+		{ID: listID2, Data: []byte("||blocked-by-list2.org^\n")},
+	})
+	t.Cleanup(d.Close)
+
+	t.Run("global_all_blocked", func(t *testing.T) {
+		// Without per-client lists, both domains should be blocked.
+		res, err := d.CheckHost("blocked-by-list1.org", dns.TypeA, setts)
+		require.NoError(t, err)
+		assert.True(t, res.IsFiltered)
+
+		res, err = d.CheckHost("blocked-by-list2.org", dns.TypeA, setts)
+		require.NoError(t, err)
+		assert.True(t, res.IsFiltered)
+	})
+
+	t.Run("per_client_only_list1", func(t *testing.T) {
+		clientSetts := *setts
+		clientSetts.ClientFilterListIDs = map[rules.ListID]bool{listID1: true}
+
+		// Blocked by assigned list1.
+		res, err := d.CheckHost("blocked-by-list1.org", dns.TypeA, &clientSetts)
+		require.NoError(t, err)
+		assert.True(t, res.IsFiltered)
+
+		// Not blocked — list2 not assigned.
+		res, err = d.CheckHost("blocked-by-list2.org", dns.TypeA, &clientSetts)
+		require.NoError(t, err)
+		assert.False(t, res.IsFiltered)
+	})
+
+	t.Run("per_client_only_list2", func(t *testing.T) {
+		clientSetts := *setts
+		clientSetts.ClientFilterListIDs = map[rules.ListID]bool{listID2: true}
+
+		// Not blocked — list1 not assigned.
+		res, err := d.CheckHost("blocked-by-list1.org", dns.TypeA, &clientSetts)
+		require.NoError(t, err)
+		assert.False(t, res.IsFiltered)
+
+		// Blocked by assigned list2.
+		res, err = d.CheckHost("blocked-by-list2.org", dns.TypeA, &clientSetts)
+		require.NoError(t, err)
+		assert.True(t, res.IsFiltered)
+	})
+
+	t.Run("user_rules_always_apply", func(t *testing.T) {
+		// Add a user rule (list ID 0 = IDCustom) that blocks a domain.
+		dUserRules, setts2 := newForTest(t, nil, []Filter{
+			{ID: rulelist.IDCustom, Data: []byte("||custom-blocked.org^\n")},
+			{ID: listID1, Data: []byte("||blocked-by-list1.org^\n")},
+		})
+		t.Cleanup(dUserRules.Close)
+
+		clientSetts := *setts2
+		clientSetts.ClientFilterListIDs = map[rules.ListID]bool{listID1: true}
+
+		// Custom rule should apply even though IDCustom is not in the map.
+		res, err := dUserRules.CheckHost("custom-blocked.org", dns.TypeA, &clientSetts)
+		require.NoError(t, err)
+		assert.True(t, res.IsFiltered)
+	})
 }

--- a/internal/home/clients.go
+++ b/internal/home/clients.go
@@ -22,6 +22,7 @@ import (
 	"github.com/AdguardTeam/golibs/errors"
 	"github.com/AdguardTeam/golibs/logutil/slogutil"
 	"github.com/AdguardTeam/golibs/timeutil"
+	"github.com/AdguardTeam/urlfilter/rules"
 )
 
 // clientsContainer is the storage of all runtime and persistent clients.
@@ -189,6 +190,10 @@ type clientObject struct {
 	ParentalEnabled          bool `yaml:"parental_enabled"`
 	SafeBrowsingEnabled      bool `yaml:"safebrowsing_enabled"`
 	UseGlobalBlockedServices bool `yaml:"use_global_blocked_services"`
+	UseGlobalFilterLists     bool `yaml:"use_global_filter_lists"`
+
+	FilterListIDs      []rules.ListID `yaml:"filter_list_ids"`
+	AllowFilterListIDs []rules.ListID `yaml:"allow_filter_list_ids"`
 
 	IgnoreQueryLog   bool `yaml:"ignore_querylog"`
 	IgnoreStatistics bool `yaml:"ignore_statistics"`
@@ -214,6 +219,9 @@ func (o *clientObject) toPersistent(
 		SafeSearchConf:        o.SafeSearchConf,
 		SafeBrowsingEnabled:   o.SafeBrowsingEnabled,
 		UseOwnBlockedServices: !o.UseGlobalBlockedServices,
+		UseOwnFilterLists:     !o.UseGlobalFilterLists,
+		FilterListIDs:         slices.Clone(o.FilterListIDs),
+		AllowFilterListIDs:    slices.Clone(o.AllowFilterListIDs),
 		IgnoreQueryLog:        o.IgnoreQueryLog,
 		IgnoreStatistics:      o.IgnoreStatistics,
 		UpstreamsCacheEnabled: o.UpstreamsCacheEnabled,
@@ -268,6 +276,14 @@ func (o *clientObject) toPersistent(
 
 	cli.Tags = slices.Clone(o.Tags)
 
+	if cli.FilterListIDs == nil {
+		cli.FilterListIDs = []rules.ListID{}
+	}
+
+	if cli.AllowFilterListIDs == nil {
+		cli.AllowFilterListIDs = []rules.ListID{}
+	}
+
 	return cli, nil
 }
 
@@ -296,6 +312,9 @@ func (clients *clientsContainer) forConfig() (objs []*clientObject) {
 			SafeSearchConf:           cli.SafeSearchConf,
 			SafeBrowsingEnabled:      cli.SafeBrowsingEnabled,
 			UseGlobalBlockedServices: !cli.UseOwnBlockedServices,
+			UseGlobalFilterLists:     !cli.UseOwnFilterLists,
+			FilterListIDs:            slices.Clone(cli.FilterListIDs),
+			AllowFilterListIDs:       slices.Clone(cli.AllowFilterListIDs),
 			IgnoreQueryLog:           cli.IgnoreQueryLog,
 			IgnoreStatistics:         cli.IgnoreStatistics,
 			UpstreamsCacheEnabled:    cli.UpstreamsCacheEnabled,

--- a/internal/home/clientshttp.go
+++ b/internal/home/clientshttp.go
@@ -11,10 +11,12 @@ import (
 	"github.com/AdguardTeam/AdGuardHome/internal/aghhttp"
 	"github.com/AdguardTeam/AdGuardHome/internal/client"
 	"github.com/AdguardTeam/AdGuardHome/internal/filtering"
+	"github.com/AdguardTeam/AdGuardHome/internal/filtering/rulelist"
 	"github.com/AdguardTeam/AdGuardHome/internal/filtering/safesearch"
 	"github.com/AdguardTeam/AdGuardHome/internal/schedule"
 	"github.com/AdguardTeam/AdGuardHome/internal/whois"
 	"github.com/AdguardTeam/golibs/logutil/slogutil"
+	"github.com/AdguardTeam/urlfilter/rules"
 )
 
 // clientJSON is a common structure used by several handlers to deal with
@@ -56,6 +58,10 @@ type clientJSON struct {
 	SafeSearchEnabled        bool `json:"safesearch_enabled"`
 	UseGlobalBlockedServices bool `json:"use_global_blocked_services"`
 	UseGlobalSettings        bool `json:"use_global_settings"`
+	UseGlobalFilterLists     bool `json:"use_global_filter_lists"`
+
+	FilterListIDs      []int64 `json:"filter_list_ids"`
+	AllowFilterListIDs []int64 `json:"allow_filter_list_ids"`
 
 	IgnoreQueryLog   aghalg.NullBool `json:"ignore_querylog"`
 	IgnoreStatistics aghalg.NullBool `json:"ignore_statistics"`
@@ -210,6 +216,9 @@ func (clients *clientsContainer) jsonToClient(
 	c.ParentalEnabled = cj.ParentalEnabled
 	c.SafeBrowsingEnabled = cj.SafeBrowsingEnabled
 	c.UseOwnBlockedServices = !cj.UseGlobalBlockedServices
+	c.UseOwnFilterLists = !cj.UseGlobalFilterLists
+	c.FilterListIDs = apiIDsToListIDs(cj.FilterListIDs)
+	c.AllowFilterListIDs = apiIDsToListIDs(cj.AllowFilterListIDs)
 
 	if c.SafeSearchConf.Enabled {
 		logger := clients.baseLogger.With(
@@ -311,6 +320,9 @@ func clientToJSON(c *client.Persistent) (cj *clientJSON) {
 		SafeBrowsingEnabled: c.SafeBrowsingEnabled,
 
 		UseGlobalBlockedServices: !c.UseOwnBlockedServices,
+		UseGlobalFilterLists:     !c.UseOwnFilterLists,
+		FilterListIDs:            listIDsToAPIIDs(c.FilterListIDs),
+		AllowFilterListIDs:       listIDsToAPIIDs(c.AllowFilterListIDs),
 
 		Schedule:        c.BlockedServices.Schedule,
 		BlockedServices: c.BlockedServices.IDs,
@@ -606,6 +618,36 @@ func (clients *clientsContainer) findRuntime(
 		Disallowed:     &disallowed,
 		DisallowedRule: disallowedRule,
 	}
+}
+
+// listIDsToAPIIDs converts a slice of rules.ListID to a slice of int64 API
+// IDs.
+func listIDsToAPIIDs(ids []rules.ListID) []int64 {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	apiIDs := make([]int64, len(ids))
+	for i, id := range ids {
+		apiIDs[i] = int64(rulelist.APIID(id))
+	}
+
+	return apiIDs
+}
+
+// apiIDsToListIDs converts a slice of int64 API IDs to a slice of
+// rules.ListID.
+func apiIDsToListIDs(apiIDs []int64) []rules.ListID {
+	if len(apiIDs) == 0 {
+		return nil
+	}
+
+	ids := make([]rules.ListID, len(apiIDs))
+	for i, id := range apiIDs {
+		ids[i] = rules.ListID(id)
+	}
+
+	return ids
 }
 
 // registerWebHandlers registers HTTP handlers.


### PR DESCRIPTION
## Summary

- Add `UseOwnFilterLists`, `FilterListIDs`, and `AllowFilterListIDs` fields to the client data model, following the existing `UseOwnBlockedServices` pattern
- Add per-client filter list filtering in `matchHost()`: when a client has its own filter lists, only rules from assigned lists apply; user rules (ID 0) always apply
- Load all filters into the DNS engine regardless of their global enabled state, so that per-client assignments work even for globally-disabled filters; globally-disabled filters are excluded at match time for clients using global settings
- Add YAML and JSON serialization for the new fields, including API endpoints for client add/update/get
- Add unit tests for `filterDNSResultByListIDs`, `CheckHost` with client filter lists, and `ApplyClientFiltering`

## Test plan

- [x] `go test ./internal/filtering/...` passes
- [x] `go test ./internal/client/...` passes
- [x] `go test ./internal/home/...` passes
- [ ] Create a client with `use_global_filter_lists: false` and specific `filter_list_ids` via the API
- [ ] Verify that a DNS query for a domain blocked by an assigned list is blocked
- [ ] Verify that a DNS query for a domain blocked by a non-assigned list passes through
- [ ] Verify that user rules always apply regardless of per-client assignment
- [ ] Verify that the YAML config saves and reloads correctly with the new fields