### PR TITLE
all: add per-client filter list assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Added
 
+- Filter lists can now be assigned to a single client, through the new
+  `use_own_filter_lists`, `filter_list_ids`, and `allow_filter_list_ids`
+  properties of the client configuration.  A client that has its own filter
+  lists only uses those, along with the user rules.  A filter list that is
+  disabled globally is only downloaded and loaded while a client uses it.
+
 - Bootstrap servers configuration now supports comments.
 
 - New property `"language"` in `POST /control/install/check_config` and `POST /control/install/configure` HTTP APIs.

--- a/internal/client/persistent.go
+++ b/internal/client/persistent.go
@@ -16,6 +16,7 @@ import (
 	"github.com/AdguardTeam/dnsproxy/upstream"
 	"github.com/AdguardTeam/golibs/errors"
 	"github.com/AdguardTeam/golibs/logutil/slogutil"
+	"github.com/AdguardTeam/urlfilter/rules"
 	"github.com/google/uuid"
 )
 
@@ -94,6 +95,14 @@ type Persistent struct {
 	// (IP, subnet, MAC, or ClientID).
 	ClientIDs []ClientID
 
+	// FilterListIDs is the set of blocking filter list IDs of the client.  It is
+	// only used when UseOwnFilterLists is true.
+	FilterListIDs []rules.ListID
+
+	// AllowFilterListIDs is the set of allowing filter list IDs of the client.
+	// It is only used when UseOwnFilterLists is true.
+	AllowFilterListIDs []rules.ListID
+
 	// UID is the unique identifier of the persistent client.
 	UID UID
 
@@ -118,6 +127,10 @@ type Persistent struct {
 
 	// UseOwnBlockedServices specifies whether custom services are blocked.
 	UseOwnBlockedServices bool
+
+	// UseOwnFilterLists specifies whether FilterListIDs and AllowFilterListIDs
+	// are used instead of the globally enabled filter lists.
+	UseOwnFilterLists bool
 
 	// IgnoreQueryLog specifies whether the client requests are logged.
 	IgnoreQueryLog bool
@@ -301,6 +314,8 @@ func (c *Persistent) ShallowClone() (clone *Persistent) {
 	clone.Subnets = slices.Clone(c.Subnets)
 	clone.MACs = slices.Clone(c.MACs)
 	clone.ClientIDs = slices.Clone(c.ClientIDs)
+	clone.FilterListIDs = slices.Clone(c.FilterListIDs)
+	clone.AllowFilterListIDs = slices.Clone(c.AllowFilterListIDs)
 
 	return clone
 }

--- a/internal/client/storage.go
+++ b/internal/client/storage.go
@@ -20,6 +20,7 @@ import (
 	"github.com/AdguardTeam/golibs/logutil/slogutil"
 	"github.com/AdguardTeam/golibs/netutil"
 	"github.com/AdguardTeam/golibs/timeutil"
+	"github.com/AdguardTeam/urlfilter/rules"
 )
 
 // allowedTags is the list of available client tags.
@@ -792,6 +793,12 @@ func (s *Storage) ApplyClientFiltering(id string, addr netip.Addr, setts *filter
 		setts.BlockedServices = c.BlockedServices.Clone()
 	}
 
+	if c.UseOwnFilterLists {
+		setts.UseOwnFilterLists = true
+		setts.ClientFilterListIDs = listIDsToMap(c.FilterListIDs)
+		setts.ClientAllowListIDs = listIDsToMap(c.AllowFilterListIDs)
+	}
+
 	setts.ClientName = c.Name
 	setts.ClientTags = slices.Clone(c.Tags)
 	if !c.UseOwnSettings {
@@ -803,4 +810,48 @@ func (s *Storage) ApplyClientFiltering(id string, addr netip.Addr, setts *filter
 	setts.ClientSafeSearch = c.SafeSearch
 	setts.SafeBrowsingEnabled = c.SafeBrowsingEnabled
 	setts.ParentalEnabled = c.ParentalEnabled
+}
+
+// listIDsToMap converts a slice of filter list IDs into a set.
+func listIDsToMap(ids []rules.ListID) (set map[rules.ListID]bool) {
+	set = make(map[rules.ListID]bool, len(ids))
+	for _, id := range ids {
+		set[id] = true
+	}
+
+	return set
+}
+
+// ReferencedFilterListIDs returns the filter list IDs used by the persistent
+// clients that have their own filter lists.  The sets are nil if no client does.
+func (s *Storage) ReferencedFilterListIDs() (blockIDs, allowIDs map[rules.ListID]bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.index.rangeByName(func(c *Persistent) (cont bool) {
+		if !c.UseOwnFilterLists {
+			return true
+		}
+
+		blockIDs = addListIDs(blockIDs, c.FilterListIDs)
+		allowIDs = addListIDs(allowIDs, c.AllowFilterListIDs)
+
+		return true
+	})
+
+	return blockIDs, allowIDs
+}
+
+// addListIDs adds ids to set, allocating it if needed.
+func addListIDs(set map[rules.ListID]bool, ids []rules.ListID) (res map[rules.ListID]bool) {
+	res = set
+	for _, id := range ids {
+		if res == nil {
+			res = map[rules.ListID]bool{}
+		}
+
+		res[id] = true
+	}
+
+	return res
 }

--- a/internal/client/storage_test.go
+++ b/internal/client/storage_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/AdguardTeam/AdGuardHome/internal/dhcpd"
 	"github.com/AdguardTeam/AdGuardHome/internal/dhcpsvc"
 	"github.com/AdguardTeam/AdGuardHome/internal/dnsforward"
+	"github.com/AdguardTeam/AdGuardHome/internal/filtering"
 	"github.com/AdguardTeam/AdGuardHome/internal/whois"
 	"github.com/AdguardTeam/golibs/errors"
 	"github.com/AdguardTeam/golibs/hostsfile"
@@ -24,6 +25,7 @@ import (
 	"github.com/AdguardTeam/golibs/testutil/faketime"
 	"github.com/AdguardTeam/golibs/testutil/servicetest"
 	"github.com/AdguardTeam/golibs/timeutil"
+	"github.com/AdguardTeam/urlfilter/rules"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1289,6 +1291,107 @@ func TestStorage_CustomUpstreamConfig(t *testing.T) {
 		require.NotNil(t, secondConf)
 
 		assert.Same(t, firstConf, secondConf)
+	})
+}
+
+func TestStorage_ApplyClientFiltering_filterLists(t *testing.T) {
+	const (
+		cliName = "test_client"
+	)
+
+	cliIP := netip.MustParseAddr("1.1.1.1")
+
+	ctx := testutil.ContextWithTimeout(t, testTimeout)
+
+	t.Run("with_own_filter_lists", func(t *testing.T) {
+		s := newTestStorage(t, nil)
+		err := s.Add(ctx, &client.Persistent{
+			Name:               cliName,
+			IPs:                []netip.Addr{cliIP},
+			UID:                client.MustNewUID(),
+			UseOwnFilterLists:  true,
+			FilterListIDs:      []rules.ListID{1, 3},
+			AllowFilterListIDs: []rules.ListID{5},
+		})
+		require.NoError(t, err)
+
+		setts := &filtering.Settings{
+			ProtectionEnabled: true,
+			FilteringEnabled:  true,
+		}
+
+		s.ApplyClientFiltering("", cliIP, setts)
+
+		assert.True(t, setts.UseOwnFilterLists)
+		assert.Equal(t, map[rules.ListID]bool{1: true, 3: true}, setts.ClientFilterListIDs)
+		assert.Equal(t, map[rules.ListID]bool{5: true}, setts.ClientAllowListIDs)
+	})
+
+	t.Run("without_own_filter_lists", func(t *testing.T) {
+		s := newTestStorage(t, nil)
+		err := s.Add(ctx, &client.Persistent{
+			Name:              cliName,
+			IPs:               []netip.Addr{cliIP},
+			UID:               client.MustNewUID(),
+			UseOwnFilterLists: false,
+		})
+		require.NoError(t, err)
+
+		setts := &filtering.Settings{
+			ProtectionEnabled: true,
+			FilteringEnabled:  true,
+		}
+
+		s.ApplyClientFiltering("", cliIP, setts)
+
+		assert.False(t, setts.UseOwnFilterLists)
+		assert.Nil(t, setts.ClientFilterListIDs)
+		assert.Nil(t, setts.ClientAllowListIDs)
+	})
+}
+
+func TestStorage_ReferencedFilterListIDs(t *testing.T) {
+	ctx := testutil.ContextWithTimeout(t, testTimeout)
+
+	t.Run("no_clients_with_own_lists", func(t *testing.T) {
+		s := newTestStorage(t, nil)
+		err := s.Add(ctx, &client.Persistent{
+			Name:          "global",
+			IPs:           []netip.Addr{netip.MustParseAddr("1.1.1.1")},
+			UID:           client.MustNewUID(),
+			FilterListIDs: []rules.ListID{1},
+		})
+		require.NoError(t, err)
+
+		blockIDs, allowIDs := s.ReferencedFilterListIDs()
+		assert.Nil(t, blockIDs)
+		assert.Nil(t, allowIDs)
+	})
+
+	t.Run("union_of_clients", func(t *testing.T) {
+		s := newTestStorage(t, nil)
+		err := s.Add(ctx, &client.Persistent{
+			Name:               "first",
+			IPs:                []netip.Addr{netip.MustParseAddr("1.1.1.1")},
+			UID:                client.MustNewUID(),
+			UseOwnFilterLists:  true,
+			FilterListIDs:      []rules.ListID{1, 2},
+			AllowFilterListIDs: []rules.ListID{10},
+		})
+		require.NoError(t, err)
+
+		err = s.Add(ctx, &client.Persistent{
+			Name:              "second",
+			IPs:               []netip.Addr{netip.MustParseAddr("2.2.2.2")},
+			UID:               client.MustNewUID(),
+			UseOwnFilterLists: true,
+			FilterListIDs:     []rules.ListID{2, 3},
+		})
+		require.NoError(t, err)
+
+		blockIDs, allowIDs := s.ReferencedFilterListIDs()
+		assert.Equal(t, map[rules.ListID]bool{1: true, 2: true, 3: true}, blockIDs)
+		assert.Equal(t, map[rules.ListID]bool{10: true}, allowIDs)
 	})
 }
 

--- a/internal/filtering/filter.go
+++ b/internal/filtering/filter.go
@@ -21,6 +21,7 @@ import (
 	"github.com/AdguardTeam/golibs/errors"
 	"github.com/AdguardTeam/golibs/ioutil"
 	"github.com/AdguardTeam/golibs/logutil/slogutil"
+	"github.com/AdguardTeam/urlfilter/rules"
 )
 
 // filterDir is the subdirectory of a data directory to store downloaded
@@ -119,19 +120,19 @@ func (d *DNSFilter) filterSetProperties(
 		"filter_url", flt.URL,
 	)
 
-	defer func(oldURL, oldName string, oldEnabled bool, oldUpdated time.Time, oldRulesCount int) {
+	// Restore the whole entry on failure, including the checksum, so that a
+	// failed update doesn't leave metadata that disagrees with the contents on
+	// disk.
+	defer func(old FilterYAML) {
 		if err != nil {
-			flt.URL = oldURL
-			flt.Name = oldName
-			flt.Enabled = oldEnabled
-			flt.LastUpdated = oldUpdated
-			flt.RulesCount = oldRulesCount
+			*flt = old
 		}
-	}(flt.URL, flt.Name, flt.Enabled, flt.LastUpdated, flt.RulesCount)
+	}(*flt)
 
 	flt.Name = newList.Name
 
-	if flt.URL != newList.URL {
+	urlChanged := flt.URL != newList.URL
+	if urlChanged {
 		if d.filterExistsLocked(newList.URL) {
 			return false, errFilterExists
 		}
@@ -148,12 +149,10 @@ func (d *DNSFilter) filterSetProperties(
 		shouldRestart = true
 	}
 
-	if !flt.Enabled {
-		// TODO(e.burkov):  The validation of the contents of the new URL is
-		// currently skipped if the rule list is disabled.  This makes it
-		// possible to set a bad rules source, but the validation should still
-		// kick in when the filter is enabled.  Consider changing this behavior
-		// to be stricter.
+	if d.shouldUnload(flt, isAllowlist, urlChanged) {
+		// TODO(e.burkov):  The contents of a rule list that stays out of the
+		// engine are not validated, which makes it possible to keep a bad rules
+		// source.  Consider changing this behavior to be stricter.
 		flt.unload()
 
 		return shouldRestart, err
@@ -163,7 +162,7 @@ func (d *DNSFilter) filterSetProperties(
 		return false, nil
 	}
 
-	return d.update(flt)
+	return d.update(flt, urlChanged)
 }
 
 // filterExists returns true if a filter with the same url exists in d.  It's
@@ -218,9 +217,14 @@ func (d *DNSFilter) filterAdd(flt FilterYAML) (err error) {
 	return nil
 }
 
-// Load filters from the disk
-// And if any filter has zero ID, assign a new one
-func (d *DNSFilter) loadFilters(ctx context.Context, array []FilterYAML) {
+// loadFilters loads filters from the disk and assigns a new ID to any filter
+// that has a zero one.  A disabled filter is only loaded if clientIDs contains
+// it, since a client may use a filter that is disabled globally.
+func (d *DNSFilter) loadFilters(
+	ctx context.Context,
+	array []FilterYAML,
+	clientIDs map[rules.ListID]bool,
+) {
 	for i := range array {
 		filter := &array[i] // otherwise we're operating on a copy
 		if filter.ID == 0 {
@@ -230,8 +234,7 @@ func (d *DNSFilter) loadFilters(ctx context.Context, array []FilterYAML) {
 			filter.ID = newID
 		}
 
-		if !filter.Enabled {
-			// No need to load a filter that is not enabled
+		if !filter.Enabled && !clientIDs[filter.ID] {
 			continue
 		}
 
@@ -273,8 +276,13 @@ func (d *DNSFilter) tryRefreshFilters(block, allow, force bool) (updated int, is
 	return updated, isNetworkErr, ok
 }
 
-// listsToUpdate returns the slice of filter lists that could be updated.
-func (d *DNSFilter) listsToUpdate(filters *[]FilterYAML, force bool) (toUpd []FilterYAML) {
+// listsToUpdate returns the slice of filter lists that could be updated.  A
+// disabled filter list is only updated if clientIDs contains it.
+func (d *DNSFilter) listsToUpdate(
+	filters *[]FilterYAML,
+	clientIDs map[rules.ListID]bool,
+	force bool,
+) (toUpd []FilterYAML) {
 	now := time.Now()
 
 	d.conf.filtersMu.RLock()
@@ -283,7 +291,7 @@ func (d *DNSFilter) listsToUpdate(filters *[]FilterYAML, force bool) (toUpd []Fi
 	for i := range *filters {
 		flt := &(*filters)[i] // otherwise we will be operating on a copy
 
-		if !flt.Enabled {
+		if !flt.Enabled && !clientIDs[flt.ID] {
 			continue
 		}
 
@@ -313,9 +321,10 @@ func (d *DNSFilter) listsToUpdate(filters *[]FilterYAML, force bool) (toUpd []Fi
 func (d *DNSFilter) refreshFiltersArray(
 	ctx context.Context,
 	filters *[]FilterYAML,
+	clientIDs map[rules.ListID]bool,
 	force bool,
 ) (updateCount int, updateFilters []FilterYAML, updateFlags []bool, isNetErr bool) {
-	updateFilters = d.listsToUpdate(filters, force)
+	updateFilters = d.listsToUpdate(filters, clientIDs, force)
 	if len(updateFilters) == 0 {
 		return 0, nil, nil, false
 	}
@@ -342,7 +351,7 @@ func (d *DNSFilter) updateFilterList(
 ) (failNum int, updateFlags []bool) {
 	for i := range updateFilters {
 		uf := &updateFilters[i]
-		updated, err := d.update(uf)
+		updated, err := d.update(uf, false)
 		updateFlags = append(updateFlags, updated)
 		if err != nil {
 			failNum++
@@ -426,13 +435,15 @@ func (d *DNSFilter) refreshFiltersIntl(block, allow, force bool) (int, bool) {
 	var toUpd []bool
 	isNetErr := false
 
+	blockIDs, allowIDs := d.clientFilterListIDs()
 	if block {
-		updNum, lists, toUpd, isNetErr = d.refreshFiltersArray(ctx, &d.conf.Filters, force)
+		updNum, lists, toUpd, isNetErr = d.refreshFiltersArray(ctx, &d.conf.Filters, blockIDs, force)
 	}
 	if allow {
 		updNumAl, listsAl, toUpdAl, isNetErrAl := d.refreshFiltersArray(
 			ctx,
 			&d.conf.WhitelistFilters,
+			allowIDs,
 			force,
 		)
 
@@ -477,10 +488,10 @@ func removeOldFilterFile(ctx context.Context, l *slog.Logger, fltPath string) {
 }
 
 // update refreshes filter's content and a/mtimes of it's file.
-func (d *DNSFilter) update(filter *FilterYAML) (b bool, err error) {
+func (d *DNSFilter) update(filter *FilterYAML, replace bool) (b bool, err error) {
 	ctx := context.TODO()
 
-	b, err = d.updateIntl(ctx, filter)
+	b, err = d.updateIntl(ctx, filter, replace)
 	filter.LastUpdated = time.Now()
 	if !b {
 		chErr := os.Chtimes(
@@ -497,8 +508,13 @@ func (d *DNSFilter) update(filter *FilterYAML) (b bool, err error) {
 }
 
 // updateIntl updates the flt rewriting it's actual file.  It returns true if
-// the actual update has been performed.  flt must not be nil.
-func (d *DNSFilter) updateIntl(ctx context.Context, flt *FilterYAML) (ok bool, err error) {
+// the actual update has been performed.  When replace is true, the contents are
+// saved even if they parse to the same checksum.  flt must not be nil.
+func (d *DNSFilter) updateIntl(
+	ctx context.Context,
+	flt *FilterYAML,
+	replace bool,
+) (ok bool, err error) {
 	d.logger.DebugContext(ctx, "downloading update for filter", "id", flt.ID, "url", flt.URL)
 
 	var res *rulelist.ParseResult
@@ -524,7 +540,7 @@ func (d *DNSFilter) updateIntl(ctx context.Context, flt *FilterYAML) (ok bool, e
 		return false, err
 	}
 
-	return res.Checksum != flt.checksum, nil
+	return replace || res.Checksum != flt.checksum, nil
 }
 
 // readFromHTTP reads filter data from urlStr via HTTP and parses it into the
@@ -660,51 +676,285 @@ func (d *DNSFilter) load(ctx context.Context, flt *FilterYAML) (err error) {
 	return nil
 }
 
+// appendEnabledFilters appends to orig the filters that must be put into the
+// engine, that is the enabled ones and those that clientIDs contains, and
+// returns the set of enabled IDs among them.  enabledIDs is nil if every
+// appended filter is enabled, in which case matching needs no ID filtering.
+func appendEnabledFilters(
+	orig []Filter,
+	flts []FilterYAML,
+	clientIDs map[rules.ListID]bool,
+	dataDir string,
+) (res []Filter, enabledIDs map[rules.ListID]bool) {
+	res = orig
+	ids := make(map[rules.ListID]bool, len(flts))
+	hasDisabled := false
+
+	for _, flt := range flts {
+		if flt.Enabled {
+			ids[flt.ID] = true
+		} else if clientIDs[flt.ID] {
+			hasDisabled = true
+		} else {
+			continue
+		}
+
+		res = append(res, Filter{
+			ID:       flt.ID,
+			FilePath: flt.Path(dataDir),
+		})
+	}
+
+	if !hasDisabled {
+		return res, nil
+	}
+
+	return res, ids
+}
+
+// shouldUnload reports whether flt must be kept out of the engine, that is when
+// it is disabled and no client uses it.  A filter with a new URL is always
+// fetched, since the file on disk is named after the ID and would otherwise keep
+// the rules of the previous source.
+func (d *DNSFilter) shouldUnload(flt *FilterYAML, isAllowlist, urlChanged bool) (ok bool) {
+	return !urlChanged && !flt.Enabled && !d.clientListIDs(isAllowlist)[flt.ID]
+}
+
+// clientListIDs is like [DNSFilter.clientFilterListIDs], but returns the IDs of
+// either the allowing or the blocking filter lists.
+func (d *DNSFilter) clientListIDs(isAllowlist bool) (ids map[rules.ListID]bool) {
+	blockIDs, allowIDs := d.clientFilterListIDs()
+	if isAllowlist {
+		return allowIDs
+	}
+
+	return blockIDs
+}
+
+// clientFilterListIDs returns the filter list IDs used by clients that have
+// their own filter lists, or nil sets if no client does.
+func (d *DNSFilter) clientFilterListIDs() (blockIDs, allowIDs map[rules.ListID]bool) {
+	if d.conf.ClientFilterListIDs == nil {
+		return nil, nil
+	}
+
+	return d.conf.ClientFilterListIDs()
+}
+
+// needRefresh returns the disabled filters of flts that next references and the
+// engine cannot enforce yet, that is the ones no client referenced before and
+// the ones whose cache is missing.  A cache can be absent because the list was
+// never downloadable, in which case being referenced already is not enough.
+// d.conf.filtersMu is expected to be locked.
+func (d *DNSFilter) needRefresh(
+	flts []FilterYAML,
+	prev, next map[rules.ListID]bool,
+) (res []*FilterYAML) {
+	for i := range flts {
+		flt := &flts[i] // otherwise we're operating on a copy
+		if flt.Enabled || !next[flt.ID] {
+			continue
+		}
+
+		if !prev[flt.ID] {
+			res = append(res, flt)
+
+			continue
+		}
+
+		if _, err := os.Stat(flt.Path(d.conf.DataDir)); err != nil {
+			res = append(res, flt)
+		}
+	}
+
+	return res
+}
+
+// refreshReferenced downloads flts, so that a list a client has just picked has
+// contents to match against even when its cache is absent or stale.  A refresh
+// that fails while a cached copy exists is only logged, since that copy is
+// enough to enforce the policy.  d.conf.filtersMu is expected to be locked for
+// writing.
+func (d *DNSFilter) refreshReferenced(ctx context.Context, flts []*FilterYAML) (errs []error) {
+	for _, flt := range flts {
+		_, err := d.update(flt, true)
+		if err == nil {
+			continue
+		}
+
+		if _, statErr := os.Stat(flt.Path(d.conf.DataDir)); statErr != nil {
+			errs = append(errs, fmt.Errorf("filter %d: %w", flt.ID, err))
+
+			continue
+		}
+
+		d.logger.WarnContext(
+			ctx,
+			"refreshing client filter list, keeping cached copy",
+			"id", flt.ID,
+			slogutil.KeyError, err,
+		)
+	}
+
+	return errs
+}
+
+// loadedListIDs returns the rule lists the engines currently hold.
+func (d *DNSFilter) loadedListIDs() (ids map[rules.ListID]bool) {
+	d.engineLock.RLock()
+	defer d.engineLock.RUnlock()
+
+	return unionListIDs(d.loadedBlockIDs, d.loadedAllowIDs)
+}
+
+// unionListIDs returns the union of a and b.  It doesn't modify either.
+func unionListIDs(a, b map[rules.ListID]bool) (res map[rules.ListID]bool) {
+	res = make(map[rules.ListID]bool, len(a)+len(b))
+	for id := range a {
+		res[id] = true
+	}
+
+	for id := range b {
+		res[id] = true
+	}
+
+	return res
+}
+
+// ErrUnknownListID is returned when a client references a filter list that is
+// not configured, or one of the wrong kind.
+const ErrUnknownListID errors.Error = "unknown filter list id"
+
+// validateListIDs returns an error if ids names a list absent from flts.  A
+// client whose policy names a list the engine cannot hold would match neither
+// that list nor the global ones, so such a request is rejected instead.
+// d.conf.filtersMu is expected to be locked.
+func validateListIDs(flts []FilterYAML, ids map[rules.ListID]bool, kind string) (err error) {
+	var errs []error
+	for id := range ids {
+		if id == rulelist.IDCustom {
+			continue
+		}
+
+		if !slices.ContainsFunc(flts, func(f FilterYAML) (ok bool) { return f.ID == id }) {
+			errs = append(errs, fmt.Errorf("%s %d: %w", kind, id, ErrUnknownListID))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// SetClientFilterLists puts the filter lists that blockIDs and allowIDs
+// reference into the engine, downloading the disabled ones that no client used
+// before.  It does nothing when the engine already holds them all.
+//
+// It must be called before a client configuration that relies on those lists
+// becomes observable, since a policy naming a list the engine doesn't hold
+// matches neither that list nor the global ones.  Lists that no client uses
+// anymore are pruned by a later [DNSFilter.EnableFilters].
+func (d *DNSFilter) SetClientFilterLists(
+	ctx context.Context,
+	blockIDs, allowIDs map[rules.ListID]bool,
+) (err error) {
+	d.conf.filtersMu.Lock()
+	defer d.conf.filtersMu.Unlock()
+
+	err = errors.Join(
+		validateListIDs(d.conf.Filters, blockIDs, "blocking filter list"),
+		validateListIDs(d.conf.WhitelistFilters, allowIDs, "allowing filter list"),
+	)
+	if err != nil {
+		return err
+	}
+
+	prevBlock, prevAllow := d.clientFilterListIDs()
+
+	newBlock := d.needRefresh(d.conf.Filters, prevBlock, blockIDs)
+	newAllow := d.needRefresh(d.conf.WhitelistFilters, prevAllow, allowIDs)
+	if len(newBlock) == 0 && len(newAllow) == 0 {
+		return nil
+	}
+
+	errs := d.refreshReferenced(ctx, newBlock)
+	errs = append(errs, d.refreshReferenced(ctx, newAllow)...)
+	if err = errors.Join(errs...); err != nil {
+		return fmt.Errorf("refreshing client filter lists: %w", err)
+	}
+
+	// Require the lists the engines hold today plus the ones this policy names,
+	// so that a file that vanished cannot silently drop a live list, while a list
+	// that was already absent stays tolerated.
+	required := unionListIDs(d.loadedListIDs(), unionListIDs(blockIDs, allowIDs))
+
+	// Keep the lists that clients use today as well, so that the rebuild never
+	// drops a policy that is still published.
+	err = d.enableFiltersLocked(
+		ctx,
+		unionListIDs(prevBlock, blockIDs),
+		unionListIDs(prevAllow, allowIDs),
+		required,
+		false,
+	)
+	if err != nil {
+		return fmt.Errorf("rebuilding with client filter lists: %w", err)
+	}
+
+	return nil
+}
+
 // EnableFilters enables filters.
 func (d *DNSFilter) EnableFilters(async bool) {
 	d.conf.filtersMu.RLock()
 	defer d.conf.filtersMu.RUnlock()
 
-	d.enableFiltersLocked(context.TODO(), async)
+	ctx := context.TODO()
+	blockIDs, allowIDs := d.clientFilterListIDs()
+
+	err := d.enableFiltersLocked(ctx, blockIDs, allowIDs, nil, async)
+	if err != nil {
+		d.logger.ErrorContext(ctx, "enabling filters", slogutil.KeyError, err)
+	}
 }
 
-// enableFiltersLocked enables filters under the conf.filtersMu lock.
-func (d *DNSFilter) enableFiltersLocked(ctx context.Context, async bool) {
+// enableFiltersLocked enables filters under the conf.filtersMu lock.  The
+// clientIDs sets tell which disabled lists must still be put into the engine
+// because a client uses them.
+func (d *DNSFilter) enableFiltersLocked(
+	ctx context.Context,
+	blockClientIDs, allowClientIDs map[rules.ListID]bool,
+	requiredIDs map[rules.ListID]bool,
+	async bool,
+) (err error) {
 	filters := make([]Filter, 1, len(d.conf.Filters)+len(d.conf.WhitelistFilters)+1)
 	filters[0] = Filter{
 		ID:   rulelist.IDCustom,
 		Data: []byte(strings.Join(d.conf.UserRules, "\n")),
 	}
 
-	for _, filter := range d.conf.Filters {
-		if !filter.Enabled {
-			continue
-		}
+	filters, enabledBlockIDs := appendEnabledFilters(
+		filters,
+		d.conf.Filters,
+		blockClientIDs,
+		d.conf.DataDir,
+	)
+	allowFilters, enabledAllowIDs := appendEnabledFilters(
+		nil,
+		d.conf.WhitelistFilters,
+		allowClientIDs,
+		d.conf.DataDir,
+	)
 
-		filters = append(filters, Filter{
-			ID:       filter.ID,
-			FilePath: filter.Path(d.conf.DataDir),
-		})
-	}
-
-	var allowFilters []Filter
-	for _, filter := range d.conf.WhitelistFilters {
-		if !filter.Enabled {
-			continue
-		}
-
-		allowFilters = append(allowFilters, Filter{
-			ID:       filter.ID,
-			FilePath: filter.Path(d.conf.DataDir),
-		})
-	}
-
-	err := d.setFilters(ctx, filters, allowFilters, async)
-	if err != nil {
-		d.logger.ErrorContext(ctx, "enabling filters", slogutil.KeyError, err)
-	}
+	err = d.setFilters(ctx, &filtersInitializerParams{
+		enabledBlockIDs: enabledBlockIDs,
+		enabledAllowIDs: enabledAllowIDs,
+		allowFilters:    allowFilters,
+		blockFilters:    filters,
+		requiredIDs:     requiredIDs,
+	}, async)
 
 	d.SetEnabled(d.conf.FilteringEnabled)
+
+	return err
 }
 
 // ApplyAdditionalFiltering enhances the provided filtering settings with

--- a/internal/filtering/filter_internal_test.go
+++ b/internal/filtering/filter_internal_test.go
@@ -7,11 +7,15 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
+	"github.com/AdguardTeam/AdGuardHome/internal/aghos"
 	"github.com/AdguardTeam/golibs/netutil/urlutil"
 	"github.com/AdguardTeam/golibs/testutil"
+	"github.com/AdguardTeam/urlfilter/rules"
 	"github.com/c2h5oh/datasize"
+	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -61,7 +65,7 @@ func updateAndAssert(
 ) {
 	tb.Helper()
 
-	ok, err := dnsFilter.update(f)
+	ok, err := dnsFilter.update(f, false)
 	require.NoError(tb, err)
 	wantUpd(tb, ok)
 
@@ -179,4 +183,547 @@ func TestFilterYAML_EnsureName(t *testing.T) {
 		updateAndAssert(t, ctx, dnsFilter, f, require.True, 1)
 		assert.Equal(t, "List 0", f.Name)
 	})
+}
+
+// Rules used by the URL change tests.
+const (
+	oldRule = "||old.example^"
+	newRule = "||new.example^"
+)
+
+// newClientListFilter is a helper that returns a DNS filter holding a single
+// enabled rule list downloaded from addr, along with the list itself.  white
+// tells whether the list is an allowing one.
+func newClientListFilter(
+	tb testing.TB,
+	white bool,
+	addr string,
+) (d *DNSFilter, flt *FilterYAML) {
+	tb.Helper()
+
+	d = newDNSFilter(tb)
+	tb.Cleanup(d.Close)
+
+	flt = &FilterYAML{
+		Filter:  Filter{ID: 1},
+		URL:     addr,
+		Name:    "test-filter",
+		Enabled: true,
+		white:   white,
+	}
+
+	_, err := d.update(flt, false)
+	require.NoError(tb, err)
+
+	if white {
+		d.conf.WhitelistFilters = []FilterYAML{*flt}
+	} else {
+		d.conf.Filters = []FilterYAML{*flt}
+	}
+
+	d.conf.ClientFilterListIDs = clientListIDsFunc(white, map[rules.ListID]bool{flt.ID: true})
+
+	return d, flt
+}
+
+// disableAndRepoint disables the only rule list of d while no client uses it,
+// then points it at newAddr.
+func disableAndRepoint(tb testing.TB, d *DNSFilter, flt *FilterYAML, newAddr string) (err error) {
+	tb.Helper()
+
+	// Drop the client reference, so that the list stays out of the engine.
+	d.conf.ClientFilterListIDs = nil
+
+	_, err = d.filterSetProperties(flt.URL, FilterYAML{
+		Name:    flt.Name,
+		URL:     flt.URL,
+		Enabled: false,
+	}, flt.white)
+	require.NoError(tb, err)
+
+	_, err = d.filterSetProperties(flt.URL, FilterYAML{
+		Name:    flt.Name,
+		URL:     newAddr,
+		Enabled: false,
+	}, flt.white)
+
+	return err
+}
+
+// clientListIDsFunc returns a [Config.ClientFilterListIDs] that reports ids as
+// used by clients, as either allowing or blocking lists.
+func clientListIDsFunc(
+	white bool,
+	ids map[rules.ListID]bool,
+) (f func() (blockIDs, allowIDs map[rules.ListID]bool)) {
+	return func() (blockIDs, allowIDs map[rules.ListID]bool) {
+		if white {
+			return nil, ids
+		}
+
+		return ids, nil
+	}
+}
+
+func TestDNSFilter_filterSetProperties_disabledURLChange(t *testing.T) {
+	const comments = "! Title: Empty list\n! Nothing to see here\n"
+
+	testCases := []struct {
+		name            string
+		newContent      string
+		white           bool
+		wantOldFiltered bool
+		wantNewFiltered bool
+	}{{
+		name:            "blocklist_non_empty",
+		newContent:      newRule + "\n",
+		white:           false,
+		wantOldFiltered: false,
+		wantNewFiltered: true,
+	}, {
+		name:            "blocklist_empty",
+		newContent:      "",
+		white:           false,
+		wantOldFiltered: false,
+		wantNewFiltered: false,
+	}, {
+		name:            "blocklist_comments_only",
+		newContent:      comments,
+		white:           false,
+		wantOldFiltered: false,
+		wantNewFiltered: false,
+	}, {
+		name:            "allowlist_non_empty",
+		newContent:      "@@" + newRule + "\n",
+		white:           true,
+		wantOldFiltered: true,
+		wantNewFiltered: false,
+	}, {
+		name:            "allowlist_empty",
+		newContent:      "",
+		white:           true,
+		wantOldFiltered: true,
+		wantNewFiltered: true,
+	}, {
+		name:            "allowlist_comments_only",
+		newContent:      comments,
+		white:           true,
+		wantOldFiltered: true,
+		wantNewFiltered: true,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, setts := repointDisabledList(t, tc.white, tc.newContent)
+
+			res, err := d.CheckHost("old.example", dns.TypeA, setts)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantOldFiltered, res.IsFiltered, "old.example")
+
+			res, err = d.CheckHost("new.example", dns.TypeA, setts)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantNewFiltered, res.IsFiltered, "new.example")
+		})
+	}
+}
+
+// repointDisabledList downloads a rule list holding oldRule, disables it while no
+// client uses it, points it at a source serving newContent, and assigns it back
+// to a client.  It returns the filter and the client settings to match with.
+func repointDisabledList(
+	t *testing.T,
+	white bool,
+	newContent string,
+) (d *DNSFilter, setts *Settings) {
+	t.Helper()
+
+	ctx := testutil.ContextWithTimeout(t, testTimeout)
+
+	prefix := ""
+	if white {
+		prefix = "@@"
+	}
+
+	oldAddr := serveFiltersLocally(t, []byte(prefix+oldRule+"\n"))
+	newAddr := serveFiltersLocally(t, []byte(newContent))
+
+	d, flt := newClientListFilter(t, white, oldAddr)
+	require.NoError(t, disableAndRepoint(t, d, flt, newAddr))
+
+	ids := map[rules.ListID]bool{flt.ID: true}
+	d.conf.ClientFilterListIDs = clientListIDsFunc(white, ids)
+	blockIDs, allowIDs := d.clientFilterListIDs()
+
+	setts = &Settings{
+		ProtectionEnabled: true,
+		FilteringEnabled:  true,
+		UseOwnFilterLists: true,
+	}
+
+	if white {
+		setts.ClientAllowListIDs = ids
+		// Block both hosts globally, so that only an allowing rule can change
+		// the outcome.
+		d.conf.UserRules = []string{oldRule, newRule}
+	} else {
+		setts.ClientFilterListIDs = ids
+	}
+
+	_ = d.enableFiltersLocked(ctx, blockIDs, allowIDs, nil, false)
+
+	return d, setts
+}
+
+func TestDNSFilter_filterSetProperties_urlChangeRollback(t *testing.T) {
+	oldAddr := serveFiltersLocally(t, []byte(oldRule+"\n"))
+	badAddr := serveHTTPLocally(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	d, flt := newClientListFilter(t, false, oldAddr)
+
+	// Drop the client reference, so that the list stays out of the engine.
+	d.conf.ClientFilterListIDs = nil
+
+	_, err := d.filterSetProperties(flt.URL, FilterYAML{
+		Name:    flt.Name,
+		URL:     flt.URL,
+		Enabled: false,
+	}, false)
+	require.NoError(t, err)
+
+	before := d.conf.Filters[0]
+
+	_, err = d.filterSetProperties(flt.URL, FilterYAML{
+		Name:    flt.Name,
+		URL:     badAddr,
+		Enabled: false,
+	}, false)
+	require.Error(t, err)
+
+	// A failed download must leave the entry exactly as it was, so that the
+	// metadata keeps agreeing with the contents on disk.
+	assert.Equal(t, before, d.conf.Filters[0])
+	assert.FileExists(t, d.conf.Filters[0].Path(d.conf.DataDir))
+}
+
+// newDisabledListFilter returns a DNS filter whose only rule list is disabled and
+// unreferenced, served from addr.  The list is left out of the engine, as it
+// would be after a restart.
+func newDisabledListFilter(tb testing.TB, addr string) (d *DNSFilter, id rules.ListID) {
+	tb.Helper()
+
+	d = newDNSFilter(tb)
+	tb.Cleanup(d.Close)
+
+	id = 1
+	d.conf.Filters = []FilterYAML{{
+		Filter:  Filter{ID: id},
+		URL:     addr,
+		Name:    "test-filter",
+		Enabled: false,
+	}}
+
+	// Never refresh on a timer, as with filters_update_interval set to zero.
+	d.conf.FiltersUpdateIntervalHours = 0
+
+	ctx := testutil.ContextWithTimeout(tb, testTimeout)
+	_ = d.enableFiltersLocked(ctx, nil, nil, nil, false)
+
+	return d, id
+}
+
+// clientSettings returns the settings of a client using only the blocking list
+// ids.
+func clientSettings(ids ...rules.ListID) (setts *Settings) {
+	set := make(map[rules.ListID]bool, len(ids))
+	for _, id := range ids {
+		set[id] = true
+	}
+
+	return &Settings{
+		ProtectionEnabled:   true,
+		FilteringEnabled:    true,
+		UseOwnFilterLists:   true,
+		ClientFilterListIDs: set,
+	}
+}
+
+func TestDNSFilter_SetClientFilterLists(t *testing.T) {
+	t.Run("absent_cache", func(t *testing.T) {
+		ctx := testutil.ContextWithTimeout(t, testTimeout)
+		addr := serveFiltersLocally(t, []byte(newRule+"\n"))
+
+		d, id := newDisabledListFilter(t, addr)
+		setts := clientSettings(id)
+
+		// Nothing is cached yet, so the promised list cannot match.
+		res, err := d.CheckHost("new.example", dns.TypeA, setts)
+		require.NoError(t, err)
+		require.False(t, res.IsFiltered)
+
+		ids := map[rules.ListID]bool{id: true}
+		require.NoError(t, d.SetClientFilterLists(ctx, ids, nil))
+
+		// The list must be downloaded and live once the call returns, since the
+		// client policy is published right after.
+		require.FileExists(t, d.conf.Filters[0].Path(d.conf.DataDir))
+
+		res, err = d.CheckHost("new.example", dns.TypeA, setts)
+		require.NoError(t, err)
+		assert.True(t, res.IsFiltered)
+	})
+
+	t.Run("stale_cache", func(t *testing.T) {
+		ctx := testutil.ContextWithTimeout(t, testTimeout)
+
+		// Serve the new rule, but leave the old one cached on disk.
+		addr := serveFiltersLocally(t, []byte(newRule+"\n"))
+		d, id := newDisabledListFilter(t, addr)
+
+		path := d.conf.Filters[0].Path(d.conf.DataDir)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), aghos.DefaultPermDir))
+		require.NoError(t, os.WriteFile(path, []byte(oldRule+"\n"), aghos.DefaultPermFile))
+
+		ids := map[rules.ListID]bool{id: true}
+		require.NoError(t, d.SetClientFilterLists(ctx, ids, nil))
+
+		setts := clientSettings(id)
+
+		res, err := d.CheckHost("new.example", dns.TypeA, setts)
+		require.NoError(t, err)
+		assert.True(t, res.IsFiltered, "the refreshed rule must apply")
+
+		res, err = d.CheckHost("old.example", dns.TypeA, setts)
+		require.NoError(t, err)
+		assert.False(t, res.IsFiltered, "the stale rule must be gone")
+	})
+
+	t.Run("already_referenced_but_cache_gone", func(t *testing.T) {
+		ctx := testutil.ContextWithTimeout(t, testTimeout)
+		addr := serveFiltersLocally(t, []byte(newRule+"\n"))
+
+		d, id := newDisabledListFilter(t, addr)
+		ids := map[rules.ListID]bool{id: true}
+
+		// A client already uses the list, but its cache never made it to disk,
+		// so being referenced is not enough to consider it enforceable.
+		d.conf.ClientFilterListIDs = func() (blockIDs, allowIDs map[rules.ListID]bool) {
+			return ids, nil
+		}
+
+		require.NoError(t, d.SetClientFilterLists(ctx, ids, nil))
+		require.FileExists(t, d.conf.Filters[0].Path(d.conf.DataDir))
+
+		res, err := d.CheckHost("new.example", dns.TypeA, clientSettings(id))
+		require.NoError(t, err)
+		assert.True(t, res.IsFiltered)
+	})
+
+	t.Run("download_failure_with_cache", func(t *testing.T) {
+		ctx := testutil.ContextWithTimeout(t, testTimeout)
+		addr := serveHTTPLocally(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+
+		d, id := newDisabledListFilter(t, addr)
+
+		// A cached copy is enough to enforce the policy, so a failed refresh
+		// must not block the client update.
+		path := d.conf.Filters[0].Path(d.conf.DataDir)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), aghos.DefaultPermDir))
+		require.NoError(t, os.WriteFile(path, []byte(newRule+"\n"), aghos.DefaultPermFile))
+
+		require.NoError(t, d.SetClientFilterLists(ctx, map[rules.ListID]bool{id: true}, nil))
+
+		res, err := d.CheckHost("new.example", dns.TypeA, clientSettings(id))
+		require.NoError(t, err)
+		assert.True(t, res.IsFiltered, "the cached rule must apply")
+	})
+
+	t.Run("download_failure_no_cache", func(t *testing.T) {
+		ctx := testutil.ContextWithTimeout(t, testTimeout)
+		addr := serveHTTPLocally(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+
+		d, id := newDisabledListFilter(t, addr)
+
+		// The caller must learn about it and keep the policy unpublished.
+		err := d.SetClientFilterLists(ctx, map[rules.ListID]bool{id: true}, nil)
+		require.Error(t, err)
+
+		assert.NoFileExists(t, d.conf.Filters[0].Path(d.conf.DataDir))
+	})
+}
+
+// TestDNSFilter_SetClientFilterLists_transition asserts that moving a client
+// from the global lists onto a globally disabled one never leaves it matching
+// neither policy.  The engine must hold both the old and the prospective lists
+// by the time the call returns, since the client policy is published right
+// after.
+func TestDNSFilter_SetClientFilterLists_transition(t *testing.T) {
+	ctx := testutil.ContextWithTimeout(t, testTimeout)
+
+	globalAddr := serveFiltersLocally(t, []byte(oldRule+"\n"))
+	ownAddr := serveFiltersLocally(t, []byte(newRule+"\n"))
+
+	const (
+		globalID rules.ListID = 1
+		ownID    rules.ListID = 2
+	)
+
+	d := newDNSFilter(t)
+	t.Cleanup(d.Close)
+
+	globalFlt := FilterYAML{
+		Filter:  Filter{ID: globalID},
+		URL:     globalAddr,
+		Name:    "global-filter",
+		Enabled: true,
+	}
+	_, err := d.update(&globalFlt, false)
+	require.NoError(t, err)
+
+	d.conf.Filters = []FilterYAML{globalFlt, {
+		Filter:  Filter{ID: ownID},
+		URL:     ownAddr,
+		Name:    "own-filter",
+		Enabled: false,
+	}}
+	d.conf.FiltersUpdateIntervalHours = 0
+	_ = d.enableFiltersLocked(ctx, nil, nil, nil, false)
+
+	globalSetts := &Settings{ProtectionEnabled: true, FilteringEnabled: true}
+
+	// The client starts on the global lists.
+	res, err := d.CheckHost("old.example", dns.TypeA, globalSetts)
+	require.NoError(t, err)
+	require.True(t, res.IsFiltered)
+
+	require.NoError(t, d.SetClientFilterLists(ctx, map[rules.ListID]bool{ownID: true}, nil))
+
+	// The global list must still be enforceable for everyone else, and the newly
+	// referenced one must already work for the client about to be stored.
+	res, err = d.CheckHost("old.example", dns.TypeA, globalSetts)
+	require.NoError(t, err)
+	assert.True(t, res.IsFiltered, "the global list must stay live during the transition")
+
+	ownSetts := clientSettings(ownID)
+
+	res, err = d.CheckHost("new.example", dns.TypeA, ownSetts)
+	require.NoError(t, err)
+	assert.True(t, res.IsFiltered, "the newly referenced list must already be enforceable")
+}
+
+// TestDNSFilter_SetClientFilterLists_noop asserts that saving a client whose
+// lists the engine already holds neither downloads anything nor rebuilds, so
+// that an unrelated edit stays cheap.
+func TestDNSFilter_SetClientFilterLists_noop(t *testing.T) {
+	ctx := testutil.ContextWithTimeout(t, testTimeout)
+
+	var hits atomic.Int64
+	addr := serveHTTPLocally(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte(newRule + "\n"))
+	}))
+
+	const id rules.ListID = 1
+
+	d := newDNSFilter(t)
+	t.Cleanup(d.Close)
+
+	// An enabled list is always in the engine, so referencing it changes
+	// nothing.
+	flt := FilterYAML{
+		Filter:  Filter{ID: id},
+		URL:     addr,
+		Name:    "test-filter",
+		Enabled: true,
+	}
+	_, err := d.update(&flt, false)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), hits.Load())
+
+	d.conf.Filters = []FilterYAML{flt}
+	_ = d.enableFiltersLocked(ctx, nil, nil, nil, false)
+
+	require.NoError(t, d.SetClientFilterLists(ctx, map[rules.ListID]bool{id: true}, nil))
+
+	assert.Equal(t, int64(1), hits.Load(), "an enabled list must not be downloaded again")
+}
+
+func TestDNSFilter_SetClientFilterLists_unknownID(t *testing.T) {
+	ctx := testutil.ContextWithTimeout(t, testTimeout)
+	addr := serveFiltersLocally(t, []byte(newRule+"\n"))
+
+	d, id := newDisabledListFilter(t, addr)
+
+	t.Run("blocking", func(t *testing.T) {
+		err := d.SetClientFilterLists(ctx, map[rules.ListID]bool{12345: true}, nil)
+		require.ErrorIs(t, err, ErrUnknownListID)
+	})
+
+	t.Run("wrong_category", func(t *testing.T) {
+		// The list is a blocking one, so naming it as an allowing one must be
+		// rejected rather than silently doing nothing.
+		err := d.SetClientFilterLists(ctx, nil, map[rules.ListID]bool{id: true})
+		require.ErrorIs(t, err, ErrUnknownListID)
+	})
+
+	t.Run("known_is_accepted", func(t *testing.T) {
+		require.NoError(t, d.SetClientFilterLists(ctx, map[rules.ListID]bool{id: true}, nil))
+	})
+}
+
+func TestDNSFilter_SetClientFilterLists_missingGlobalFile(t *testing.T) {
+	ctx := testutil.ContextWithTimeout(t, testTimeout)
+
+	globalAddr := serveFiltersLocally(t, []byte(oldRule+"\n"))
+	ownAddr := serveFiltersLocally(t, []byte(newRule+"\n"))
+
+	const (
+		globalID rules.ListID = 1
+		ownID    rules.ListID = 2
+	)
+
+	d := newDNSFilter(t)
+	t.Cleanup(d.Close)
+
+	globalFlt := FilterYAML{
+		Filter:  Filter{ID: globalID},
+		URL:     globalAddr,
+		Name:    "global-filter",
+		Enabled: true,
+	}
+	_, err := d.update(&globalFlt, false)
+	require.NoError(t, err)
+
+	d.conf.Filters = []FilterYAML{globalFlt, {
+		Filter:  Filter{ID: ownID},
+		URL:     ownAddr,
+		Name:    "own-filter",
+		Enabled: false,
+	}}
+	d.conf.FiltersUpdateIntervalHours = 0
+	require.NoError(t, d.enableFiltersLocked(ctx, nil, nil, nil, false))
+
+	globalSetts := &Settings{ProtectionEnabled: true, FilteringEnabled: true}
+
+	res, err := d.CheckHost("old.example", dns.TypeA, globalSetts)
+	require.NoError(t, err)
+	require.True(t, res.IsFiltered)
+
+	// The global list's cache disappears behind our back.
+	require.NoError(t, os.Remove(globalFlt.Path(d.conf.DataDir)))
+
+	// Assigning the disabled list must not swap in an engine that silently lost
+	// the global list.
+	err = d.SetClientFilterLists(ctx, map[rules.ListID]bool{ownID: true}, nil)
+	require.Error(t, err)
+
+	// The previous engine must still be enforcing it.
+	res, err = d.CheckHost("old.example", dns.TypeA, globalSetts)
+	require.NoError(t, err)
+	assert.True(t, res.IsFiltered, "the old engine must be retained")
 }

--- a/internal/filtering/filtering.go
+++ b/internal/filtering/filtering.go
@@ -56,11 +56,24 @@ type Settings struct {
 	// is nil if the client does not have any blocked services.
 	BlockedServices *BlockedServices
 
+	// ClientFilterListIDs is the set of blocking filter list IDs of a client.
+	// It is only used when UseOwnFilterLists is true.
+	ClientFilterListIDs map[rules.ListID]bool
+
+	// ClientAllowListIDs is the set of allowing filter list IDs of a client.
+	// It is only used when UseOwnFilterLists is true.
+	ClientAllowListIDs map[rules.ListID]bool
+
 	ProtectionEnabled   bool
 	FilteringEnabled    bool
 	SafeSearchEnabled   bool
 	SafeBrowsingEnabled bool
 	ParentalEnabled     bool
+
+	// UseOwnFilterLists signals whether to use ClientFilterListIDs and
+	// ClientAllowListIDs instead of the globally enabled filter lists.  Rules
+	// from the user's own list apply either way.
+	UseOwnFilterLists bool
 
 	// ClientSafeSearch is a client configured safe search.
 	ClientSafeSearch SafeSearch
@@ -95,6 +108,12 @@ type Config struct {
 	// ClientID or client IP address, and applies it to the filtering settings.
 	// It must not be nil.
 	ApplyClientFiltering func(clientID string, cliAddr netip.Addr, setts *Settings) `yaml:"-"`
+
+	// ClientFilterListIDs returns the filter list IDs used by persistent clients
+	// that have their own filter lists.  A disabled filter list is only
+	// downloaded and loaded when it appears in one of these sets.  It may be
+	// nil.
+	ClientFilterListIDs func() (blockIDs, allowIDs map[rules.ListID]bool) `yaml:"-"`
 
 	// BlockedServices is the configuration of blocked services.
 	// Per-client settings can override this configuration.
@@ -234,6 +253,17 @@ type Stats struct {
 
 // Parameters to pass to filters-initializer goroutine
 type filtersInitializerParams struct {
+	// enabledBlockIDs and enabledAllowIDs are the sets of enabled filter list
+	// IDs, or nil when no disabled list is loaded.
+	enabledBlockIDs map[rules.ListID]bool
+	enabledAllowIDs map[rules.ListID]bool
+
+	// requiredIDs are the rule lists whose absence must fail the build instead of
+	// being skipped, so that a rebuild never quietly swaps in an engine that
+	// lacks a list the caller relies on.  A list that was already missing is not
+	// in it, since there is nothing to lose.
+	requiredIDs map[rules.ListID]bool
+
 	allowFilters []Filter
 	blockFilters []Filter
 }
@@ -266,6 +296,23 @@ type DNSFilter struct {
 	rulesStorageAllow    *filterlist.RuleStorage
 	filteringEngineAllow *urlfilter.DNSEngine
 
+	// enabledBlockFilterIDs is the set of enabled blocking filter list IDs.  It
+	// is nil unless filteringEngine holds a disabled list, in which case
+	// clients using the global lists need no match-time filtering.  It is
+	// protected by engineLock.
+	enabledBlockFilterIDs map[rules.ListID]bool
+
+	// enabledAllowFilterIDs is like enabledBlockFilterIDs, but for allowing
+	// filter lists.  It is protected by engineLock.
+	enabledAllowFilterIDs map[rules.ListID]bool
+
+	// loadedBlockIDs and loadedAllowIDs are the rule lists the engines actually
+	// hold, as opposed to those merely configured.  A rebuild requires them, so
+	// that a list that is live now cannot be lost silently.  They are protected
+	// by engineLock.
+	loadedBlockIDs map[rules.ListID]bool
+	loadedAllowIDs map[rules.ListID]bool
+
 	safeSearch SafeSearch
 
 	// safeBrowsingChecker is the safe browsing hash-prefix checker.
@@ -293,7 +340,7 @@ type DNSFilter struct {
 	done chan struct{}
 
 	// Channel for passing data to filters-initializer goroutine
-	filtersInitializerChan chan filtersInitializerParams
+	filtersInitializerChan chan *filtersInitializerParams
 	filtersInitializerLock sync.Mutex
 
 	refreshLock *sync.Mutex
@@ -358,16 +405,10 @@ func (d *DNSFilter) WriteDiskConfig(c *Config) {
 // In this case the caller must ensure that the old filter files are intact.
 func (d *DNSFilter) setFilters(
 	ctx context.Context,
-	blockFilters []Filter,
-	allowFilters []Filter,
+	params *filtersInitializerParams,
 	async bool,
 ) (err error) {
 	if async {
-		params := filtersInitializerParams{
-			allowFilters: allowFilters,
-			blockFilters: blockFilters,
-		}
-
 		d.filtersInitializerLock.Lock()
 		defer d.filtersInitializerLock.Unlock()
 
@@ -387,7 +428,7 @@ func (d *DNSFilter) setFilters(
 		return nil
 	}
 
-	return d.initFiltering(ctx, allowFilters, blockFilters)
+	return d.initFiltering(ctx, params)
 }
 
 // Close - close the object
@@ -670,30 +711,39 @@ func (d *DNSFilter) matchBlockedServicesRules(
 // Adding rule and matching against the rules
 //
 
-func newRuleStorage(filters []Filter) (rs *filterlist.RuleStorage, err error) {
+func newRuleStorage(
+	filters []Filter,
+	requiredIDs map[rules.ListID]bool,
+) (rs *filterlist.RuleStorage, loaded map[rules.ListID]bool, err error) {
 	lists := make([]filterlist.Interface, 0, len(filters))
+	loaded = make(map[rules.ListID]bool, len(filters))
 	for _, f := range filters {
 		var rl filterlist.Interface
 		var skip bool
 		rl, skip, err = ruleListFromFilter(f)
 		if skip {
+			if requiredIDs[f.ID] {
+				return nil, nil, fmt.Errorf("rule list %d: %q is missing", f.ID, f.FilePath)
+			}
+
 			continue
 		}
 
 		if err != nil {
 			// Don't wrap the error, because it's informative enough as is.
-			return nil, err
+			return nil, nil, err
 		}
 
+		loaded[f.ID] = true
 		lists = append(lists, rl)
 	}
 
 	rs, err = filterlist.NewRuleStorage(lists)
 	if err != nil {
-		return nil, fmt.Errorf("creating rule storage: %w", err)
+		return nil, nil, fmt.Errorf("creating rule storage: %w", err)
 	}
 
-	return rs, nil
+	return rs, loaded, nil
 }
 
 // ruleListFromFilter returns a rule list from a Filter.
@@ -742,14 +792,14 @@ func ruleListFromFilter(f Filter) (rl filterlist.Interface, skip bool, err error
 	return rl, false, nil
 }
 
-// Initialize urlfilter objects.
-func (d *DNSFilter) initFiltering(ctx context.Context, allowFilters, blockFilters []Filter) (err error) {
-	rulesStorage, err := newRuleStorage(blockFilters)
+// Initialize urlfilter objects.  params must not be nil.
+func (d *DNSFilter) initFiltering(ctx context.Context, params *filtersInitializerParams) (err error) {
+	rulesStorage, loadedBlock, err := newRuleStorage(params.blockFilters, params.requiredIDs)
 	if err != nil {
 		return err
 	}
 
-	rulesStorageAllow, err := newRuleStorage(allowFilters)
+	rulesStorageAllow, loadedAllow, err := newRuleStorage(params.allowFilters, params.requiredIDs)
 	if err != nil {
 		return err
 	}
@@ -766,6 +816,11 @@ func (d *DNSFilter) initFiltering(ctx context.Context, allowFilters, blockFilter
 		d.filteringEngine = filteringEngine
 		d.rulesStorageAllow = rulesStorageAllow
 		d.filteringEngineAllow = filteringEngineAllow
+
+		d.enabledBlockFilterIDs = params.enabledBlockIDs
+		d.enabledAllowFilterIDs = params.enabledAllowIDs
+		d.loadedBlockIDs = loadedBlock
+		d.loadedAllowIDs = loadedAllow
 	}()
 
 	// Make sure that the OS reclaims memory as soon as possible.
@@ -879,6 +934,92 @@ func hostResultForOtherQType(dnsres *urlfilter.DNSResult) (res Result) {
 	return Result{}
 }
 
+// keepListIDs removes from dnsres the rules that come from a filter list absent
+// from ids, and reports whether dnsres still matches.  Rules from the user's own
+// list are kept regardless when keepCustom is true.  dnsres must not be nil.
+func keepListIDs(
+	dnsres *urlfilter.DNSResult,
+	ids map[rules.ListID]bool,
+	keepCustom bool,
+) (hasMatch bool) {
+	keep := func(id rules.ListID) (ok bool) {
+		return ids[id] || keepCustom && id == rulelist.IDCustom
+	}
+
+	dnsres.NetworkRules = keepRules(dnsres.NetworkRules, keep)
+	dnsres.HostRulesV4 = keepRules(dnsres.HostRulesV4, keep)
+	dnsres.HostRulesV6 = keepRules(dnsres.HostRulesV6, keep)
+
+	// Reselect the basic rule the way [urlfilter.DNSEngine] does, so that rule
+	// priority, $badfilter, and $replace behave the same for every client.
+	dnsres.NetworkRule = rules.GetDNSBasicRule(dnsres.NetworkRules)
+
+	return dnsres.NetworkRule != nil ||
+		len(dnsres.HostRulesV4) > 0 ||
+		len(dnsres.HostRulesV6) > 0
+}
+
+// keepAllowListIDs filters dnsres by the allowing filter lists that apply to
+// setts, and reports whether it still matches.  matched is returned as is when
+// it is false or when no filtering is needed.  d.engineLock is expected to be
+// locked for reading.
+func (d *DNSFilter) keepAllowListIDs(
+	dnsres *urlfilter.DNSResult,
+	setts *Settings,
+	matched bool,
+) (hasMatch bool) {
+	if !matched {
+		return false
+	}
+
+	if setts.UseOwnFilterLists {
+		return keepListIDs(dnsres, setts.ClientAllowListIDs, false)
+	} else if d.enabledAllowFilterIDs != nil {
+		return keepListIDs(dnsres, d.enabledAllowFilterIDs, false)
+	}
+
+	return true
+}
+
+// keepBlockListIDs filters dnsres by the blocking filter lists that apply to
+// setts, and reports whether it still matches.  matched is returned as is when
+// no filtering is needed.  d.engineLock is expected to be locked for reading.
+func (d *DNSFilter) keepBlockListIDs(
+	dnsres *urlfilter.DNSResult,
+	setts *Settings,
+	matched bool,
+) (hasMatch bool) {
+	if setts.UseOwnFilterLists {
+		return keepListIDs(dnsres, setts.ClientFilterListIDs, true)
+	} else if d.enabledBlockFilterIDs != nil {
+		return keepListIDs(dnsres, d.enabledBlockFilterIDs, true)
+	}
+
+	return matched
+}
+
+// keepRules returns orig without the rules rejected by keep.  It doesn't
+// allocate if every rule is kept, which is the common case.
+func keepRules[T rules.Rule](orig []T, keep func(id rules.ListID) (ok bool)) (kept []T) {
+	for i, r := range orig {
+		if keep(r.GetFilterListID()) {
+			continue
+		}
+
+		kept = make([]T, i, len(orig)-1)
+		copy(kept, orig[:i])
+		for _, r = range orig[i+1:] {
+			if keep(r.GetFilterListID()) {
+				kept = append(kept, r)
+			}
+		}
+
+		return kept
+	}
+
+	return orig
+}
+
 // matchHost is a low-level way to check only if host is filtered by rules,
 // skipping expensive safebrowsing and parental lookups.
 func (d *DNSFilter) matchHost(
@@ -910,6 +1051,7 @@ func (d *DNSFilter) matchHost(
 
 	if setts.ProtectionEnabled && d.filteringEngineAllow != nil {
 		dnsres, ok := d.filteringEngineAllow.MatchRequest(ufReq)
+		ok = d.keepAllowListIDs(dnsres, setts, ok)
 		if ok {
 			return d.matchHostProcessAllowList(ctx, host, dnsres)
 		}
@@ -920,6 +1062,7 @@ func (d *DNSFilter) matchHost(
 	}
 
 	dnsres, matchedEngine := d.filteringEngine.MatchRequest(ufReq)
+	matchedEngine = d.keepBlockListIDs(dnsres, setts, matchedEngine)
 
 	// Check DNS rewrites first, because the API there is a bit awkward.
 	dnsRWRes := d.processDNSResultRewrites(dnsres, host)
@@ -1030,7 +1173,7 @@ func New(c *Config, blockFilters []Filter) (d *DNSFilter, err error) {
 	}
 
 	if blockFilters != nil {
-		err = d.initFiltering(ctx, nil, blockFilters)
+		err = d.initFiltering(ctx, &filtersInitializerParams{blockFilters: blockFilters})
 		if err != nil {
 			d.Close()
 
@@ -1045,8 +1188,9 @@ func New(c *Config, blockFilters []Filter) (d *DNSFilter, err error) {
 		return nil, fmt.Errorf("making filtering directory: %w", err)
 	}
 
-	d.loadFilters(ctx, d.conf.Filters)
-	d.loadFilters(ctx, d.conf.WhitelistFilters)
+	blockClientIDs, allowClientIDs := d.clientFilterListIDs()
+	d.loadFilters(ctx, d.conf.Filters, blockClientIDs)
+	d.loadFilters(ctx, d.conf.WhitelistFilters, allowClientIDs)
 
 	d.conf.Filters = deduplicateFilters(d.conf.Filters)
 	d.conf.WhitelistFilters = deduplicateFilters(d.conf.WhitelistFilters)
@@ -1075,7 +1219,7 @@ func (d *DNSFilter) validateSafeFSPatterns(patterns []string) (err error) {
 
 // Start registers web handlers and starts filters updates loop.
 func (d *DNSFilter) Start() {
-	d.filtersInitializerChan = make(chan filtersInitializerParams, 1)
+	d.filtersInitializerChan = make(chan *filtersInitializerParams, 1)
 	d.done = make(chan struct{}, 1)
 
 	d.RegisterFilteringHandlers()
@@ -1093,7 +1237,7 @@ func (d *DNSFilter) updatesLoop(ctx context.Context) {
 	for {
 		select {
 		case params := <-d.filtersInitializerChan:
-			err := d.initFiltering(ctx, params.allowFilters, params.blockFilters)
+			err := d.initFiltering(ctx, params)
 			if err != nil {
 				d.logger.ErrorContext(ctx, "initializing", slogutil.KeyError, err)
 

--- a/internal/filtering/filtering_internal_test.go
+++ b/internal/filtering/filtering_internal_test.go
@@ -10,9 +10,11 @@ import (
 
 	"github.com/AdguardTeam/AdGuardHome/internal/aghtest"
 	"github.com/AdguardTeam/AdGuardHome/internal/filtering/hashprefix"
+	"github.com/AdguardTeam/AdGuardHome/internal/filtering/rulelist"
 	"github.com/AdguardTeam/golibs/logutil/slogutil"
 	"github.com/AdguardTeam/golibs/netutil"
 	"github.com/AdguardTeam/golibs/testutil"
+	"github.com/AdguardTeam/urlfilter"
 	"github.com/AdguardTeam/urlfilter/rules"
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
@@ -565,7 +567,10 @@ func TestWhitelist(t *testing.T) {
 	d, setts := newForTest(t, nil, filters)
 
 	ctx := testutil.ContextWithTimeout(t, testTimeout)
-	err := d.setFilters(ctx, filters, whiteFilters, false)
+	err := d.setFilters(ctx, &filtersInitializerParams{
+		allowFilters: whiteFilters,
+		blockFilters: filters,
+	}, false)
 	require.NoError(t, err)
 
 	t.Cleanup(d.Close)
@@ -730,4 +735,262 @@ func BenchmarkSafeBrowsing_parallel(b *testing.B) {
 	//	pkg: github.com/AdguardTeam/AdGuardHome/internal/filtering
 	//	cpu: Apple M3
 	//	BenchmarkSafeBrowsing_parallel-8   	 1040792	      1076 ns/op	    1472 B/op	      43 allocs/op
+}
+
+func TestKeepListIDs(t *testing.T) {
+	const (
+		listID1 rules.ListID = 1
+		listID2 rules.ListID = 2
+		listID3 rules.ListID = 3
+	)
+
+	newRule := func(tb testing.TB, text string, id rules.ListID) *rules.NetworkRule {
+		tb.Helper()
+
+		r, err := rules.NewNetworkRule(text, id)
+		require.NoError(tb, err)
+
+		return r
+	}
+
+	t.Run("allowed_list_kept", func(t *testing.T) {
+		r := newRule(t, "||example.org^", listID1)
+		dnsres := &urlfilter.DNSResult{
+			NetworkRule:  r,
+			NetworkRules: []*rules.NetworkRule{r},
+		}
+		allowed := map[rules.ListID]bool{listID1: true}
+
+		ok := keepListIDs(dnsres, allowed, false)
+		assert.True(t, ok)
+		assert.Equal(t, r, dnsres.NetworkRule)
+		assert.Len(t, dnsres.NetworkRules, 1)
+	})
+
+	t.Run("disallowed_list_removed", func(t *testing.T) {
+		r := newRule(t, "||example.org^", listID2)
+		dnsres := &urlfilter.DNSResult{
+			NetworkRule:  r,
+			NetworkRules: []*rules.NetworkRule{r},
+		}
+		allowed := map[rules.ListID]bool{listID1: true}
+
+		ok := keepListIDs(dnsres, allowed, false)
+		assert.False(t, ok)
+		assert.Nil(t, dnsres.NetworkRule)
+		assert.Empty(t, dnsres.NetworkRules)
+	})
+
+	t.Run("user_rules_always_kept", func(t *testing.T) {
+		r := newRule(t, "||example.org^", rulelist.IDCustom)
+		dnsres := &urlfilter.DNSResult{
+			NetworkRule:  r,
+			NetworkRules: []*rules.NetworkRule{r},
+		}
+		allowed := map[rules.ListID]bool{listID1: true}
+
+		ok := keepListIDs(dnsres, allowed, true)
+		assert.True(t, ok)
+		assert.Equal(t, r, dnsres.NetworkRule)
+	})
+
+	t.Run("user_rules_not_kept_when_flag_false", func(t *testing.T) {
+		r := newRule(t, "||example.org^", rulelist.IDCustom)
+		dnsres := &urlfilter.DNSResult{
+			NetworkRule:  r,
+			NetworkRules: []*rules.NetworkRule{r},
+		}
+		allowed := map[rules.ListID]bool{listID1: true}
+
+		ok := keepListIDs(dnsres, allowed, false)
+		assert.False(t, ok)
+	})
+
+	t.Run("mixed_rules", func(t *testing.T) {
+		r1 := newRule(t, "||disallowed.org^", listID2)
+		r2 := newRule(t, "||allowed.org^", listID1)
+		dnsres := &urlfilter.DNSResult{
+			NetworkRule:  r1,
+			NetworkRules: []*rules.NetworkRule{r1, r2},
+		}
+		allowed := map[rules.ListID]bool{listID1: true}
+
+		ok := keepListIDs(dnsres, allowed, false)
+		assert.True(t, ok)
+		assert.Equal(t, r2, dnsres.NetworkRule)
+		assert.Len(t, dnsres.NetworkRules, 1)
+		assert.Equal(t, r2, dnsres.NetworkRules[0])
+	})
+
+	t.Run("empty_result", func(t *testing.T) {
+		dnsres := &urlfilter.DNSResult{}
+		allowed := map[rules.ListID]bool{listID1: true}
+
+		ok := keepListIDs(dnsres, allowed, false)
+		assert.False(t, ok)
+	})
+
+	t.Run("exception_wins_over_block", func(t *testing.T) {
+		block := newRule(t, "||example.org^", listID1)
+		exc := newRule(t, "@@||example.org^", listID3)
+		dnsres := &urlfilter.DNSResult{
+			NetworkRule:  block,
+			NetworkRules: []*rules.NetworkRule{block, exc},
+		}
+		allowed := map[rules.ListID]bool{listID1: true, listID3: true}
+
+		ok := keepListIDs(dnsres, allowed, false)
+		assert.True(t, ok)
+
+		// The rule must be reselected by priority, as urlfilter does, and not
+		// by position.
+		assert.Equal(t, exc, dnsres.NetworkRule)
+	})
+
+	t.Run("badfilter_negates_block", func(t *testing.T) {
+		block := newRule(t, "||example.org^", listID1)
+		bad := newRule(t, "||example.org^$badfilter", listID1)
+		dnsres := &urlfilter.DNSResult{
+			NetworkRule:  block,
+			NetworkRules: []*rules.NetworkRule{block, bad},
+		}
+		allowed := map[rules.ListID]bool{listID1: true}
+
+		ok := keepListIDs(dnsres, allowed, false)
+		assert.False(t, ok)
+		assert.Nil(t, dnsres.NetworkRule)
+	})
+
+	t.Run("no_alloc_when_all_kept", func(t *testing.T) {
+		r := newRule(t, "||example.org^", listID1)
+		orig := []*rules.NetworkRule{r}
+		dnsres := &urlfilter.DNSResult{
+			NetworkRule:  r,
+			NetworkRules: orig,
+		}
+		allowed := map[rules.ListID]bool{listID1: true}
+
+		ok := keepListIDs(dnsres, allowed, false)
+		assert.True(t, ok)
+
+		// The slice must be reused, so that a request that keeps every rule
+		// doesn't allocate.
+		assert.Equal(t, &orig[0], &dnsres.NetworkRules[0])
+	})
+}
+
+func TestAppendEnabledFilters(t *testing.T) {
+	const (
+		enabledID  rules.ListID = 1
+		disabledID rules.ListID = 2
+	)
+
+	flts := []FilterYAML{{
+		Filter:  Filter{ID: enabledID},
+		Enabled: true,
+	}, {
+		Filter:  Filter{ID: disabledID},
+		Enabled: false,
+	}}
+
+	t.Run("no_client_lists", func(t *testing.T) {
+		res, enabledIDs := appendEnabledFilters(nil, flts, nil, "")
+		require.Len(t, res, 1)
+
+		assert.Equal(t, enabledID, res[0].ID)
+
+		// A configuration in which every loaded filter is enabled must need no
+		// match-time filtering at all.
+		assert.Nil(t, enabledIDs)
+	})
+
+	t.Run("disabled_used_by_client", func(t *testing.T) {
+		clientIDs := map[rules.ListID]bool{disabledID: true}
+		res, enabledIDs := appendEnabledFilters(nil, flts, clientIDs, "")
+		require.Len(t, res, 2)
+
+		assert.Equal(t, map[rules.ListID]bool{enabledID: true}, enabledIDs)
+	})
+
+	t.Run("client_uses_enabled_only", func(t *testing.T) {
+		clientIDs := map[rules.ListID]bool{enabledID: true}
+		res, enabledIDs := appendEnabledFilters(nil, flts, clientIDs, "")
+		require.Len(t, res, 1)
+
+		assert.Nil(t, enabledIDs)
+	})
+}
+
+func TestDNSFilter_CheckHost_clientFilterLists(t *testing.T) {
+	const (
+		listID1 rules.ListID = 1
+		listID2 rules.ListID = 2
+	)
+
+	d, setts := newForTest(t, nil, []Filter{
+		{ID: listID1, Data: []byte("||blocked-by-list1.org^\n")},
+		{ID: listID2, Data: []byte("||blocked-by-list2.org^\n")},
+	})
+	t.Cleanup(d.Close)
+
+	t.Run("global_all_blocked", func(t *testing.T) {
+		// Without per-client lists, both domains should be blocked.
+		res, err := d.CheckHost("blocked-by-list1.org", dns.TypeA, setts)
+		require.NoError(t, err)
+		assert.True(t, res.IsFiltered)
+
+		res, err = d.CheckHost("blocked-by-list2.org", dns.TypeA, setts)
+		require.NoError(t, err)
+		assert.True(t, res.IsFiltered)
+	})
+
+	t.Run("per_client_only_list1", func(t *testing.T) {
+		clientSetts := *setts
+		clientSetts.UseOwnFilterLists = true
+		clientSetts.ClientFilterListIDs = map[rules.ListID]bool{listID1: true}
+
+		// Blocked by assigned list1.
+		res, err := d.CheckHost("blocked-by-list1.org", dns.TypeA, &clientSetts)
+		require.NoError(t, err)
+		assert.True(t, res.IsFiltered)
+
+		// Not blocked, list2 is not assigned.
+		res, err = d.CheckHost("blocked-by-list2.org", dns.TypeA, &clientSetts)
+		require.NoError(t, err)
+		assert.False(t, res.IsFiltered)
+	})
+
+	t.Run("per_client_only_list2", func(t *testing.T) {
+		clientSetts := *setts
+		clientSetts.UseOwnFilterLists = true
+		clientSetts.ClientFilterListIDs = map[rules.ListID]bool{listID2: true}
+
+		// Not blocked, list1 is not assigned.
+		res, err := d.CheckHost("blocked-by-list1.org", dns.TypeA, &clientSetts)
+		require.NoError(t, err)
+		assert.False(t, res.IsFiltered)
+
+		// Blocked by assigned list2.
+		res, err = d.CheckHost("blocked-by-list2.org", dns.TypeA, &clientSetts)
+		require.NoError(t, err)
+		assert.True(t, res.IsFiltered)
+	})
+
+	t.Run("user_rules_always_apply", func(t *testing.T) {
+		// Add a rule from the user's own list, which must always apply.
+		dUserRules, setts2 := newForTest(t, nil, []Filter{
+			{ID: rulelist.IDCustom, Data: []byte("||custom-blocked.org^\n")},
+			{ID: listID1, Data: []byte("||blocked-by-list1.org^\n")},
+		})
+		t.Cleanup(dUserRules.Close)
+
+		clientSetts := *setts2
+		clientSetts.UseOwnFilterLists = true
+		clientSetts.ClientFilterListIDs = map[rules.ListID]bool{listID1: true}
+
+		// The rule applies even though [rulelist.IDCustom] is not assigned.
+		res, err := dUserRules.CheckHost("custom-blocked.org", dns.TypeA, &clientSetts)
+		require.NoError(t, err)
+		assert.True(t, res.IsFiltered)
+	})
 }

--- a/internal/filtering/http.go
+++ b/internal/filtering/http.go
@@ -118,7 +118,7 @@ func (d *DNSFilter) handleFilteringAddURL(w http.ResponseWriter, r *http.Request
 	}
 
 	// Download the filter contents
-	ok, err := d.update(&filt)
+	ok, err := d.update(&filt, false)
 	if err != nil {
 		aghhttp.ErrorAndLog(
 			ctx,

--- a/internal/home/clients.go
+++ b/internal/home/clients.go
@@ -22,6 +22,7 @@ import (
 	"github.com/AdguardTeam/golibs/errors"
 	"github.com/AdguardTeam/golibs/logutil/slogutil"
 	"github.com/AdguardTeam/golibs/timeutil"
+	"github.com/AdguardTeam/urlfilter/rules"
 )
 
 // clientsContainer is the storage of all runtime and persistent clients.
@@ -53,6 +54,12 @@ type clientsContainer struct {
 	// TODO(a.garipov): Use a pointer and describe which fields are protected in
 	// more detail.  Use sync.RWMutex.
 	lock sync.Mutex
+
+	// filterListsMu serializes the whole sequence of preparing the DNS filtering
+	// engine, storing the client and pruning, so that two concurrent mutations
+	// cannot each prepare against a storage that lacks the other's prospective
+	// policy and drop the list it has just loaded.
+	filterListsMu sync.Mutex
 
 	// safeSearchCacheSize is the size of the safe search cache to use for
 	// persistent clients.
@@ -140,6 +147,7 @@ func (clients *clientsContainer) Init(
 	sigHdlr.addClientStorage(clients.storage)
 
 	filteringConf.ApplyClientFiltering = clients.storage.ApplyClientFiltering
+	filteringConf.ClientFilterListIDs = clients.storage.ReferencedFilterListIDs
 
 	return nil
 }
@@ -190,6 +198,13 @@ type clientObject struct {
 	SafeBrowsingEnabled      bool `yaml:"safebrowsing_enabled"`
 	UseGlobalBlockedServices bool `yaml:"use_global_blocked_services"`
 
+	// UseOwnFilterLists uses the positive form, unlike the fields above, so that
+	// its zero value keeps the global filter lists for older configurations.
+	UseOwnFilterLists bool `yaml:"use_own_filter_lists"`
+
+	FilterListIDs      []rules.ListID `yaml:"filter_list_ids"`
+	AllowFilterListIDs []rules.ListID `yaml:"allow_filter_list_ids"`
+
 	IgnoreQueryLog   bool `yaml:"ignore_querylog"`
 	IgnoreStatistics bool `yaml:"ignore_statistics"`
 }
@@ -214,6 +229,9 @@ func (o *clientObject) toPersistent(
 		SafeSearchConf:        o.SafeSearchConf,
 		SafeBrowsingEnabled:   o.SafeBrowsingEnabled,
 		UseOwnBlockedServices: !o.UseGlobalBlockedServices,
+		UseOwnFilterLists:     o.UseOwnFilterLists,
+		FilterListIDs:         slices.Clone(o.FilterListIDs),
+		AllowFilterListIDs:    slices.Clone(o.AllowFilterListIDs),
 		IgnoreQueryLog:        o.IgnoreQueryLog,
 		IgnoreStatistics:      o.IgnoreStatistics,
 		UpstreamsCacheEnabled: o.UpstreamsCacheEnabled,
@@ -296,6 +314,9 @@ func (clients *clientsContainer) forConfig() (objs []*clientObject) {
 			SafeSearchConf:           cli.SafeSearchConf,
 			SafeBrowsingEnabled:      cli.SafeBrowsingEnabled,
 			UseGlobalBlockedServices: !cli.UseOwnBlockedServices,
+			UseOwnFilterLists:        cli.UseOwnFilterLists,
+			FilterListIDs:            slices.Clone(cli.FilterListIDs),
+			AllowFilterListIDs:       slices.Clone(cli.AllowFilterListIDs),
 			IgnoreQueryLog:           cli.IgnoreQueryLog,
 			IgnoreStatistics:         cli.IgnoreStatistics,
 			UpstreamsCacheEnabled:    cli.UpstreamsCacheEnabled,

--- a/internal/home/clientsfilterlists_internal_test.go
+++ b/internal/home/clientsfilterlists_internal_test.go
@@ -1,0 +1,171 @@
+package home
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/AdguardTeam/AdGuardHome/internal/client"
+	"github.com/AdguardTeam/AdGuardHome/internal/filtering"
+	"github.com/AdguardTeam/AdGuardHome/internal/schedule"
+	"github.com/AdguardTeam/golibs/testutil"
+	"github.com/AdguardTeam/urlfilter/rules"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yaml "go.yaml.in/yaml/v4"
+)
+
+// TestClientObject_toPersistent_filterLists makes sure that a client stored
+// before per-client filter lists were introduced keeps using the global ones,
+// since a client with its own but empty lists matches nothing but the user
+// rules.
+func TestClientObject_toPersistent_filterLists(t *testing.T) {
+	testCases := []struct {
+		name      string
+		conf      string
+		wantBlock []rules.ListID
+		wantAllow []rules.ListID
+		wantOwn   bool
+	}{{
+		name: "legacy_no_fields",
+		conf: `name: legacy
+ids: [192.0.2.1]
+use_global_settings: true
+use_global_blocked_services: true
+`,
+		wantOwn:   false,
+		wantBlock: nil,
+		wantAllow: nil,
+	}, {
+		name: "own_lists",
+		conf: `name: own
+ids: [192.0.2.2]
+use_own_filter_lists: true
+filter_list_ids: [1, 3]
+allow_filter_list_ids: [5]
+`,
+		wantOwn:   true,
+		wantBlock: []rules.ListID{1, 3},
+		wantAllow: []rules.ListID{5},
+	}, {
+		name: "own_lists_none_selected",
+		conf: `name: strict
+ids: [192.0.2.3]
+use_own_filter_lists: true
+`,
+		wantOwn:   true,
+		wantBlock: nil,
+		wantAllow: nil,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			o := &clientObject{}
+			require.NoError(t, yaml.Unmarshal([]byte(tc.conf), o))
+
+			ctx := testutil.ContextWithTimeout(t, testTimeout)
+			cli, err := o.toPersistent(ctx, testLogger, 0, 0)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantOwn, cli.UseOwnFilterLists)
+			assert.Equal(t, tc.wantBlock, cli.FilterListIDs)
+			assert.Equal(t, tc.wantAllow, cli.AllowFilterListIDs)
+		})
+	}
+}
+
+// TestClientsContainer_jsonToClient_filterLists makes sure that an add or update
+// request that predates per-client filter lists keeps the global ones.
+func TestClientsContainer_jsonToClient_filterLists(t *testing.T) {
+	clients := newClientsContainer(t)
+
+	testCases := []struct {
+		name    string
+		body    string
+		wantOwn bool
+	}{{
+		name:    "legacy_no_field",
+		body:    `{"name":"legacy","ids":["192.0.2.1"],"use_global_settings":true}`,
+		wantOwn: false,
+	}, {
+		name:    "own_lists",
+		body:    `{"name":"own","ids":["192.0.2.2"],"use_own_filter_lists":true,"filter_list_ids":[2]}`,
+		wantOwn: true,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cj := clientJSON{}
+			require.NoError(t, json.Unmarshal([]byte(tc.body), &cj))
+
+			ctx := testutil.ContextWithTimeout(t, testTimeout)
+			c, err := clients.jsonToClient(ctx, cj, nil)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantOwn, c.UseOwnFilterLists)
+		})
+	}
+}
+
+// TestClientsContainer_jsonToClient_preservesFilterLists makes sure that an
+// update request that omits the filter list fields keeps the ones already
+// configured, so that editing an unrelated property through an older client
+// doesn't silently move the client back onto the global lists.
+func TestClientsContainer_jsonToClient_preservesFilterLists(t *testing.T) {
+	clients := newClientsContainer(t)
+
+	prev := &client.Persistent{
+		Name:               "stored",
+		UID:                client.MustNewUID(),
+		BlockedServices:    &filtering.BlockedServices{Schedule: schedule.EmptyWeekly()},
+		UseOwnFilterLists:  true,
+		FilterListIDs:      []rules.ListID{1, 3},
+		AllowFilterListIDs: []rules.ListID{10},
+	}
+
+	testCases := []struct {
+		name      string
+		body      string
+		wantBlock []rules.ListID
+		wantAllow []rules.ListID
+		wantOwn   bool
+	}{{
+		name:      "omitted_keeps_stored",
+		body:      `{"name":"stored","ids":["192.0.2.1"],"use_global_settings":true}`,
+		wantBlock: []rules.ListID{1, 3},
+		wantAllow: []rules.ListID{10},
+		wantOwn:   true,
+	}, {
+		name:      "explicit_false_clears",
+		body:      `{"name":"stored","ids":["192.0.2.1"],"use_own_filter_lists":false}`,
+		wantBlock: []rules.ListID{1, 3},
+		wantAllow: []rules.ListID{10},
+		wantOwn:   false,
+	}, {
+		name:      "empty_list_clears_ids",
+		body:      `{"name":"stored","ids":["192.0.2.1"],"use_own_filter_lists":true,"filter_list_ids":[]}`,
+		wantBlock: nil,
+		wantAllow: []rules.ListID{10},
+		wantOwn:   true,
+	}, {
+		name:      "new_ids_replace_stored",
+		body:      `{"name":"stored","ids":["192.0.2.1"],"filter_list_ids":[7]}`,
+		wantBlock: []rules.ListID{7},
+		wantAllow: []rules.ListID{10},
+		wantOwn:   true,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cj := clientJSON{}
+			require.NoError(t, json.Unmarshal([]byte(tc.body), &cj))
+
+			ctx := testutil.ContextWithTimeout(t, testTimeout)
+			c, err := clients.jsonToClient(ctx, cj, prev)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantOwn, c.UseOwnFilterLists)
+			assert.Equal(t, tc.wantBlock, c.FilterListIDs)
+			assert.Equal(t, tc.wantAllow, c.AllowFilterListIDs)
+		})
+	}
+}

--- a/internal/home/clientshttp.go
+++ b/internal/home/clientshttp.go
@@ -6,15 +6,20 @@ import (
 	"fmt"
 	"net/http"
 	"net/netip"
+	"slices"
+
+	"github.com/AdguardTeam/golibs/errors"
 
 	"github.com/AdguardTeam/AdGuardHome/internal/aghalg"
 	"github.com/AdguardTeam/AdGuardHome/internal/aghhttp"
 	"github.com/AdguardTeam/AdGuardHome/internal/client"
 	"github.com/AdguardTeam/AdGuardHome/internal/filtering"
+	"github.com/AdguardTeam/AdGuardHome/internal/filtering/rulelist"
 	"github.com/AdguardTeam/AdGuardHome/internal/filtering/safesearch"
 	"github.com/AdguardTeam/AdGuardHome/internal/schedule"
 	"github.com/AdguardTeam/AdGuardHome/internal/whois"
 	"github.com/AdguardTeam/golibs/logutil/slogutil"
+	"github.com/AdguardTeam/urlfilter/rules"
 )
 
 // clientJSON is a common structure used by several handlers to deal with
@@ -56,6 +61,17 @@ type clientJSON struct {
 	SafeSearchEnabled        bool `json:"safesearch_enabled"`
 	UseGlobalBlockedServices bool `json:"use_global_blocked_services"`
 	UseGlobalSettings        bool `json:"use_global_settings"`
+
+	// UseOwnFilterLists uses the positive form, unlike the fields above, so that
+	// its zero value keeps the global filter lists.  It is absence aware, so
+	// that an update request that omits it doesn't reset the filter lists of a
+	// client configured by other means.
+	UseOwnFilterLists aghalg.NullBool `json:"use_own_filter_lists"`
+
+	// FilterListIDs and AllowFilterListIDs are pointers to tell an omitted
+	// field, which keeps the stored IDs, from an empty one, which clears them.
+	FilterListIDs      *[]int64 `json:"filter_list_ids"`
+	AllowFilterListIDs *[]int64 `json:"allow_filter_list_ids"`
 
 	IgnoreQueryLog   aghalg.NullBool `json:"ignore_querylog"`
 	IgnoreStatistics aghalg.NullBool `json:"ignore_statistics"`
@@ -128,6 +144,33 @@ func (clients *clientsContainer) handleGetClients(w http.ResponseWriter, r *http
 	aghhttp.WriteJSONResponseOK(ctx, clients.logger, w, r, data)
 }
 
+// filterListsFromJSON returns the filter list policy of the client described by
+// cj, falling back to prev for each field that cj omits.
+func filterListsFromJSON(
+	cj clientJSON,
+	prev *client.Persistent,
+) (useOwn bool, blockIDs, allowIDs []rules.ListID) {
+	if prev != nil {
+		useOwn = prev.UseOwnFilterLists
+		blockIDs = slices.Clone(prev.FilterListIDs)
+		allowIDs = slices.Clone(prev.AllowFilterListIDs)
+	}
+
+	if cj.UseOwnFilterLists != aghalg.NBNull {
+		useOwn = cj.UseOwnFilterLists == aghalg.NBTrue
+	}
+
+	if cj.FilterListIDs != nil {
+		blockIDs = apiIDsToListIDs(*cj.FilterListIDs)
+	}
+
+	if cj.AllowFilterListIDs != nil {
+		allowIDs = apiIDsToListIDs(*cj.AllowFilterListIDs)
+	}
+
+	return useOwn, blockIDs, allowIDs
+}
+
 // initPrev initializes the persistent client with the default or previous
 // client properties.
 func initPrev(cj clientJSON, prev *client.Persistent) (c *client.Persistent, err error) {
@@ -146,6 +189,8 @@ func initPrev(cj clientJSON, prev *client.Persistent) (c *client.Persistent, err
 		upsCacheEnabled = prev.UpstreamsCacheEnabled
 		upsCacheSize = prev.UpstreamsCacheSize
 	}
+
+	useOwnFilterLists, filterListIDs, allowFilterListIDs := filterListsFromJSON(cj, prev)
 
 	if cj.IgnoreQueryLog != aghalg.NBNull {
 		ignoreQueryLog = cj.IgnoreQueryLog == aghalg.NBTrue
@@ -175,10 +220,13 @@ func initPrev(cj clientJSON, prev *client.Persistent) (c *client.Persistent, err
 	return &client.Persistent{
 		BlockedServices:       svcs,
 		UID:                   uid,
+		FilterListIDs:         filterListIDs,
+		AllowFilterListIDs:    allowFilterListIDs,
 		IgnoreQueryLog:        ignoreQueryLog,
 		IgnoreStatistics:      ignoreStatistics,
 		UpstreamsCacheEnabled: upsCacheEnabled,
 		UpstreamsCacheSize:    upsCacheSize,
+		UseOwnFilterLists:     useOwnFilterLists,
 	}, nil
 }
 
@@ -271,11 +319,12 @@ func copyBlockedServices(
 	prev *client.Persistent,
 ) (svcs *filtering.BlockedServices, err error) {
 	var weekly *schedule.Weekly
-	if sch != nil {
+	switch {
+	case sch != nil:
 		weekly = sch.Clone()
-	} else if prev != nil {
+	case prev != nil && prev.BlockedServices != nil:
 		weekly = prev.BlockedServices.Schedule.Clone()
-	} else {
+	default:
 		weekly = schedule.EmptyWeekly()
 	}
 
@@ -311,6 +360,9 @@ func clientToJSON(c *client.Persistent) (cj *clientJSON) {
 		SafeBrowsingEnabled: c.SafeBrowsingEnabled,
 
 		UseGlobalBlockedServices: !c.UseOwnBlockedServices,
+		UseOwnFilterLists:        aghalg.BoolToNullBool(c.UseOwnFilterLists),
+		FilterListIDs:            pointerTo(listIDsToAPIIDs(c.FilterListIDs)),
+		AllowFilterListIDs:       pointerTo(listIDsToAPIIDs(c.AllowFilterListIDs)),
 
 		Schedule:        c.BlockedServices.Schedule,
 		BlockedServices: c.BlockedServices.IDs,
@@ -353,6 +405,21 @@ func (clients *clientsContainer) handleAddClient(w http.ResponseWriter, r *http.
 		return
 	}
 
+	// Keep the whole sequence of preparing the engine, storing the client and
+	// pruning atomic against another mutation.
+	clients.filterListsMu.Lock()
+	defer clients.filterListsMu.Unlock()
+
+	// Make the engine able to enforce the policy before storing the client.
+	err = clients.prepareFilterLists(ctx, c)
+	if err != nil {
+		aghhttp.ErrorAndLog(ctx, l, r, w, filterListsStatus(err), "%s", err)
+
+		return
+	}
+
+	prevBlock, prevAllow := clients.storage.ReferencedFilterListIDs()
+
 	err = clients.storage.Add(ctx, c)
 	if err != nil {
 		aghhttp.ErrorAndLog(ctx, l, r, w, http.StatusBadRequest, "%s", err)
@@ -360,7 +427,103 @@ func (clients *clientsContainer) handleAddClient(w http.ResponseWriter, r *http.
 		return
 	}
 
+	clients.reloadFilterLists(prevBlock, prevAllow)
 	clients.confModifier.Apply(ctx)
+}
+
+// prepareFilterLists puts the filter lists that c references into the DNS
+// filtering engine.  It must be called before c becomes observable, since a
+// client naming a list the engine doesn't hold matches neither that list nor the
+// global ones.
+func (clients *clientsContainer) prepareFilterLists(
+	ctx context.Context,
+	c *client.Persistent,
+) (err error) {
+	f := globalContext.filters
+	if f == nil || !c.UseOwnFilterLists {
+		return nil
+	}
+
+	blockIDs, allowIDs := clients.storage.ReferencedFilterListIDs()
+
+	return f.SetClientFilterLists(
+		ctx,
+		withListIDs(blockIDs, c.FilterListIDs),
+		withListIDs(allowIDs, c.AllowFilterListIDs),
+	)
+}
+
+// hasDropped reports whether some ID of prev is absent from cur.
+func hasDropped(prev, cur map[rules.ListID]bool) (ok bool) {
+	for id := range prev {
+		if !cur[id] {
+			return true
+		}
+	}
+
+	return false
+}
+
+// filterListsStatus returns the status code to answer a failed filter list
+// preparation with.  A list the configuration doesn't have is the caller's
+// fault, anything else is not.
+func filterListsStatus(err error) (code int) {
+	if errors.Is(err, filtering.ErrUnknownListID) {
+		return http.StatusBadRequest
+	}
+
+	return http.StatusInternalServerError
+}
+
+// withListIDs returns the union of set and ids.  It doesn't modify set.
+func withListIDs(set map[rules.ListID]bool, ids []rules.ListID) (res map[rules.ListID]bool) {
+	res = make(map[rules.ListID]bool, len(set)+len(ids))
+	for id := range set {
+		res[id] = true
+	}
+
+	for _, id := range ids {
+		res[id] = true
+	}
+
+	return res
+}
+
+// findByName returns the persistent client with the given name, or nil if there
+// is none.
+func (clients *clientsContainer) findByName(name string) (c *client.Persistent) {
+	clients.storage.RangeByName(func(p *client.Persistent) (cont bool) {
+		if p.Name != name {
+			return true
+		}
+
+		c = p
+
+		return false
+	})
+
+	return c
+}
+
+// reloadFilterLists reloads the filter lists if the set of those used by
+// clients with their own filter lists differs from prevBlock and prevAllow.  It
+// must be called after the client storage has been modified and unlocked, since
+// a globally disabled list is only put into the engine while a client uses it.
+func (clients *clientsContainer) reloadFilterLists(prevBlock, prevAllow map[rules.ListID]bool) {
+	if globalContext.filters == nil {
+		return
+	}
+
+	blockIDs, allowIDs := clients.storage.ReferencedFilterListIDs()
+
+	// Newly referenced lists are already in the engine, since prepareFilterLists
+	// put them there before the client became observable.  Only dropping a list
+	// still needs a rebuild.
+	if !hasDropped(prevBlock, blockIDs) && !hasDropped(prevAllow, allowIDs) {
+		return
+	}
+
+	globalContext.filters.EnableFilters(true)
 }
 
 // handleDelClient is the handler for POST /control/clients/delete HTTP API.
@@ -390,12 +553,18 @@ func (clients *clientsContainer) handleDelClient(w http.ResponseWriter, r *http.
 		return
 	}
 
+	clients.filterListsMu.Lock()
+	defer clients.filterListsMu.Unlock()
+
+	prevBlock, prevAllow := clients.storage.ReferencedFilterListIDs()
+
 	if !clients.storage.RemoveByName(ctx, cj.Name) {
 		aghhttp.ErrorAndLog(ctx, l, r, w, http.StatusBadRequest, "Client not found")
 
 		return
 	}
 
+	clients.reloadFilterLists(prevBlock, prevAllow)
 	clients.confModifier.Apply(ctx)
 }
 
@@ -434,12 +603,26 @@ func (clients *clientsContainer) handleUpdateClient(w http.ResponseWriter, r *ht
 		return
 	}
 
-	c, err := clients.jsonToClient(ctx, dj.Data, nil)
+	// Pass the stored client, so that a request omitting an absence aware field
+	// keeps its current value instead of resetting it.
+	c, err := clients.jsonToClient(ctx, dj.Data, clients.findByName(dj.Name))
 	if err != nil {
 		aghhttp.ErrorAndLog(ctx, l, r, w, http.StatusBadRequest, "%s", err)
 
 		return
 	}
+
+	clients.filterListsMu.Lock()
+	defer clients.filterListsMu.Unlock()
+
+	err = clients.prepareFilterLists(ctx, c)
+	if err != nil {
+		aghhttp.ErrorAndLog(ctx, l, r, w, filterListsStatus(err), "%s", err)
+
+		return
+	}
+
+	prevBlock, prevAllow := clients.storage.ReferencedFilterListIDs()
 
 	err = clients.storage.Update(ctx, dj.Name, c)
 	if err != nil {
@@ -448,6 +631,7 @@ func (clients *clientsContainer) handleUpdateClient(w http.ResponseWriter, r *ht
 		return
 	}
 
+	clients.reloadFilterLists(prevBlock, prevAllow)
 	clients.confModifier.Apply(ctx)
 }
 
@@ -606,6 +790,40 @@ func (clients *clientsContainer) findRuntime(
 		Disallowed:     &disallowed,
 		DisallowedRule: disallowedRule,
 	}
+}
+
+// pointerTo returns a pointer to v, so that an always present field is told from
+// an omitted one.
+func pointerTo[T any](v T) (ptr *T) {
+	return &v
+}
+
+// listIDsToAPIIDs converts filter list IDs into their API representation.
+func listIDsToAPIIDs(ids []rules.ListID) (apiIDs []int64) {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	apiIDs = make([]int64, len(ids))
+	for i, id := range ids {
+		apiIDs[i] = int64(rulelist.APIID(id))
+	}
+
+	return apiIDs
+}
+
+// apiIDsToListIDs converts filter list IDs from their API representation.
+func apiIDsToListIDs(apiIDs []int64) (ids []rules.ListID) {
+	if len(apiIDs) == 0 {
+		return nil
+	}
+
+	ids = make([]rules.ListID, len(apiIDs))
+	for i, id := range apiIDs {
+		ids[i] = rules.ListID(id)
+	}
+
+	return ids
 }
 
 // registerWebHandlers registers HTTP handlers.

--- a/internal/home/dns.go
+++ b/internal/home/dns.go
@@ -455,9 +455,22 @@ func startDNSServer() (err error) {
 
 	// TODO(s.chzhen):  Pass context.
 	ctx := context.TODO()
+
 	err = globalContext.clients.Start(ctx)
 	if err != nil {
 		return fmt.Errorf("starting clients container: %w", err)
+	}
+
+	// Fetch the filter lists that clients use but that never made it to disk, so
+	// that a restored configuration or a cleared cache doesn't leave a promised
+	// list inactive until the next refresh.  It has to happen before the
+	// listeners accept traffic, since an own-list client whose list is absent
+	// matches neither that list nor the global ones.  The HTTP client has a
+	// timeout, so a dead source cannot hold startup indefinitely.
+	blockIDs, allowIDs := globalContext.clients.storage.ReferencedFilterListIDs()
+	err = globalContext.filters.SetClientFilterLists(ctx, blockIDs, allowIDs)
+	if err != nil {
+		log.Error("dnsforward: preparing client filter lists: %s", err)
 	}
 
 	err = globalContext.dnsServer.Start(ctx)

--- a/openapi/CHANGELOG.md
+++ b/openapi/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## v0.107.79: API changes
 
+### Per-client filter lists
+
+- New properties `use_own_filter_lists`, `filter_list_ids`, and `allow_filter_list_ids` in the `Client` schema assign filter lists to a single client.  When `use_own_filter_lists` is `true`, only the assigned lists apply to that client, along with the user rules.  Omitting the properties in `POST /control/clients/add` keeps the globally enabled filter lists.
+
+    Omitting them in `POST /control/clients/update` leaves the stored values unchanged, so that a client that does not know about these properties cannot reset them.  Send `filter_list_ids` or `allow_filter_list_ids` as an empty array to clear them.
+
 - Field `bootstrap_dns` in `POST /control/dns_config` now accepts comments.  A comment must start with the `#` symbol.
 
 - Fixed wrong property names: `enable` → `enabled` in the Parental status response, `protection_disabled_until` → `protection_disabled_duration` in `ServerStatus`, `ratelimit_subnet_subnet_len_ipv4` and `ratelimit_subnet_subnet_len_ipv6` in `DNSConfig`.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2856,6 +2856,41 @@
           '$ref': '#/components/schemas/SafeSearchConfig'
         'use_global_blocked_services':
           'type': 'boolean'
+        'use_own_filter_lists':
+          'type': 'boolean'
+          'description': |
+            Whether to use the filter lists in `filter_list_ids` and
+            `allow_filter_list_ids` instead of the globally enabled ones.  Rules
+            from the user's own list apply either way.
+
+            NOTE: If `use_own_filter_lists` is not set in the
+            `POST /clients/add` request then the default value (false) will be
+            used, and the client uses the globally enabled filter lists.
+
+            If it is not set in the `POST /clients/update` request then the
+            existing value will not be changed.
+        'filter_list_ids':
+          'type': 'array'
+          'description': |
+            IDs of the blocking filter lists of the client.  They are only used
+            if `use_own_filter_lists` is `true`.
+
+            NOTE: If `filter_list_ids` is not set in the `POST /clients/update`
+            request then the existing value will not be changed.  Set it to an
+            empty array to clear it.
+          'items':
+            'type': 'integer'
+        'allow_filter_list_ids':
+          'type': 'array'
+          'description': |
+            IDs of the allowing filter lists of the client.  They are only used
+            if `use_own_filter_lists` is `true`.
+
+            NOTE: If `allow_filter_list_ids` is not set in the
+            `POST /clients/update` request then the existing value will not be
+            changed.  Set it to an empty array to clear it.
+          'items':
+            'type': 'integer'
         'blocked_services_schedule':
           '$ref': '#/components/schemas/Schedule'
         'blocked_services':


### PR DESCRIPTION
## Summary

Adds the ability to assign specific blocklists and allowlists to individual clients. When a client has `use_own_filter_lists` set, only the lists named in `filter_list_ids` and `allow_filter_list_ids` apply to it. Rules from the user's own list always apply, either way.

## What changed since the first review

**Backward compatibility.** The flag is now `use_own_filter_lists`, in the positive form, so its zero value keeps the global lists. The previous `use_global_filter_lists` decoded to `false` for every config file and every API request written before this feature existed, which flipped all existing clients onto an empty own list set and silently dropped every downloaded list. Thanks @Sil3ntVip3r for spotting it. The positive form fixes YAML and JSON at once, with no schema migration. Regression tests cover a legacy YAML client and an add/update payload without the field.

**Resource usage.** A globally disabled filter list is now downloaded and loaded into the engine only while at least one client references it, through a new `ClientFilterListIDs` hook on `filtering.Config`. A configuration without per client lists keeps exactly the memory and traffic it has today. In that case no match time filtering happens at all, so requests from clients on the global lists stay allocation free. Disabling a list also no longer triggers a download.

**Rule selection.** The match result is now narrowed with `rules.GetDNSBasicRule`, the same function `urlfilter` uses, instead of a hand written scan. `$badfilter`, `$replace`, and rule priority behave identically for clients with and without their own lists. The previous version resolved conflicts by position, so a rule negated by `$badfilter` could still block.

**Concurrency.** The enabled list ID sets are swapped inside the same `engineLock` critical section as the engines they describe, since `matchHost` reads both together. They were previously written under `filtersMu` only.

**Housekeeping.** OpenAPI schema and both changelogs updated. Unrelated `.gitignore` and `package-lock.json` churn removed. Rebased onto master.

## Test plan

* [x] `make go-lint` clean, same baseline as master
* [x] `make go-test` clean, race detector enabled
* [x] Legacy YAML config with no `use_own_filter_lists`: both global blocklists still apply
* [x] Client with `filter_list_ids: [1]`: list 1 blocks, list 2 does not, user rules still apply
* [x] Globally disabled list assigned to a client: the list works, and it is absent from the engine when no client uses it
* [x] Allowlists: global allowlist exempts, an unassigned allowlist does not, an assigned one does
* [x] `POST /control/clients/add` and `/update` without the field keep the global lists
* [x] YAML round trip saves and reloads the new fields
* [x] Assigning a disabled list through the API takes effect without a restart

Verified against a running instance with `dig`, not only in unit tests. Building the previous revision of this branch and pointing it at a legacy config reproduced the reported regression, which confirms the fix.
