### PR TITLE
Fix rate-limit whitelist handling

### DIFF
--- a/internal/dnsforward/config.go
+++ b/internal/dnsforward/config.go
@@ -419,11 +419,18 @@ func newRatelimitMw(
 		return proxy.MiddlewareFunc(proxy.PassThrough), nil
 	}
 
+	allowlistAddrs := make(netutil.SliceSubnetSet, 0, len(conf.RatelimitWhitelist))
+	for _, addr := range conf.RatelimitWhitelist {
+		addr = addr.Unmap()
+		allowlistAddrs = append(allowlistAddrs, netip.PrefixFrom(addr, addr.BitLen()))
+	}
+
 	rlConf := &ratelimit.Config{
-		Logger:        l.With(slogutil.KeyPrefix, "ratelimit"),
-		Ratelimit:     uint(conf.Ratelimit),
-		SubnetLenIPv4: conf.RatelimitSubnetLenIPv4,
-		SubnetLenIPv6: conf.RatelimitSubnetLenIPv6,
+		Logger:         l.With(slogutil.KeyPrefix, "ratelimit"),
+		AllowlistAddrs: allowlistAddrs,
+		Ratelimit:      uint(conf.Ratelimit),
+		SubnetLenIPv4:  conf.RatelimitSubnetLenIPv4,
+		SubnetLenIPv6:  conf.RatelimitSubnetLenIPv6,
 	}
 	if err = rlConf.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)

--- a/internal/dnsforward/config_internal_test.go
+++ b/internal/dnsforward/config_internal_test.go
@@ -1,10 +1,15 @@
 package dnsforward
 
 import (
+	"context"
+	"net/netip"
 	"slices"
 	"testing"
 
+	"github.com/AdguardTeam/dnsproxy/proxy"
+	"github.com/AdguardTeam/golibs/netutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAnyNameMatches(t *testing.T) {
@@ -54,4 +59,43 @@ func TestAnyNameMatches(t *testing.T) {
 			assert.Equal(t, tc.want, anyNameMatches(dnsNames, tc.dnsName))
 		})
 	}
+}
+
+func TestNewRatelimitMw_ratelimitWhitelist(t *testing.T) {
+	t.Parallel()
+
+	const limit = 1
+
+	addr := netip.MustParseAddr("192.0.2.1")
+	mw, err := newRatelimitMw(testLogger, ServerConfig{
+		Config: Config{
+			Ratelimit:              limit,
+			RatelimitSubnetLenIPv4: netutil.IPv4BitLen,
+			RatelimitSubnetLenIPv6: netutil.IPv6BitLen,
+			RatelimitWhitelist:     []netip.Addr{addr},
+		},
+	})
+	require.NoError(t, err)
+
+	called := 0
+	handler := mw.Wrap(proxy.HandlerFunc(func(
+		_ context.Context,
+		_ *proxy.Proxy,
+		_ *proxy.DNSContext,
+	) (err error) {
+		called++
+
+		return nil
+	}))
+
+	dctx := &proxy.DNSContext{
+		Addr:  netip.AddrPortFrom(addr, 53),
+		Proto: proxy.ProtoUDP,
+	}
+	for i := 0; i < limit+1; i++ {
+		err = handler.ServeDNS(context.Background(), nil, dctx)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, limit+1, called)
 }


### PR DESCRIPTION
Closes #8349.

This passes the configured rate-limit whitelist into the dnsproxy rate-limit middleware.  Each whitelisted IP is converted to a full-length prefix, so repeated UDP requests from that address bypass the rate limiter while other clients still use the configured per-subnet buckets.

Testing:

- `go test ./internal/dnsforward -run '^TestNewRatelimitMw_ratelimitWhitelist$' -count=1`\n- `go test ./internal/dnsforward -count=1`\n- `go vet ./internal/dnsforward`\n- `go tool gofumpt --extra -e -l internal/dnsforward/config.go internal/dnsforward/config_internal_test.go`\n- `git diff --check`