### PR TITLE
home: recover HTTP handler panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,12 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- HTTP requests whose handlers panic before writing a response now receive a
+  generic `500 Internal Server Error` response ([#3740]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#3740]: https://github.com/AdguardTeam/AdGuardHome/issues/3740
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/internal/home/middlewares.go
+++ b/internal/home/middlewares.go
@@ -1,10 +1,16 @@
 package home
 
 import (
+	"bufio"
 	"io"
+	"log/slog"
+	"net"
 	"net/http"
+	"strings"
 
+	"github.com/AdguardTeam/golibs/httphdr"
 	"github.com/AdguardTeam/golibs/ioutil"
+	"github.com/AdguardTeam/golibs/logutil/slogutil"
 	"github.com/c2h5oh/datasize"
 )
 
@@ -16,6 +22,112 @@ const (
 	// larger requests.
 	largerReqBodySzLim datasize.ByteSize = 4 * datasize.MB
 )
+
+// recoveryResponseWriter tracks whether the response has already been
+// committed.  It also supports unwrapping by [http.ResponseController].
+type recoveryResponseWriter struct {
+	http.ResponseWriter
+
+	committed bool
+}
+
+// Unwrap returns the underlying response writer.
+func (w *recoveryResponseWriter) Unwrap() (rw http.ResponseWriter) {
+	return w.ResponseWriter
+}
+
+// Write implements the [http.ResponseWriter] interface.
+func (w *recoveryResponseWriter) Write(b []byte) (n int, err error) {
+	w.committed = true
+
+	return w.ResponseWriter.Write(b)
+}
+
+// WriteHeader implements the [http.ResponseWriter] interface.
+func (w *recoveryResponseWriter) WriteHeader(statusCode int) {
+	w.ResponseWriter.WriteHeader(statusCode)
+
+	if statusCode == http.StatusSwitchingProtocols || statusCode >= 200 {
+		w.committed = true
+	}
+}
+
+// FlushError flushes the response through the underlying response writer.
+func (w *recoveryResponseWriter) FlushError() (err error) {
+	w.committed = true
+
+	return http.NewResponseController(w.ResponseWriter).Flush()
+}
+
+// Hijack implements the [http.Hijacker] interface.
+func (w *recoveryResponseWriter) Hijack() (conn net.Conn, rw *bufio.ReadWriter, err error) {
+	w.committed = true
+
+	return http.NewResponseController(w.ResponseWriter).Hijack()
+}
+
+// preparePanicResponse removes response-specific headers while preserving
+// headers set by outer middleware, such as CORS and transport-security headers.
+func preparePanicResponse(h http.Header) {
+	for _, name := range []string{
+		httphdr.ContentDisposition,
+		httphdr.ContentEncoding,
+		httphdr.ContentLength,
+		httphdr.ContentType,
+		httphdr.ETag,
+		httphdr.Expires,
+		httphdr.LastModified,
+		httphdr.Location,
+		httphdr.RetryAfter,
+		httphdr.SetCookie,
+		httphdr.Trailer,
+		httphdr.TransferEncoding,
+		httphdr.WWWAuthenticate,
+	} {
+		h.Del(name)
+	}
+
+	for name := range h {
+		if strings.HasPrefix(name, http.TrailerPrefix) {
+			h.Del(name)
+		}
+	}
+
+	h.Set(httphdr.CacheControl, "no-store")
+}
+
+// recoverPanics returns a handler that recovers from panics, logs them, and
+// responds with a generic error.  l and h must not be nil.
+func recoverPanics(l *slog.Logger, h http.Handler) (wrapped http.Handler) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rw := &recoveryResponseWriter{ResponseWriter: w}
+
+		defer func() {
+			v := recover()
+			if v == nil {
+				return
+			}
+
+			if err, ok := v.(error); ok && err == http.ErrAbortHandler {
+				panic(v)
+			}
+
+			slogutil.PrintRecovered(r.Context(), l, v)
+			if rw.committed {
+				panic(http.ErrAbortHandler)
+			}
+
+			preparePanicResponse(rw.Header())
+			http.Error(
+				rw,
+				http.StatusText(http.StatusInternalServerError),
+				http.StatusInternalServerError,
+			)
+		}()
+
+		h.ServeHTTP(rw, r)
+	})
+}
 
 // expectsLargerRequests shows if this request should use a larger body size
 // limit.  These are exceptions for poorly designed current APIs as well as APIs

--- a/internal/home/middlewares_internal_test.go
+++ b/internal/home/middlewares_internal_test.go
@@ -1,16 +1,253 @@
 package home
 
 import (
+	"bytes"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/AdguardTeam/golibs/httphdr"
 	"github.com/AdguardTeam/golibs/ioutil"
+	"github.com/AdguardTeam/golibs/logutil/slogutil"
+	"github.com/AdguardTeam/golibs/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRecoverPanics(t *testing.T) {
+	const panicMessage = "sensitive test panic"
+
+	logOutput := &bytes.Buffer{}
+	l := slog.New(slog.NewTextHandler(logOutput, &slog.HandlerOptions{
+		ReplaceAttr: slogutil.RemoveTime,
+	}))
+	h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		header := w.Header()
+		header.Set(httphdr.AccessControlAllowOrigin, "http://example.test")
+		header.Set(httphdr.AltSvc, `h3=":443"`)
+		header.Set(httphdr.ContentEncoding, "gzip")
+		header.Set(httphdr.ContentType, "application/json")
+		header.Set(httphdr.SetCookie, "secret=value")
+		header.Set(httphdr.StrictTransportSecurity, "max-age=31536000")
+		header.Set(httphdr.Trailer, "X-Test-Trailer")
+		header.Set(httphdr.Vary, httphdr.Origin)
+		header.Set(http.TrailerPrefix+"X-Test-Trailer", "value")
+
+		panic(panicMessage)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.test/panic", nil)
+	res := httptest.NewRecorder()
+
+	require.NotPanics(t, func() {
+		recoverPanics(l, h).ServeHTTP(res, req)
+	})
+
+	assert.Equal(t, http.StatusInternalServerError, res.Code)
+	assert.Equal(t, http.StatusText(http.StatusInternalServerError)+"\n", res.Body.String())
+	header := res.Header()
+	assert.Equal(t, "http://example.test", header.Get(httphdr.AccessControlAllowOrigin))
+	assert.Equal(t, `h3=":443"`, header.Get(httphdr.AltSvc))
+	assert.Equal(t, "text/plain; charset=utf-8", header.Get(httphdr.ContentType))
+	assert.Equal(t, "no-store", header.Get(httphdr.CacheControl))
+	assert.Equal(t, "nosniff", header.Get(httphdr.XContentTypeOptions))
+	assert.Equal(t, "max-age=31536000", header.Get(httphdr.StrictTransportSecurity))
+	assert.Equal(t, httphdr.Origin, header.Get(httphdr.Vary))
+	assert.Empty(t, header.Values(httphdr.SetCookie))
+	assert.Empty(t, header.Get(httphdr.ContentEncoding))
+	assert.Empty(t, header.Get(httphdr.Trailer))
+	assert.Empty(t, header.Get(http.TrailerPrefix+"X-Test-Trailer"))
+	assert.NotContains(t, res.Body.String(), panicMessage)
+
+	logString := logOutput.String()
+	assert.Contains(t, logString, `level=ERROR msg="recovered from panic" value="`+panicMessage+`"`)
+	assert.Contains(t, logString, "level=ERROR msg=stack")
+}
+
+func TestRecoverPanics_invalidStatus(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(99)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.test/panic", nil)
+	res := httptest.NewRecorder()
+
+	require.NotPanics(t, func() {
+		recoverPanics(testLogger, h).ServeHTTP(res, req)
+	})
+	assert.Equal(t, http.StatusInternalServerError, res.Code)
+	assert.Equal(t, http.StatusText(http.StatusInternalServerError)+"\n", res.Body.String())
+}
+
+type informationalResponseWriter struct {
+	header http.Header
+	body   bytes.Buffer
+
+	finalStatus int
+	infos       []int
+}
+
+func (w *informationalResponseWriter) Header() (h http.Header) {
+	return w.header
+}
+
+func (w *informationalResponseWriter) Write(b []byte) (n int, err error) {
+	if w.finalStatus == 0 {
+		w.finalStatus = http.StatusOK
+	}
+
+	return w.body.Write(b)
+}
+
+func (w *informationalResponseWriter) WriteHeader(statusCode int) {
+	if statusCode >= 100 && statusCode <= 199 && statusCode != http.StatusSwitchingProtocols {
+		w.infos = append(w.infos, statusCode)
+
+		return
+	}
+
+	if w.finalStatus == 0 {
+		w.finalStatus = statusCode
+	}
+}
+
+func TestRecoverPanics_earlyHints(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusEarlyHints)
+
+		panic("after early hints")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.test/panic", nil)
+	res := &informationalResponseWriter{header: http.Header{}}
+
+	require.NotPanics(t, func() {
+		recoverPanics(testLogger, h).ServeHTTP(res, req)
+	})
+	assert.Equal(t, []int{http.StatusEarlyHints}, res.infos)
+	assert.Equal(t, http.StatusInternalServerError, res.finalStatus)
+	assert.Equal(t, http.StatusText(http.StatusInternalServerError)+"\n", res.body.String())
+}
+
+func TestRecoverPanics_normal(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Test", "value")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, "response body")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.test/normal", nil)
+	res := httptest.NewRecorder()
+	recoverPanics(testLogger, h).ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusCreated, res.Code)
+	assert.Equal(t, "value", res.Header().Get("X-Test"))
+	assert.Equal(t, "response body", res.Body.String())
+}
+
+func TestRecoverPanics_abort(t *testing.T) {
+	logOutput := &bytes.Buffer{}
+	l := slog.New(slog.NewTextHandler(logOutput, nil))
+	h := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic(http.ErrAbortHandler)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.test/abort", nil)
+	res := httptest.NewRecorder()
+
+	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
+		recoverPanics(l, h).ServeHTTP(res, req)
+	})
+	assert.Empty(t, logOutput.String())
+}
+
+func TestRecoverPanics_committed(t *testing.T) {
+	testCases := []struct {
+		prepare func(w http.ResponseWriter) (err error)
+		name    string
+	}{
+		{
+			name: "write",
+			prepare: func(w http.ResponseWriter) (err error) {
+				_, err = io.WriteString(w, "partial response")
+
+				return err
+			},
+		}, {
+			name: "write_header",
+			prepare: func(w http.ResponseWriter) (err error) {
+				w.WriteHeader(http.StatusNoContent)
+
+				return nil
+			},
+		}, {
+			name: "flush",
+			prepare: func(w http.ResponseWriter) (err error) {
+				return http.NewResponseController(w).Flush()
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				require.NoError(t, tc.prepare(w))
+
+				panic("after commit")
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "https://example.test/panic", nil)
+			res := httptest.NewRecorder()
+
+			require.PanicsWithValue(t, http.ErrAbortHandler, func() {
+				recoverPanics(testLogger, h).ServeHTTP(res, req)
+			})
+		})
+	}
+}
+
+func TestRecoverPanics_responseController(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		err := http.NewResponseController(w).Flush()
+		require.NoError(t, err)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.test/flush", nil)
+	res := httptest.NewRecorder()
+	recoverPanics(testLogger, h).ServeHTTP(res, req)
+
+	assert.True(t, res.Flushed)
+}
+
+func TestRecoverPanics_committedServer(t *testing.T) {
+	const partialBody = "partial response"
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(httphdr.ContentLength, "100")
+		_, err := io.WriteString(w, partialBody)
+		require.NoError(t, err)
+
+		err = http.NewResponseController(w).Flush()
+		require.NoError(t, err)
+
+		panic("after flush")
+	})
+
+	srv := httptest.NewServer(recoverPanics(testLogger, h))
+	t.Cleanup(srv.Close)
+
+	res, err := srv.Client().Get(srv.URL)
+	require.NoError(t, err)
+	testutil.CleanupAndRequireSuccess(t, res.Body.Close)
+
+	body, err := io.ReadAll(res.Body)
+	assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, partialBody, string(body))
+}
 
 func TestLimitRequestBody(t *testing.T) {
 	errReqLimitReached := &ioutil.LimitError{

--- a/internal/home/web.go
+++ b/internal/home/web.go
@@ -404,8 +404,9 @@ func (web *webAPI) wrapMux(l *slog.Logger) (h http.Handler) {
 	// TODO(a.garipov):  Remove other logs like this in other code.
 	logMw := httputil.NewLogMiddleware(l, slog.LevelDebug)
 	h = logMw.Wrap(h)
+	h = web.auth.middleware().Wrap(h)
 
-	return web.auth.middleware().Wrap(h)
+	return recoverPanics(l, h)
 }
 
 // close gracefully shuts down the HTTP servers.

--- a/internal/home/web_internal_test.go
+++ b/internal/home/web_internal_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/AdguardTeam/AdGuardHome/internal/agh"
 	"github.com/AdguardTeam/AdGuardHome/internal/aghalg"
 	"github.com/AdguardTeam/AdGuardHome/internal/aghtls"
+	"github.com/AdguardTeam/AdGuardHome/internal/aghuser"
 	"github.com/AdguardTeam/AdGuardHome/internal/client"
 	"github.com/AdguardTeam/AdGuardHome/internal/dnsforward"
 	"github.com/AdguardTeam/golibs/netutil"
@@ -25,6 +26,31 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestWebAPI_wrapMux_recoversPanic(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /panic", func(http.ResponseWriter, *http.Request) {
+		panic("test panic")
+	})
+
+	web := &webAPI{
+		conf: &webAPIConfig{mux: mux},
+		auth: &auth{
+			logger: testLogger,
+			mux:    mux,
+			users:  aghuser.NewDefaultDB(),
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/panic", nil)
+	res := httptest.NewRecorder()
+
+	require.NotPanics(t, func() {
+		web.wrapMux(testLogger).ServeHTTP(res, req)
+	})
+	assert.Equal(t, http.StatusInternalServerError, res.Code)
+	assert.Equal(t, http.StatusText(http.StatusInternalServerError)+"\n", res.Body.String())
+}
 
 func TestWebAPI_HandleTLSConfigure(t *testing.T) {
 	// Store the global state before making any changes.


### PR DESCRIPTION
Updates #3740.

## Summary

- recover handler panics before response commitment and return a generic 500 response
- log the panic and stack server-side without exposing panic text to clients
- preserve `http.ErrAbortHandler` semantics and abort responses that panic after headers or body bytes are committed
- retain transport and security headers while removing stale representation, cookie, and trailer metadata from recovered responses
- add unit and real HTTP-server regression coverage

## Validation

- focused race-enabled recovery tests, including 20 repeated runs
- `go test -race -count=1 ./internal/home`
- `make go-check`
- `make txt-lint`

No public API or configuration format changes are included.