### PR TITLE
home: fix IPv6 support for DoH, DoT, DoQ, and HTTPS

### DIFF
--- a/internal/home/config.go
+++ b/internal/home/config.go
@@ -457,7 +457,7 @@ var config = &configuration{
 	AuthAttempts: 5,
 	AuthBlockMin: 15,
 	HTTPConfig: httpConfig{
-		Address:    netip.AddrPortFrom(netip.IPv4Unspecified(), 3000),
+		Address:    netip.AddrPortFrom(netip.IPv6Unspecified(), 3000),
 		SessionTTL: timeutil.Duration(30 * timeutil.Day),
 		Pprof: &httpPprofConfig{
 			Enabled: false,
@@ -474,7 +474,7 @@ var config = &configuration{
 		},
 	},
 	DNS: dnsConfig{
-		BindHosts: []netip.Addr{netip.IPv4Unspecified()},
+		BindHosts: []netip.Addr{netip.IPv4Unspecified(), netip.IPv6Unspecified()},
 		Port:      defaultPortDNS,
 		Config: dnsforward.Config{
 			Ratelimit:              20,

--- a/internal/home/config_internal_test.go
+++ b/internal/home/config_internal_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/AdguardTeam/AdGuardHome/internal/aghtest"
+	"github.com/AdguardTeam/golibs/netutil"
 	"github.com/AdguardTeam/golibs/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -88,4 +90,32 @@ func TestConfigFilePath(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestNewServerConfig_DefaultHosts(t *testing.T) {
+	dnsConf := &dnsConfig{
+		BindHosts: nil,
+		Port:      53,
+		PendingRequests: &pendingRequests{
+			Enabled: false,
+		},
+	}
+	tlsConf := &tlsConfigSettings{}
+	dohConf := &doHConfig{}
+
+	conf, err := newServerConfig(
+		dnsConf,
+		&clientSourcesConfig{},
+		tlsConf,
+		dohConf,
+		&tlsManager{},
+		&aghtest.Registrar{},
+		nil, // clientsContainer
+		&aghtest.ConfigModifier{},
+	)
+	require.NoError(t, err)
+	require.Len(t, conf.UDPListenAddrs, 2)
+
+	assert.Equal(t, netutil.IPv4Localhost().String(), conf.UDPListenAddrs[0].IP.String())
+	assert.Equal(t, netutil.IPv6Localhost().String(), conf.UDPListenAddrs[1].IP.String())
 }

--- a/internal/home/control.go
+++ b/internal/home/control.go
@@ -71,7 +71,7 @@ func appendDNSAddrsWithIfaces(dst []string, src []netip.Addr) (res []string, err
 // tlsMgr must not be nil.
 func collectDNSAddresses(tlsMgr *tlsManager) (addrs []string, err error) {
 	if hosts := config.DNS.BindHosts; len(hosts) == 0 {
-		addrs = appendDNSAddrs(addrs, netutil.IPv4Localhost())
+		addrs = appendDNSAddrs(addrs, netutil.IPv4Localhost(), netutil.IPv6Localhost())
 	} else {
 		addrs, err = appendDNSAddrsWithIfaces(addrs, hosts)
 		if err != nil {

--- a/internal/home/dns.go
+++ b/internal/home/dns.go
@@ -269,7 +269,10 @@ func newServerConfig(
 	clientsContainer dnsforward.ClientsContainer,
 	confModifier agh.ConfigModifier,
 ) (newConf *dnsforward.ServerConfig, err error) {
-	hosts := aghalg.CoalesceSlice(dnsConf.BindHosts, []netip.Addr{netutil.IPv4Localhost()})
+	hosts := aghalg.CoalesceSlice(dnsConf.BindHosts, []netip.Addr{
+		netutil.IPv4Localhost(),
+		netutil.IPv6Localhost(),
+	})
 
 	fwdConf := dnsConf.Config
 	fwdConf.ClientsContainer = clientsContainer

--- a/internal/home/web.go
+++ b/internal/home/web.go
@@ -251,6 +251,17 @@ func (web *webAPI) tlsConfigChanged(ctx context.Context, tlsConf *tlsConfigSetti
 // loggerKeyServer is the key used by [webAPI] to identify servers.
 const loggerKeyServer = "server"
 
+// getBindAddr returns the address string for the server to listen on.  If the
+// address is unspecified, it returns the ":port" format to enable dual-stack
+// listening.
+func (web *webAPI) getBindAddr(addr netip.Addr, port uint16) (addrStr string) {
+	if addr.IsUnspecified() {
+		return netutil.JoinHostPort("", port)
+	}
+
+	return netip.AddrPortFrom(addr, port).String()
+}
+
 // start - start serving HTTP requests
 func (web *webAPI) start(ctx context.Context) {
 	defer slogutil.RecoverAndExit(ctx, web.logger, osutil.ExitCodeFailure)
@@ -283,7 +294,7 @@ func (web *webAPI) start(ctx context.Context) {
 
 		// Create a new instance, because the Web is not usable after Shutdown.
 		web.httpServer = &http.Server{
-			Addr:              web.conf.BindAddr.String(),
+			Addr:              web.getBindAddr(web.conf.BindAddr.Addr(), web.conf.BindAddr.Port()),
 			Handler:           hdlr,
 			ReadTimeout:       web.conf.ReadTimeout,
 			ReadHeaderTimeout: web.conf.ReadHeaderTimeout,
@@ -359,7 +370,7 @@ func (web *webAPI) serveTLS(ctx context.Context) (next bool) {
 		portHTTPS = config.TLS.PortHTTPS
 	}()
 
-	addr := netip.AddrPortFrom(web.conf.BindAddr.Addr(), portHTTPS).String()
+	addrStr := web.getBindAddr(web.conf.BindAddr.Addr(), portHTTPS)
 	logger := web.baseLogger.With(loggerKeyServer, "https")
 
 	// TODO(a.garipov):  Remove other logs like this in other code.
@@ -367,7 +378,7 @@ func (web *webAPI) serveTLS(ctx context.Context) (next bool) {
 	hdlr := logMw.Wrap(withMiddlewares(web.conf.mux, limitRequestBody))
 
 	web.httpsServer.server = &http.Server{
-		Addr:    addr,
+		Addr:    addrStr,
 		Handler: web.auth.middleware().Wrap(hdlr),
 		TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{web.httpsServer.cert},
@@ -384,7 +395,7 @@ func (web *webAPI) serveTLS(ctx context.Context) (next bool) {
 	printHTTPAddresses(ctx, web.logger, urlutil.SchemeHTTPS, web.tlsManager)
 
 	if web.conf.serveHTTP3 {
-		go web.mustStartHTTP3(ctx, addr)
+		go web.mustStartHTTP3(ctx, addrStr)
 	}
 
 	logger.InfoContext(ctx, "starting https server")
@@ -443,10 +454,9 @@ func (web *webAPI) mustStartHTTP3(ctx context.Context, address string) {
 	}
 }
 
-// startPprof launches the debug and profiling server on the provided port.
+// startPprof launches the debug and profiling server on the provided port on
+// both IPv4 and IPv6 loopback addresses.
 func startPprof(baseLogger *slog.Logger, port uint16) {
-	addr := netip.AddrPortFrom(netutil.IPv4Localhost(), port)
-
 	runtime.SetBlockProfileRate(1)
 	runtime.SetMutexProfileFraction(1)
 
@@ -456,13 +466,24 @@ func startPprof(baseLogger *slog.Logger, port uint16) {
 	ctx := context.Background()
 	logger := baseLogger.With(slogutil.KeyPrefix, "pprof")
 
-	go func() {
-		defer slogutil.RecoverAndLog(ctx, logger)
+	go servePprof(ctx, logger, mux, netutil.IPv4Localhost(), port)
+	go servePprof(ctx, logger, mux, netutil.IPv6Localhost(), port)
+}
 
-		logger.InfoContext(ctx, "listening", "addr", addr)
-		err := http.ListenAndServe(addr.String(), mux)
-		if !errors.Is(err, http.ErrServerClosed) {
-			logger.ErrorContext(ctx, "shutting down", slogutil.KeyError, err)
-		}
-	}()
+// servePprof serves the pprof HTTP endpoints on the given host and port.
+func servePprof(
+	ctx context.Context,
+	logger *slog.Logger,
+	mux *http.ServeMux,
+	host netip.Addr,
+	port uint16,
+) {
+	defer slogutil.RecoverAndLog(ctx, logger)
+
+	addrStr := netip.AddrPortFrom(host, port).String()
+	logger.InfoContext(ctx, "listening", "addr", addrStr)
+	err := http.ListenAndServe(addrStr, mux)
+	if !errors.Is(err, http.ErrServerClosed) {
+		logger.ErrorContext(ctx, "shutting down", slogutil.KeyError, err)
+	}
 }


### PR DESCRIPTION
## Fixes #8363

DoH, DoT, DoQ, and the HTTPS admin panel were only binding to IPv4 even when the user had IPv6 configured.

### What changed
- Unspecified-address listeners now use `:port` format for dual-stack support
- Default bind addresses updated to include `::`
- `pprof` now listens on both `127.0.0.1` and `[::1]` (was IPv4 loopback only)

### Testing
Added `TestNewServerConfig_DefaultHosts` to verify dual-stack fallback. `make go-check` passes.