### PR TITLE
Add ADGUARD_HOME_LOG_TO_STDOUT to log to stdout

### DIFF
--- a/internal/home/log.go
+++ b/internal/home/log.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"runtime"
 
@@ -55,6 +56,10 @@ func configureLogger(ls *logSettings, workDir string) (err error) {
 
 	// Write logs to stdout by default.
 	if ls.File == "" {
+		if os.Getenv("ADGUARD_HOME_LOG_TO_STDOUT") != "" {
+			log.SetOutput(os.Stdout)
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
Hello,

everywhere in the codebase, it is stated that when no logging file is given, it logs to stdout. The thing is that is not the case, see, in Go the default behavior is to log to stderr and this is exactly what AdGuard Home does. There is a reason for that behavior and that is in UNIX all logging or debugging output should really go to stderr. So one can argue all is good, change all those comments and everyone is happy.

Well, thing is, I use AdGuard in podman where stdout/stderr is forwarded into journald as info/err and I have all info/debug lines in red on my systems which is driving me crazy. For the record, I documented my podman setup in here: https://lukas.zapletalovi.com/posts/2025/deploy-adguard-via-quadlets/

Here is how it looks like, note the PRIORITY column:

```
journalctl -u adguard.service -n 1 -o json-pretty
{
        "_HOSTNAME" : "hori.internal",
        "_TRANSPORT" : "journal",
        "_BOOT_ID" : "5ab3767ca2c541448a1f5ae10f1da936",
        "__SEQNUM" : "44571",
        "_SYSTEMD_INVOCATION_ID" : "4d705c3b9f214a22902d51b8a4068b55",
        "_MACHINE_ID" : "16280e91e67f46939858b238138a23f2",
        "_SELINUX_CONTEXT" : "system_u:system_r:container_runtime_t:s0",
        "CODE_FILE" : "src/ctr_logging.c",
        "_COMM" : "conmon",
        "_CAP_EFFECTIVE" : "1ffffffffff",
        "CONTAINER_ID_FULL" : "b5dd6aed6b322ab73f18ef56eaeee286e16e4194dbb4818289ee282d181364bb",
        "_SYSTEMD_SLICE" : "system.slice",
        "__MONOTONIC_TIMESTAMP" : "36401872902",
        "__REALTIME_TIMESTAMP" : "1774369171572361",
        "CONTAINER_NAME" : "adguard",
        "_GID" : "0",
        "CODE_LINE" : "467",
        "MESSAGE" : "2026/03/24 16:19:31.572204 [info] dnsproxy: entering listener loop proto=tcp addr=192.168.1.9:53\n",
        "CODE_FUNC" : "write_journald",
        "_PID" : "69994",
        "_SYSTEMD_CGROUP" : "/system.slice/adguard.service/runtime",
        "_EXE" : "/usr/bin/conmon",
        "__CURSOR" : "s=7bde46e7d2e54a3faf57c806abdc3c76;i=ae1b;b=5ab3767ca2c541448a1f5ae10f1da936;m=879b88006;t=64dc7842c0689;x=b61889bf1d101745",
        "_UID" : "0",
        "PRIORITY" : "3",
        "_RUNTIME_SCOPE" : "system",
        "CONTAINER_ID" : "b5dd6aed6b32",
        "__SEQNUM_ID" : "7bde46e7d2e54a3faf57c806abdc3c76",
        "SYSLOG_IDENTIFIER" : "adguard",
        "_SYSTEMD_UNIT" : "adguard.service",
        "_CMDLINE" : "/usr/bin/conmon --api-version 1 -c b5dd6aed6b322ab73f18ef56eaeee286e16e4194dbb4818289ee282d181364bb -u b5dd6aed6b322ab73f18ef56eaeee286e16e4194db>
        "_SOURCE_REALTIME_TIMESTAMP" : "1774369171572241"
}
```

<img width="1139" height="311" alt="image" src="https://github.com/user-attachments/assets/e1bff7c3-3293-4ab4-81c2-f1e45f2eeb74" />


Now, to change the default behavior from stderr to stdout would be too disturbing, I get this. This is why I propose to introduce an environment variable which podman users can set and mitigate this behavior. Alternatively, a config option could be added too if this is what you want.

Cheers.