### PR TITLE
dnsforward: add rewritten addresses to ipsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,13 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- IP addresses from local DNS rewrites are now added to configured ipsets
+  ([#8341]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
+[#8341]: https://github.com/AdguardTeam/AdGuardHome/issues/8341
 
 <!--
 NOTE: Add new changes ABOVE THIS COMMENT.

--- a/internal/dnsforward/ipset.go
+++ b/internal/dnsforward/ipset.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/AdguardTeam/AdGuardHome/internal/filtering"
 	"github.com/AdguardTeam/AdGuardHome/internal/ipset"
 	"github.com/AdguardTeam/golibs/errors"
 	"github.com/AdguardTeam/golibs/logutil/slogutil"
@@ -66,10 +67,27 @@ func (h *ipsetHandler) close() (err error) {
 	return nil
 }
 
+// isIpsetRewrite returns true if res represents a local DNS rewrite response
+// whose IP addresses should be added to ipsets.
+func isIpsetRewrite(res *filtering.Result) (ok bool) {
+	if res == nil {
+		return false
+	}
+
+	switch res.Reason {
+	case filtering.Rewritten,
+		filtering.RewrittenAutoHosts,
+		filtering.RewrittenRule:
+		return true
+	default:
+		return false
+	}
+}
+
 // dctxIsFilled returns true if dctx has enough information to process.
 func dctxIsFilled(dctx *dnsContext) (ok bool) {
 	return dctx != nil &&
-		dctx.responseFromUpstream &&
+		(dctx.responseFromUpstream || isIpsetRewrite(dctx.result)) &&
 		dctx.proxyCtx != nil &&
 		dctx.proxyCtx.Res != nil &&
 		dctx.proxyCtx.Req != nil &&

--- a/internal/dnsforward/ipset_internal_test.go
+++ b/internal/dnsforward/ipset_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/AdguardTeam/AdGuardHome/internal/filtering"
 	"github.com/AdguardTeam/dnsproxy/proxy"
 	"github.com/AdguardTeam/golibs/testutil"
 	"github.com/miekg/dns"
@@ -119,6 +120,48 @@ func TestIpsetCtx_process(t *testing.T) {
 		err := ictx.close()
 		assert.NoError(t, err)
 	})
+
+	t.Run("rewrite_ipv4", func(t *testing.T) {
+		dctx := &dnsContext{
+			proxyCtx: &proxy.DNSContext{
+				Req: req4,
+				Res: resp4,
+			},
+			result: &filtering.Result{Reason: filtering.Rewritten},
+		}
+
+		m := &fakeIpsetMgr{}
+		ictx := &ipsetHandler{
+			ipsetMgr: m,
+			logger:   testLogger,
+		}
+
+		rc := ictx.process(testutil.ContextWithTimeout(t, testTimeout), testLogger, dctx)
+		assert.Equal(t, resultCodeSuccess, rc)
+		assert.Equal(t, []net.IP{ip4}, m.ip4s)
+		assert.Empty(t, m.ip6s)
+	})
+
+	t.Run("rewrite_ipv6", func(t *testing.T) {
+		dctx := &dnsContext{
+			proxyCtx: &proxy.DNSContext{
+				Req: req6,
+				Res: resp6,
+			},
+			result: &filtering.Result{Reason: filtering.Rewritten},
+		}
+
+		m := &fakeIpsetMgr{}
+		ictx := &ipsetHandler{
+			ipsetMgr: m,
+			logger:   testLogger,
+		}
+
+		rc := ictx.process(testutil.ContextWithTimeout(t, testTimeout), testLogger, dctx)
+		assert.Equal(t, resultCodeSuccess, rc)
+		assert.Empty(t, m.ip4s)
+		assert.Equal(t, []net.IP{ip6}, m.ip6s)
+	})
 }
 
 func TestIpsetCtx_SkipIpsetProcessing(t *testing.T) {
@@ -152,6 +195,39 @@ func TestIpsetCtx_SkipIpsetProcessing(t *testing.T) {
 		},
 	}, {
 		name: "rewrite",
+		want: false,
+		dctx: &dnsContext{
+			proxyCtx: &proxy.DNSContext{
+				Req: req4,
+				Res: resp4,
+			},
+
+			result: &filtering.Result{Reason: filtering.Rewritten},
+		},
+	}, {
+		name: "hosts_rewrite",
+		want: false,
+		dctx: &dnsContext{
+			proxyCtx: &proxy.DNSContext{
+				Req: req4,
+				Res: resp4,
+			},
+
+			result: &filtering.Result{Reason: filtering.RewrittenAutoHosts},
+		},
+	}, {
+		name: "rule_rewrite",
+		want: false,
+		dctx: &dnsContext{
+			proxyCtx: &proxy.DNSContext{
+				Req: req4,
+				Res: resp4,
+			},
+
+			result: &filtering.Result{Reason: filtering.RewrittenRule},
+		},
+	}, {
+		name: "blocked",
 		want: true,
 		dctx: &dnsContext{
 			proxyCtx: &proxy.DNSContext{
@@ -159,8 +235,54 @@ func TestIpsetCtx_SkipIpsetProcessing(t *testing.T) {
 				Res: resp4,
 			},
 
-			responseFromUpstream: false,
+			result: &filtering.Result{Reason: filtering.FilteredBlockList},
 		},
+	}, {
+		name: "safe_search",
+		want: true,
+		dctx: &dnsContext{
+			proxyCtx: &proxy.DNSContext{
+				Req: req4,
+				Res: resp4,
+			},
+
+			result: &filtering.Result{Reason: filtering.FilteredSafeSearch},
+		},
+	}, {
+		name: "dhcp",
+		want: true,
+		dctx: &dnsContext{
+			proxyCtx: &proxy.DNSContext{
+				Req: req4,
+				Res: resp4,
+			},
+
+			isDHCPHost: true,
+		},
+	}, {
+		name: "unrelated_local",
+		want: true,
+		dctx: &dnsContext{
+			proxyCtx: &proxy.DNSContext{
+				Req: req4,
+				Res: resp4,
+			},
+
+			result: &filtering.Result{Reason: filtering.NotFilteredNotFound},
+		},
+	}, {
+		name: "nil_result",
+		want: true,
+		dctx: &dnsContext{
+			proxyCtx: &proxy.DNSContext{
+				Req: req4,
+				Res: resp4,
+			},
+		},
+	}, {
+		name: "nil_context",
+		want: true,
+		dctx: nil,
 	}, {
 		name: "empty_req",
 		want: true,


### PR DESCRIPTION
Updates #8341.

## Summary

- allow local DNS rewrite results to reach ipset processing
- limit the exception to explicit rewrite reasons
- keep blocked, Safe Search, DHCP, unrelated local, and nil results excluded
- add IPv4, IPv6, and skip-path regression coverage

## Validation

- focused race-enabled ipset tests, including 20 repeated runs
- `go test -race -count=1 ./internal/dnsforward`
- `make go-check`
- `make txt-lint`

No public API or configuration format changes are included.