### PR TITLE
querylog: truncate CGNAT (100.64.0.0/10) IPs to 100.64.0.0/32 in AnonymizeIP

### DIFF
--- a/internal/querylog/decode_internal_test.go
+++ b/internal/querylog/decode_internal_test.go
@@ -289,7 +289,11 @@ func TestDecodeLogEntry_backwardCompatability(t *testing.T) {
 // It only exists in purposes of benchmark comparison, see BenchmarkAnonymizeIP.
 func anonymizeIPSlow(ip net.IP) {
 	if ip4 := ip.To4(); ip4 != nil {
-		copy(ip4[net.IPv4len-2:net.IPv4len], []byte{0, 0})
+		if ip4[0] == 100 && ip4[1]&0xC0 == 64 {
+			copy(ip4[1:net.IPv4len], []byte{64, 0, 0})
+		} else {
+			copy(ip4[net.IPv4len-2:net.IPv4len], []byte{0, 0})
+		}
 	} else if len(ip) == net.IPv6len {
 		copy(ip[net.IPv6len-10:net.IPv6len], []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0})
 	}
@@ -324,6 +328,14 @@ func BenchmarkAnonymizeIP(b *testing.B) {
 			0x0, 0x0, 0x0, 0x0,
 			0x0, 0x0, 0x0, 0x0,
 		},
+	}, {
+		name: "v4_cgnat",
+		ip:   net.IP{100, 100, 1, 2},
+		want: net.IP{100, 64, 0, 0},
+	}, {
+		name: "v4_cgnat_mapped",
+		ip:   net.IP{100, 127, 255, 255}.To16(),
+		want: net.IP{100, 64, 0, 0}.To16(),
 	}, {
 		name: "invalid",
 		ip:   net.IP{1, 2, 3},

--- a/internal/querylog/http.go
+++ b/internal/querylog/http.go
@@ -157,10 +157,23 @@ func AnonymizeIP(ip net.IP) {
 	const zeroes = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
 
 	if ip4 := ip.To4(); ip4 != nil {
-		copy(ip4[net.IPv4len-2:net.IPv4len], zeroes)
+		if isCGNAT(ip4) {
+			// Truncate Tailscale/CGNAT IPs (100.64.0.0/10) to
+			// 100.64.0.0/32 so that individual device IPs within the
+			// /16 cannot be identified.
+			copy(ip4[1:net.IPv4len], zeroes)
+			ip4[1] = 64
+		} else {
+			copy(ip4[net.IPv4len-2:net.IPv4len], zeroes)
+		}
 	} else if len(ip) == net.IPv6len {
 		copy(ip[net.IPv6len-10:net.IPv6len], zeroes)
 	}
+}
+
+// isCGNAT returns true if ip4 is within the 100.64.0.0/10 CGNAT range.
+func isCGNAT(ip4 net.IP) (ok bool) {
+	return ip4[0] == 100 && ip4[1]&0xC0 == 64
 }
 
 // handleQueryLogConfig is the handler for the POST /control/querylog_config


### PR DESCRIPTION
Tailscale device IPs fall within the CGNAT range and the default /16 anonymization leaves enough bits to identify individual devices. Truncate to the network base address instead.
