### PR TITLE
Advertise HTTP/3 in DDR responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,12 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- Discovery of Designated Resolvers responses now advertise HTTP/3 for
+  DNS-over-HTTPS when it is enabled ([#6487]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#6487]: https://github.com/AdguardTeam/AdGuardHome/issues/6487
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/internal/dnsforward/process.go
+++ b/internal/dnsforward/process.go
@@ -209,9 +209,14 @@ func (s *Server) makeDDRResponse(req *dns.Msg) (resp *dns.Msg) {
 	// name somewhere.
 	domainName := dns.Fqdn(s.conf.TLSConf.ServerName)
 
+	dohALPN := []string{"h2"}
+	if s.conf.ServeHTTP3 {
+		dohALPN = append(dohALPN, "h3")
+	}
+
 	for _, addr := range s.conf.TLSConf.HTTPSListenAddrs {
 		values := []dns.SVCBKeyValue{
-			&dns.SVCBAlpn{Alpn: []string{"h2"}},
+			&dns.SVCBAlpn{Alpn: dohALPN},
 			&dns.SVCBPort{Port: addr.Port()},
 			&dns.SVCBDoHPath{Template: "/dns-query{?dns}"},
 		}

--- a/internal/dnsforward/process_internal_test.go
+++ b/internal/dnsforward/process_internal_test.go
@@ -222,11 +222,20 @@ func TestServer_ProcessFilteringAfterResponse(t *testing.T) {
 }
 
 func TestServer_ProcessDDRQuery(t *testing.T) {
-	dohSVCB := &dns.SVCB{
+	dohHTTP2SVCB := &dns.SVCB{
 		Priority: 1,
 		Target:   ddrTestFQDN,
 		Value: []dns.SVCBKeyValue{
 			&dns.SVCBAlpn{Alpn: []string{"h2"}},
+			&dns.SVCBPort{Port: 8044},
+			&dns.SVCBDoHPath{Template: "/dns-query{?dns}"},
+		},
+	}
+	dohHTTP3SVCB := &dns.SVCB{
+		Priority: 1,
+		Target:   ddrTestFQDN,
+		Value: []dns.SVCBKeyValue{
+			&dns.SVCBAlpn{Alpn: []string{"h2", "h3"}},
 			&dns.SVCBPort{Port: 8044},
 			&dns.SVCBDoHPath{Template: "/dns-query{?dns}"},
 		},
@@ -264,6 +273,7 @@ func TestServer_ProcessDDRQuery(t *testing.T) {
 		addrsDoQ   []*net.UDPAddr
 		qtype      uint16
 		ddrEnabled bool
+		serveHTTP3 bool
 	}{{
 		name:       "pass_host",
 		wantRes:    resultCodeSuccess,
@@ -300,12 +310,21 @@ func TestServer_ProcessDDRQuery(t *testing.T) {
 		ddrEnabled: true,
 		addrsDoT:   addrsDoT,
 	}, {
-		name:       "doh",
+		name:       "doh_http2",
 		wantRes:    resultCodeFinish,
-		want:       []*dns.SVCB{dohSVCB},
+		want:       []*dns.SVCB{dohHTTP2SVCB},
 		host:       ddrHostFQDN,
 		qtype:      dns.TypeSVCB,
 		ddrEnabled: true,
+		addrsDoH:   addrsDoH,
+	}, {
+		name:       "doh_http3",
+		wantRes:    resultCodeFinish,
+		want:       []*dns.SVCB{dohHTTP3SVCB},
+		host:       ddrHostFQDN,
+		qtype:      dns.TypeSVCB,
+		ddrEnabled: true,
+		serveHTTP3: true,
 		addrsDoH:   addrsDoH,
 	}, {
 		name:       "doq",
@@ -318,7 +337,7 @@ func TestServer_ProcessDDRQuery(t *testing.T) {
 	}, {
 		name:       "dot_doh",
 		wantRes:    resultCodeFinish,
-		want:       []*dns.SVCB{dotSVCB, dohSVCB},
+		want:       []*dns.SVCB{dotSVCB, dohHTTP2SVCB},
 		host:       ddrHostFQDN,
 		qtype:      dns.TypeSVCB,
 		ddrEnabled: true,
@@ -352,6 +371,7 @@ func TestServer_ProcessDDRQuery(t *testing.T) {
 						HTTPSListenAddrs: tc.addrsDoH,
 						QUICListenAddrs:  tc.addrsDoQ,
 					},
+					ServeHTTP3:    tc.serveHTTP3,
 					ServePlainDNS: true,
 				},
 				tlsConfProvider,


### PR DESCRIPTION
## Summary

- advertise `h3` alongside `h2` in the DNS-over-HTTPS SVCB ALPN list when
  `serve_http3` is enabled
- preserve the existing `h2`-only response when HTTP/3 is disabled
- add focused coverage for both configurations and document the fix in the
  changelog

The SVCB `alpn` parameter describes the application protocols available at the
advertised endpoint.  Omitting `h3` while the same DoH endpoint serves HTTP/3
hides an enabled transport from DDR clients; advertising both values reflects
the configured capability without changing the endpoint, port, or DoH path.

Fixes #6487.

## Testing

- `go test -race -count=1 -run '^TestServer_ProcessDDRQuery$' ./internal/dnsforward`
- `go test -race -count=20 -run '^TestServer_ProcessDDRQuery$' ./internal/dnsforward`
- `go test -race -count=1 ./internal/dnsforward`
- `make go-check`
- repository pre-commit hooks: Markdown and text lint, multi-platform `go vet`,
  Go lint and vulnerability analysis, and the race-enabled Go test suite
