### PR TITLE
home: log client IP on basic auth failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,12 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Changed
 
+- Basic Authentication failure logs now include the client IP address
+  ([#8428]).
+
 - The `edge` channel has been switched to the new UI and versioning scheme.
+
+[#8428]: https://github.com/AdguardTeam/AdGuardHome/issues/8428
 
 ### Deprecated
 

--- a/internal/home/authhttp.go
+++ b/internal/home/authhttp.go
@@ -80,6 +80,31 @@ func realIP(r *http.Request) (ip netip.Addr, err error) {
 	return netip.ParseAddr(ipStr)
 }
 
+// authLogIP returns the client IP address to use in authentication logs.  It
+// only trusts forwarded IP headers when the direct peer is a trusted proxy.
+func authLogIP(r *http.Request, trustedProxies netutil.SubnetSet) (ip string) {
+	remoteIP, err := netutil.SplitHost(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+
+	if trustedProxies == nil {
+		return remoteIP
+	}
+
+	remoteAddr, err := netip.ParseAddr(remoteIP)
+	if err != nil || !trustedProxies.Contains(remoteAddr.Unmap()) {
+		return remoteIP
+	}
+
+	clientIP, err := realIP(r)
+	if err != nil {
+		return remoteIP
+	}
+
+	return clientIP.String()
+}
+
 // writeErrorWithIP is like [aghhttp.Error], but includes the remote IP address
 // when it writes to the log.  r, w and err must not be nil.
 func (web *webAPI) writeErrorWithIP(
@@ -441,7 +466,17 @@ func (mw *authMiddlewareDefault) handleAuthenticatedUser(
 ) (ok bool) {
 	u, err := mw.userFromRequest(ctx, r)
 	if err != nil {
-		mw.logger.ErrorContext(ctx, "retrieving user from request", slogutil.KeyError, err)
+		_, _, hasBasicAuth := r.BasicAuth()
+		if hasBasicAuth {
+			mw.logger.ErrorContext(
+				ctx,
+				"retrieving user from request",
+				"ip", authLogIP(r, mw.trustedProxies),
+				slogutil.KeyError, err,
+			)
+		} else {
+			mw.logger.ErrorContext(ctx, "retrieving user from request", slogutil.KeyError, err)
+		}
 	}
 
 	if u == nil {

--- a/internal/home/authhttp_internal_test.go
+++ b/internal/home/authhttp_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"log/slog"
 	"maps"
 	"net/http"
 	"net/http/httptest"
@@ -23,6 +24,8 @@ import (
 	"github.com/AdguardTeam/AdGuardHome/internal/aghtls"
 	"github.com/AdguardTeam/AdGuardHome/internal/aghuser"
 	"github.com/AdguardTeam/golibs/httphdr"
+	"github.com/AdguardTeam/golibs/logutil/slogutil"
+	"github.com/AdguardTeam/golibs/netutil"
 	"github.com/AdguardTeam/golibs/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -289,6 +292,123 @@ func TestAuthMiddlewareDefault(t *testing.T) {
 			assert.Equal(t, tc.wantUser, h.user)
 		})
 	}
+}
+
+type authLogTestCase struct {
+	trustedProxies netutil.SubnetSet
+	name           string
+	remoteIP       string
+	forwardedIP    string
+	wantIP         string
+	blocked        bool
+}
+
+func TestAuthMiddlewareDefault_logClientIP(t *testing.T) {
+	const (
+		remoteIP = "192.0.2.1"
+		clientIP = "198.51.100.2"
+	)
+
+	testCases := []authLogTestCase{
+		{
+			trustedProxies: nil,
+			name:           "direct_blocked",
+			remoteIP:       remoteIP,
+			forwardedIP:    "",
+			wantIP:         remoteIP,
+			blocked:        true,
+		},
+		{
+			trustedProxies: netutil.SliceSubnetSet{
+				netip.MustParsePrefix(remoteIP + "/32"),
+			},
+			name:        "trusted_proxy",
+			remoteIP:    remoteIP,
+			forwardedIP: clientIP,
+			wantIP:      clientIP,
+			blocked:     false,
+		},
+		{
+			trustedProxies: netutil.SliceSubnetSet{
+				netip.MustParsePrefix("203.0.113.1/32"),
+			},
+			name:        "untrusted_proxy_spoof",
+			remoteIP:    remoteIP,
+			forwardedIP: clientIP,
+			wantIP:      remoteIP,
+			blocked:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testAuthMiddlewareDefaultLogClientIP(t, tc)
+		})
+	}
+}
+
+func testAuthMiddlewareDefaultLogClientIP(t *testing.T, tc authLogTestCase) {
+	t.Helper()
+
+	const (
+		username = "log-user-secret"
+		password = "log-pass-secret"
+	)
+
+	logOutput := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(logOutput, &slog.HandlerOptions{
+		ReplaceAttr: slogutil.RemoveTime,
+	}))
+
+	usersDB := newTestUsersDB()
+	usersDB.onAll = func(_ context.Context) (users []*aghuser.User, err error) {
+		return []*aghuser.User{{}}, nil
+	}
+	usersDB.onByLogin = func(
+		_ context.Context,
+		_ aghuser.Login,
+	) (u *aghuser.User, err error) {
+		return nil, nil
+	}
+
+	var rateLimiter loginRateLimiter = emptyRateLimiter{}
+	if tc.blocked {
+		limiter := newAuthRateLimiter(time.Hour, 1)
+		limiter.inc(tc.remoteIP)
+		rateLimiter = limiter
+	}
+
+	mw := newAuthMiddlewareDefault(&authMiddlewareDefaultConfig{
+		logger:         logger,
+		mux:            http.NewServeMux(),
+		rateLimiter:    rateLimiter,
+		trustedProxies: tc.trustedProxies,
+		sessions:       newTestSessionStorage(),
+		users:          usersDB,
+	})
+
+	req := authRequest("/control/profile", nil, username, password)
+	req.RemoteAddr = tc.remoteIP + ":1234"
+	if tc.forwardedIP != "" {
+		req.Header.Set(httphdr.XRealIP, tc.forwardedIP)
+	}
+
+	h := &testAuthHandler{}
+	w := httptest.NewRecorder()
+	mw.Wrap(h).ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.False(t, h.called)
+
+	logLine := logOutput.String()
+	assert.Contains(t, logLine, " ip="+tc.wantIP)
+	if tc.forwardedIP != "" && tc.forwardedIP != tc.wantIP {
+		assert.NotContains(t, logLine, tc.forwardedIP)
+	}
+
+	assert.NotContains(t, logLine, username)
+	assert.NotContains(t, logLine, password)
+	assert.NotContains(t, logLine, req.Header.Get("Authorization"))
 }
 
 func TestAuthMiddlewareDefault_public(t *testing.T) {


### PR DESCRIPTION
## Summary

- add the client IP address to Basic Authentication failure logs
- trust forwarded client-IP headers only when the direct peer is in the configured trusted-proxy set
- fall back to the direct peer address for untrusted proxies or invalid forwarded headers
- avoid logging usernames, passwords, and raw Authorization header values

This intentionally addresses only the source-IP logging part of the issue.  It does not add usernames to failure logs or implement two-factor authentication.

Updates #8428.

## Testing

The repository pre-commit hook completed successfully, including:

- `make md-lint`
- `make txt-lint`
- `make go-os-check`
- `make go-lint` (including `govulncheck`, with no called vulnerabilities)
- `make go-test` (the full race-enabled Go test suite)