### PR TITLE
dhcpd: skip empty disabled dhcpv4 config

### DIFF
--- a/internal/dhcpd/dhcpd_unix_internal_test.go
+++ b/internal/dhcpd/dhcpd_unix_internal_test.go
@@ -129,6 +129,14 @@ func TestV4Server_badRange(t *testing.T) {
 	}
 }
 
+func TestV4Server_Create_disabled(t *testing.T) {
+	s, err := v4Create(&V4ServerConf{})
+
+	require.NoError(t, err)
+	assert.NotNil(t, s)
+	assert.False(t, s.enabled())
+}
+
 // cloneUDPAddr returns a deep copy of a.
 func cloneUDPAddr(a *net.UDPAddr) (clone *net.UDPAddr) {
 	return &net.UDPAddr{

--- a/internal/dhcpd/v4_unix.go
+++ b/internal/dhcpd/v4_unix.go
@@ -1417,6 +1417,15 @@ func v4Create(conf *V4ServerConf) (srv *v4Server, err error) {
 		ipIndex:    map[netip.Addr]*dhcpsvc.Lease{},
 	}
 
+	if conf != nil &&
+		!conf.Enabled &&
+		!conf.GatewayIP.IsValid() &&
+		!conf.SubnetMask.IsValid() &&
+		!conf.RangeStart.IsValid() &&
+		!conf.RangeEnd.IsValid() {
+		return s, nil
+	}
+
 	err = conf.Validate()
 	if err != nil {
 		// TODO(a.garipov): Don't use a disabled server in other places or just


### PR DESCRIPTION
Updates #8348.

When DHCPv4 is disabled and its address fields are empty, `v4Create` now returns an unconfigured disabled server without validating the empty IPv4 addresses.

Disabled but configured DHCPv4 settings still go through validation, so existing status output for saved disabled DHCPv4 ranges is preserved.

Tests:

- `go test ./internal/dhcpd`
- `make go-check`

Note: `make go-check` prints existing `govulncheck` findings for the pinned Go 1.26.2 standard library, but the target exits successfully.