### PR TITLE
Fix DNS rewrite CNAMEs for DHCP hostnames

### DIFF
--- a/internal/dnsforward/process.go
+++ b/internal/dnsforward/process.go
@@ -447,26 +447,16 @@ func (s *Server) processUpstream(
 	defer l.DebugContext(ctx, "finished processing upstream")
 
 	pctx := dctx.proxyCtx
-	req := pctx.Req
 
 	if pctx.Res != nil {
 		// The response has already been set.
 		return resultCodeSuccess
 	} else if dctx.isDHCPHost {
-		// A DHCP client hostname query that hasn't been handled or filtered.
-		// Respond with an NXDOMAIN.
-		//
-		// TODO(a.garipov): Route such queries to a custom upstream for the
-		// local domain name if there is one.
-		name := req.Question[0].Name
-		l.DebugContext(
-			ctx,
-			"dhcp client hostname was not filtered",
-			"hostname", name[:len(name)-1],
-		)
-		pctx.Res = s.NewMsgNXDOMAIN(req)
-
-		return resultCodeFinish
+		resolveNormally := false
+		rc, resolveNormally = s.processUnresolvedDHCPHost(ctx, l, dctx)
+		if !resolveNormally {
+			return rc
+		}
 	}
 
 	s.setCustomUpstream(ctx, l, pctx, dctx.clientID)
@@ -487,6 +477,45 @@ func (s *Server) processUpstream(
 	dctx.responseAD = pctx.Res.AuthenticatedData
 
 	return resultCodeSuccess
+}
+
+// processUnresolvedDHCPHost handles local DHCP hostnames that were not resolved
+// by [*Server.processDHCPHosts].  If resolveNormally is true, the caller should
+// continue resolving the request through the usual upstream path.
+func (s *Server) processUnresolvedDHCPHost(
+	ctx context.Context,
+	l *slog.Logger,
+	dctx *dnsContext,
+) (rc resultCode, resolveNormally bool) {
+	pctx := dctx.proxyCtx
+	if dctx.origQuestion.Name != "" {
+		rc = s.processDHCPHosts(ctx, l, dctx)
+		if rc != resultCodeSuccess || pctx.Res != nil {
+			return rc, false
+		} else if !dctx.isDHCPHost {
+			return resultCodeSuccess, true
+		}
+	}
+
+	// A DHCP client hostname query that hasn't been handled or filtered.
+	// Respond with an NXDOMAIN.
+	//
+	// TODO(a.garipov): Route such queries to a custom upstream for the local
+	// domain name if there is one.
+	req := pctx.Req
+	name := req.Question[0].Name
+	l.DebugContext(
+		ctx,
+		"dhcp client hostname was not filtered",
+		"hostname", name[:len(name)-1],
+	)
+	pctx.Res = s.NewMsgNXDOMAIN(req)
+
+	if dctx.origQuestion.Name != "" {
+		return resultCodeSuccess, false
+	}
+
+	return resultCodeFinish, false
 }
 
 // dhcpHostFromRequest returns a hostname from question, if the request is for a

--- a/internal/dnsforward/process_internal_test.go
+++ b/internal/dnsforward/process_internal_test.go
@@ -500,6 +500,101 @@ func TestServer_ProcessDHCPHosts_localRestriction(t *testing.T) {
 	}
 }
 
+func TestServer_ProcessDHCPHosts_rewrittenCNAME(t *testing.T) {
+	const (
+		localDomainSuffix = "lan"
+		dhcpClient        = "example"
+		originalHost      = "service.example.lan"
+	)
+
+	knownIP := netip.MustParseAddr("1.2.3.4")
+	dhcp := &testDHCP{
+		OnEnabled: func() (_ bool) { return true },
+		OnIPByHost: func(host string) (ip netip.Addr) {
+			if host == dhcpClient {
+				ip = knownIP
+			}
+
+			return ip
+		},
+		OnHostByIP: func(ip netip.Addr) (_ string) { panic(testutil.UnexpectedCall(ip)) },
+	}
+
+	f, err := filtering.New(&filtering.Config{
+		Logger:       testLogger,
+		BlockingMode: filtering.BlockingModeDefault,
+	}, []filtering.Filter{{
+		ID:   0,
+		Data: []byte("|service.example.lan^$dnsrewrite=example.lan"),
+	}})
+	require.NoError(t, err)
+	f.SetEnabled(true)
+
+	s, err := NewServer(DNSCreateParams{
+		DHCPServer:  dhcp,
+		DNSFilter:   f,
+		PrivateNets: netutil.SubnetSetFunc(netutil.IsLocallyServed),
+		Logger:      testLogger,
+		LocalDomain: localDomainSuffix,
+	})
+	require.NoError(t, err)
+	err = s.Prepare(testutil.ContextWithTimeout(t, testTimeout), &ServerConfig{
+		TLSConf: &TLSConfig{},
+		Config: Config{
+			UpstreamMode:     UpstreamModeLoadBalance,
+			EDNSClientSubnet: &EDNSClientSubnet{Enabled: false},
+			ClientsContainer: EmptyClientsContainer{},
+		},
+		ServePlainDNS: true,
+	})
+	require.NoError(t, err)
+
+	req := (&dns.Msg{}).SetQuestion(dns.Fqdn(originalHost), dns.TypeA)
+	dctx := &dnsContext{
+		proxyCtx: &proxy.DNSContext{
+			Req:             req,
+			Addr:            testClientAddrPort,
+			IsPrivateClient: true,
+		},
+		setts: &filtering.Settings{
+			FilteringEnabled:  true,
+			ProtectionEnabled: true,
+		},
+		protectionEnabled: true,
+	}
+
+	ctx := testutil.ContextWithTimeout(t, testTimeout)
+
+	assert.Equal(t, resultCodeSuccess, s.processDHCPHosts(ctx, testLogger, dctx))
+	require.Nil(t, dctx.proxyCtx.Res)
+	assert.True(t, dctx.isDHCPHost)
+
+	assert.Equal(t, resultCodeSuccess, s.processFilteringBeforeRequest(ctx, testLogger, dctx))
+	require.Nil(t, dctx.proxyCtx.Res)
+	require.Equal(t, dns.Fqdn(originalHost), dctx.origQuestion.Name)
+	require.Equal(t, dns.Fqdn(dhcpClient+"."+localDomainSuffix), req.Question[0].Name)
+
+	assert.Equal(t, resultCodeSuccess, s.processUpstream(ctx, testLogger, dctx))
+	require.NotNil(t, dctx.proxyCtx.Res)
+
+	assert.Equal(t, resultCodeSuccess, s.processFilteringAfterResponse(ctx, testLogger, dctx))
+
+	resp := dctx.proxyCtx.Res
+	require.NotNil(t, resp)
+	require.Len(t, resp.Question, 1)
+	assert.Equal(t, dns.Fqdn(originalHost), resp.Question[0].Name)
+
+	require.Len(t, resp.Answer, 2)
+
+	cname := testutil.RequireTypeAssert[*dns.CNAME](t, resp.Answer[0])
+	assert.Equal(t, dns.Fqdn(originalHost), cname.Hdr.Name)
+	assert.Equal(t, dns.Fqdn(dhcpClient+"."+localDomainSuffix), cname.Target)
+
+	a := testutil.RequireTypeAssert[*dns.A](t, resp.Answer[1])
+	assert.Equal(t, dns.Fqdn(dhcpClient+"."+localDomainSuffix), a.Hdr.Name)
+	assert.Equal(t, net.IP(knownIP.AsSlice()), net.IP(a.A))
+}
+
 func TestServer_ProcessDHCPHosts(t *testing.T) {
 	const (
 		localTLD  = "lan"


### PR DESCRIPTION
Closes #8068.

This updates the unresolved DHCP-host path to re-check the current request name after filtering rewrites a local-domain query to a CNAME target. When the rewritten name is a known DHCP hostname, the server now returns the local DHCP answer and lets post-filtering restore the original question and prepend the CNAME.

Tests:
- `go test ./internal/dnsforward -run TestServer_ProcessDHCPHosts_rewrittenCNAME -count=1`
- `go test ./internal/dnsforward ./internal/filtering -count=1`
- `go test -race ./internal/dnsforward -run 'TestServer_ProcessDHCPHosts|TestServer_ProcessUpstream' -count=1`\n- `make go-lint`\n- `git diff --check`\n\nNotes:\n- `make go-lint` prints existing Go 1.26.3 standard-library `govulncheck` findings (`GO-2026-5039`, `GO-2026-5037`), and the target still passes with its configured non-reproducible vulnerability-scan ignore.\n- `make go-test` reached the touched `internal/dnsforward` package successfully, then failed later in `internal/home` because `TestWeb_HandleGetProfile/add_user` timed out after 1m30s while running bcrypt under the race detector. The isolated retry `go test -race ./internal/home -run TestWeb_HandleGetProfile -count=1 -timeout 5m` passed.