### PR TITLE
fix: ignore downgrade update checks

### DIFF
--- a/internal/updater/check.go
+++ b/internal/updater/check.go
@@ -8,11 +8,13 @@ import (
 	"maps"
 	"net/http"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/AdguardTeam/AdGuardHome/internal/aghalg"
 	"github.com/AdguardTeam/golibs/errors"
 	"github.com/AdguardTeam/golibs/ioutil"
+	"github.com/AdguardTeam/AdGuardHome/internal/version"
 	"github.com/c2h5oh/datasize"
 	"golang.org/x/mod/semver"
 )
@@ -99,7 +101,7 @@ func (u *Updater) parseVersionResponse(ctx context.Context, data []byte) (Versio
 	info.Announcement = versionJSON["announcement"]
 	info.AnnouncementURL = versionJSON["announcement_url"]
 
-	if semver.Compare(info.NewVersion, u.version) <= 0 {
+	if !isNewerVersion(info.NewVersion, u.version, u.channel) {
 		info.NewVersion = u.version
 
 		return info, nil
@@ -116,6 +118,34 @@ func (u *Updater) parseVersionResponse(ctx context.Context, data []byte) (Versio
 	u.packageURL = packageURL
 
 	return info, nil
+}
+
+func isNewerVersion(newVersion, currentVersion, channel string) bool {
+	if semver.Compare(newVersion, currentVersion) > 0 {
+		return true
+	}
+
+	if semver.Compare(versionCore(newVersion), versionCore(currentVersion)) > 0 {
+		return true
+	}
+
+	return channel != version.ChannelRelease &&
+		versionCore(newVersion) == versionCore(currentVersion) &&
+		hasPrerelease(newVersion) &&
+		!hasPrerelease(currentVersion)
+}
+
+func versionCore(v string) string {
+	core, _, found := strings.Cut(v, "-")
+	if !found {
+		return v
+	}
+
+	return core
+}
+
+func hasPrerelease(v string) bool {
+	return strings.Contains(v, "-")
 }
 
 // downloadURL returns the download URL for current build as well as its key in

--- a/internal/updater/check.go
+++ b/internal/updater/check.go
@@ -14,6 +14,7 @@ import (
 	"github.com/AdguardTeam/golibs/errors"
 	"github.com/AdguardTeam/golibs/ioutil"
 	"github.com/c2h5oh/datasize"
+	"golang.org/x/mod/semver"
 )
 
 // TODO(a.garipov): Make configurable.
@@ -98,12 +99,18 @@ func (u *Updater) parseVersionResponse(ctx context.Context, data []byte) (Versio
 	info.Announcement = versionJSON["announcement"]
 	info.AnnouncementURL = versionJSON["announcement_url"]
 
+	if semver.Compare(info.NewVersion, u.version) <= 0 {
+		info.NewVersion = u.version
+
+		return info, nil
+	}
+
 	packageURL, key, found := u.downloadURL(ctx, versionJSON)
 	if !found {
 		return info, fmt.Errorf("version.json: no package URL: key %q not found in object", key)
 	}
 
-	info.CanAutoUpdate = aghalg.BoolToNullBool(info.NewVersion != u.version)
+	info.CanAutoUpdate = aghalg.NBTrue
 
 	u.newVersion = info.NewVersion
 	u.packageURL = packageURL

--- a/internal/updater/check_test.go
+++ b/internal/updater/check_test.go
@@ -155,3 +155,35 @@ func TestUpdater_VersionInfo_others(t *testing.T) {
 		assert.Equal(t, aghalg.NBTrue, info.CanAutoUpdate)
 	}
 }
+
+func TestUpdater_VersionInfo_olderVersion(t *testing.T) {
+	const jsonData = `{
+  "version": "v0.107.75",
+  "announcement": "AdGuard Home v0.107.75 is now available!",
+  "announcement_url": "https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.107.75",
+  "selfupdate_min_version": "v0.0",
+  "download_linux_amd64": "https://static.adtidy.org/adguardhome/release/AdGuardHome_linux_amd64.tar.gz"
+}`
+
+	fakeClient, fakeURL := aghtest.StartHTTPServer(t, []byte(jsonData))
+	fakeURL = fakeURL.JoinPath("adguardhome", version.ChannelRelease, "version.json")
+
+	u := updater.NewUpdater(&updater.Config{
+		Client:             fakeClient,
+		Logger:             testLogger,
+		CommandConstructor: testCmdCons,
+		Version:            "v0.107.76",
+		Channel:            version.ChannelRelease,
+		GOOS:               "linux",
+		GOARCH:             "amd64",
+		VersionCheckURL:    fakeURL,
+	})
+
+	ctx := testutil.ContextWithTimeout(t, testTimeout)
+	info, err := u.VersionInfo(ctx, false)
+	require.NoError(t, err)
+
+	assert.Equal(t, "v0.107.76", info.NewVersion)
+	assert.Equal(t, aghalg.NBFalse, info.CanAutoUpdate)
+	assert.Empty(t, u.NewVersion())
+}


### PR DESCRIPTION
Fixes #8393.

Repro: run v0.107.76, point /control/version.json at v0.107.75, then hit Check for updates. It offers a downgrade as an upgrade

Now the updater ignores true downgrades, but beta checks still work. Small fix