### PR TITLE
add option to use EDNS Client Subnet IP in statistics and query log

### DIFF
--- a/client/src/__locales/en.json
+++ b/client/src/__locales/en.json
@@ -251,6 +251,8 @@
   "edns_enable": "Enable EDNS client subnet",
   "edns_use_custom_ip": "Use custom IP for EDNS",
   "edns_use_custom_ip_desc": "Allow to use custom IP for EDNS",
+  "edns_use_in_stats": "Use EDNS client subnet for statistics",
+  "edns_use_in_stats_desc": "If enabled, the client IP from the EDNS Client Subnet option will be used in statistics and query log instead of the real connection IP.  Use this when AdGuard Home runs behind a DNS proxy.",
   "elapsed": "Elapsed",
   "empty_response_status": "Empty",
   "enable_protection": "Enable protection",

--- a/client/src/components/Settings/Dns/Config/Form.tsx
+++ b/client/src/components/Settings/Dns/Config/Form.tsx
@@ -19,6 +19,7 @@ type FormData = {
     edns_cs_enabled: boolean;
     edns_cs_use_custom: boolean;
     edns_cs_custom_ip?: string;
+    edns_cs_use_in_stats: boolean;
     dnssec_enabled: boolean;
     disable_ipv6: boolean;
     blocking_mode: string;
@@ -253,6 +254,24 @@ const Form = ({ processing, initialValues, onSubmit }: Props) => {
                                 />
                             )}
                         />
+                    </div>
+
+                    <div className="col-12">
+                        <div className="form__group form__group--settings">
+                            <Controller
+                                name="edns_cs_use_in_stats"
+                                control={control}
+                                render={({ field }) => (
+                                    <Checkbox
+                                        {...field}
+                                        data-testid="dns_config_edns_use_in_stats"
+                                        title={t('edns_use_in_stats')}
+                                        subtitle={t('edns_use_in_stats_desc')}
+                                        disabled={processing || !edns_cs_enabled}
+                                    />
+                                )}
+                            />
+                        </div>
                     </div>
 
                     {edns_cs_use_custom && (

--- a/client/src/components/Settings/Dns/Config/index.tsx
+++ b/client/src/components/Settings/Dns/Config/index.tsx
@@ -23,6 +23,7 @@ const Config = () => {
         edns_cs_enabled,
         edns_cs_use_custom,
         edns_cs_custom_ip,
+        edns_cs_use_in_stats,
         dnssec_enabled,
         disable_ipv6,
         processingSetConfig,
@@ -50,6 +51,7 @@ const Config = () => {
                         dnssec_enabled,
                         edns_cs_use_custom,
                         edns_cs_custom_ip,
+                        edns_cs_use_in_stats,
                     }}
                     onSubmit={handleFormSubmit}
                     processing={processingSetConfig}

--- a/client/src/initialState.ts
+++ b/client/src/initialState.ts
@@ -329,6 +329,7 @@ export type DnsConfigData = {
     ratelimit_subnet_len_ipv6?: number;
     edns_cs_use_custom?: boolean;
     edns_cs_custom_ip?: string;
+    edns_cs_use_in_stats?: boolean;
     cache_enabled?: boolean;
     cache_size?: number;
     cache_ttl_max?: number;

--- a/client/src/reducers/dnsConfig.ts
+++ b/client/src/reducers/dnsConfig.ts
@@ -68,6 +68,7 @@ const dnsConfig = handleActions(
         blocked_response_ttl: 10,
         upstream_timeout: 10,
         edns_cs_enabled: false,
+        edns_cs_use_in_stats: false,
         disable_ipv6: false,
         dnssec_enabled: false,
         upstream_dns_file: '',

--- a/internal/dnsforward/config.go
+++ b/internal/dnsforward/config.go
@@ -181,6 +181,11 @@ type EDNSClientSubnet struct {
 
 	// UseCustom defines if CustomIP should be used.
 	UseCustom bool `yaml:"use_custom"`
+
+	// UseInStats defines if the client IP from EDNS Client Subnet should be
+	// used in statistics and query log instead of the real connection IP.
+	// Disabled by default.
+	UseInStats bool `yaml:"use_in_stats"`
 }
 
 // TLSConfig contains the TLS configuration settings for DNSCrypt,

--- a/internal/dnsforward/http.go
+++ b/internal/dnsforward/http.go
@@ -73,6 +73,11 @@ type jsonDNSConfig struct {
 	// EDNSCSUseCustom defines if EDNSCSCustomIP should be used.
 	EDNSCSUseCustom *bool `json:"edns_cs_use_custom"`
 
+	// EDNSCSUseInStats defines if the client IP from EDNS Client Subnet
+	// should be used in statistics and query log instead of the actual
+	// connection IP.
+	EDNSCSUseInStats *bool `json:"edns_cs_use_in_stats"`
+
 	// DNSSECEnabled defines if DNSSEC is enabled.
 	DNSSECEnabled *bool `json:"dnssec_enabled"`
 
@@ -163,6 +168,7 @@ func (s *Server) getDNSConfig(ctx context.Context) (c *jsonDNSConfig) {
 	customIP := s.conf.EDNSClientSubnet.CustomIP
 	enableEDNSClientSubnet := s.conf.EDNSClientSubnet.Enabled
 	useCustom := s.conf.EDNSClientSubnet.UseCustom
+	useInStats := s.conf.EDNSClientSubnet.UseInStats
 
 	enableDNSSEC := s.conf.EnableDNSSEC
 	aaaaDisabled := s.conf.AAAADisabled
@@ -209,6 +215,7 @@ func (s *Server) getDNSConfig(ctx context.Context) (c *jsonDNSConfig) {
 		EDNSCSCustomIP:           customIP,
 		EDNSCSEnabled:            &enableEDNSClientSubnet,
 		EDNSCSUseCustom:          &useCustom,
+		EDNSCSUseInStats:         &useInStats,
 		DNSSECEnabled:            &enableDNSSEC,
 		DisableIPv6:              &aaaaDisabled,
 		BlockedResponseTTL:       &blockedResponseTTL,
@@ -658,6 +665,7 @@ func (s *Server) setConfigRestartable(dc *jsonDNSConfig) (shouldRestart bool) {
 		setIfNotNil(&s.conf.FallbackDNS, dc.Fallbacks),
 		setIfNotNil(&s.conf.EDNSClientSubnet.Enabled, dc.EDNSCSEnabled),
 		setIfNotNil(&s.conf.EDNSClientSubnet.UseCustom, dc.EDNSCSUseCustom),
+		setIfNotNil(&s.conf.EDNSClientSubnet.UseInStats, dc.EDNSCSUseInStats),
 		setIfNotNil(&s.conf.CacheEnabled, dc.CacheEnabled),
 		setIfNotNil(&s.conf.CacheSize, dc.CacheSize),
 		setIfNotNil(&s.conf.CacheMinTTL, dc.CacheMinTTL),

--- a/internal/dnsforward/stats.go
+++ b/internal/dnsforward/stats.go
@@ -30,6 +30,9 @@ func (s *Server) processQueryLogsAndStats(
 	processingTime := time.Since(dctx.startTime)
 
 	ip := pctx.Addr.Addr().AsSlice()
+	if s.conf.EDNSClientSubnet != nil && s.conf.EDNSClientSubnet.UseInStats && pctx.ReqECS != nil {
+		ip = pctx.ReqECS.IP
+	}
 	s.anonymizer.Load()(ip)
 	ipStr := net.IP(ip).String()
 

--- a/internal/dnsforward/testdata/TestDNSForwardHTTP_handleGetConfig.json
+++ b/internal/dnsforward/testdata/TestDNSForwardHTTP_handleGetConfig.json
@@ -38,7 +38,8 @@
     "use_private_ptr_resolvers": false,
     "local_ptr_upstreams": [],
     "edns_cs_use_custom": false,
-    "edns_cs_custom_ip": ""
+    "edns_cs_custom_ip": "",
+    "edns_cs_use_in_stats": false
   },
   "fastest_addr": {
     "upstream_dns": [
@@ -79,7 +80,8 @@
     "use_private_ptr_resolvers": false,
     "local_ptr_upstreams": [],
     "edns_cs_use_custom": false,
-    "edns_cs_custom_ip": ""
+    "edns_cs_custom_ip": "",
+    "edns_cs_use_in_stats": false
   },
   "parallel": {
     "upstream_dns": [
@@ -120,6 +122,7 @@
     "use_private_ptr_resolvers": false,
     "local_ptr_upstreams": [],
     "edns_cs_use_custom": false,
-    "edns_cs_custom_ip": ""
+    "edns_cs_custom_ip": "",
+    "edns_cs_use_in_stats": false
   }
 }

--- a/internal/dnsforward/testdata/TestDNSForwardHTTP_handleSetConfig.json
+++ b/internal/dnsforward/testdata/TestDNSForwardHTTP_handleSetConfig.json
@@ -43,7 +43,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "bootstraps": {
@@ -86,7 +87,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "blocking_mode_good": {
@@ -130,7 +132,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "blocking_mode_bad": {
@@ -174,7 +177,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "ratelimit": {
@@ -218,7 +222,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "ratelimit_subnet_len": {
@@ -264,7 +269,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "ratelimit_whitelist_not_ip": {
@@ -311,7 +317,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "edns_cs_enabled": {
@@ -355,7 +362,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "edns_cs_use_custom": {
@@ -401,7 +409,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": true,
-      "edns_cs_custom_ip": "1.2.3.4"
+      "edns_cs_custom_ip": "1.2.3.4",
+      "edns_cs_use_in_stats": false
     }
   },
   "edns_cs_use_custom_bad_ip": {
@@ -447,7 +456,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "dnssec_enabled": {
@@ -491,7 +501,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "cache_size": {
@@ -535,7 +546,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "cache_enabled": {
@@ -580,7 +592,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "upstream_mode_parallel": {
@@ -624,7 +637,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "upstream_mode_fastest_addr": {
@@ -668,7 +682,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "upstream_dns_bad": {
@@ -714,7 +729,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "bootstraps_bad": {
@@ -760,7 +776,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "cache_bad_ttl": {
@@ -805,7 +822,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "upstream_mode_bad": {
@@ -849,7 +867,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "local_ptr_upstreams_good": {
@@ -897,7 +916,8 @@
         "123.123.123.123"
       ],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "local_ptr_upstreams_bad": {
@@ -944,7 +964,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "local_ptr_upstreams_null": {
@@ -988,7 +1009,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "fallbacks": {
@@ -1036,7 +1058,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "blocked_response_ttl": {
@@ -1080,7 +1103,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "multiple_domain_specific_upstreams": {
@@ -1127,7 +1151,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   },
   "upstream_timeout": {
@@ -1171,7 +1196,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_in_stats": false
     }
   }
 }

--- a/internal/home/config.go
+++ b/internal/home/config.go
@@ -497,9 +497,10 @@ var config = &configuration{
 			EnableDNSSEC:             true,
 
 			EDNSClientSubnet: &dnsforward.EDNSClientSubnet{
-				CustomIP:  netip.Addr{},
-				Enabled:   false,
-				UseCustom: false,
+				CustomIP:   netip.Addr{},
+				Enabled:    false,
+				UseCustom:  false,
+				UseInStats: false,
 			},
 
 			// set default maximum concurrent queries to 300


### PR DESCRIPTION
## Summary

Closes **#1727** — Allow using EDNS Client Subnet client IP in statistics and query log instead of the actual connection IP.

When AdGuard Home runs behind a DNS proxy (e.g., `dnsmasq`, `unbound`, a load balancer, or Kubernetes `NodePort`), all client IPs in statistics and query log appear as the proxy's IP. With EDNS Client Subnet enabled, clients may send their original IP via the EDSN0 option. This change allows users to opt-in to using the ECS client IP for identification in statistics and query log.

## How it works

- Adds a new boolean field `UseInStats` to the `EDNSClientSubnet` config
- When `UseInStats` is `true` and the incoming DNS query contains an EDNS Client Subnet option (`pctx.ReqECS != nil`), the ECS IP replaces `pctx.Addr.Addr().AsSlice()` in `processQueryLogsAndStats()`
- The IP still passes through the anonymizer, so privacy controls are preserved
- The upstream EDNS behavior (custom IP, etc.) is unaffected — this only affects stats/query log *client* identification
- **Disabled by default** — no behavioral change for existing users

## Changes

### Backend (`internal/dnsforward/`)

| File | Change |
|------|--------|
| `config.go` | Added `UseInStats bool` field to `EDNSClientSubnet` struct |
| `http.go` | Added `EDNSCSUseInStats *bool` to `jsonDNSConfig`, serialized in `getDNSConfig()`, deserialized via `setIfNotNil` in `setConfigRestartable()` |
| `stats.go` | Added ECS IP selection logic in `processQueryLogsAndStats()` — when `UseInStats && pctx.ReqECS != nil`, uses ECS IP |

### Backend (`internal/home/`)

| File | Change |
|------|--------|
| `config.go` | Added `UseInStats: false` default in default configuration |

### Frontend (`client/`)

| File | Change |
|------|--------|
| `Form.tsx` | Added `edns_cs_use_in_stats` checkbox to DNS Settings form, disabled when ECS is disabled |
| `index.tsx` | Added `edns_cs_use_in_stats` to selector and `initialValues` |
| `reducers/dnsConfig.ts` | Added `edns_cs_use_in_stats: false` to initial state |
| `initialState.ts` | Added `edns_cs_use_in_stats?: boolean` to `DnsConfigData` type |
| `__locales/en.json` | Added `edns_use_in_stats` and `edns_use_in_stats_desc` i18n keys |

### Test data

| File | Change |
|------|--------|
| `TestDNSForwardHTTP_handleGetConfig.json` | Added `"edns_cs_use_in_stats": false` to all expected responses |
| `TestDNSForwardHTTP_handleSetConfig.json` | Added `"edns_cs_use_in_stats": false` to all expected responses |

## Verification

### 1. Unit tests

```bash
cd internal/dnsforward && go test -run \
  "TestServer_ProcessQueryLogsAndStats|TestDNSForwardHTTP_handleGetConfig|TestDNSForwardHTTP_handleSetConfig" \
  -v -count=1
```

All pass.

### 2. Manual test (API)

```bash
# Enable ECS + use_in_stats
curl -X POST http://localhost:8080/control/dns_config \
  -H "Content-Type: application/json" \
  -d '{
    "edns_cs_enabled": true,
    "edns_cs_use_custom": true,
    "edns_cs_custom_ip": "1.2.3.4",
    "edns_cs_use_in_stats": true
  }'

# Send query WITH ECS subnet option
dig @localhost -p 5300 example.com A +subnet=10.0.0.1/24

# Check query log
curl -s http://localhost:8080/control/querylog?limit=1 | jq '.data[0].client, .data[0].ecs'
```

### 3. Manual test (Web UI)

1. Open **Settings → DNS Settings**
2. Check **Enable EDNS client subnet**
3. Check **Use EDNS client subnet for statistics**
4. Click **Save**
5. Send a query with ECS: `dig @localhost example.com +subnet=10.0.0.1/24`
6. Verify query log shows `10.0.0.0` (the ECS subnet IP, anonymized with /24)

## Test Results (verified)

### With `use_in_stats: true`

```
Client IP in query log: 10.0.0.0    ← ECS subnet IP (10.0.0.1/24, anonymized)
ECS field:               10.0.0.0/24
Connection IP:           (not used for client identification)
```

### With `use_in_stats: false` (default)

```
Client IP in query log: 172.17.0.1  ← actual connection IP
ECS field:               10.0.0.0/24
```

## API Contract

New field in `GET /control/dns_info` and `POST /control/dns_config`:

```json
{
  "edns_cs_enabled": true,
  "edns_cs_use_custom": true,
  "edns_cs_custom_ip": "1.2.3.4",
  "edns_cs_use_in_stats": true
}
```

## Design decisions

- **Disabled by default** — zero impact on existing installations, no config migration needed
- **Stored alongside existing EDNS settings** — logically belongs with the ECS configuration block
- **Works with both auto ECS and custom ECS IP** — `pctx.ReqECS` is populated by dnsproxy regardless of `use_custom` setting
- **Anonymization respected** — ECS IP passes through `s.anonymizer.Load()(ip)` same as connection IP
- **No restart required** — live config update via `setConfigRestartable`

## Caveats

- Only works when the *incoming client query* includes an EDNS Client Subnet option (`pctx.ReqECS`)
- If the client does not send ECS, falls back to connection IP (same as before)
- If `use_custom` is set, the custom IP is sent to *upstreams* but `pctx.ReqECS` still contains the *client's* ECS option (or nil if client didn't send one)
