### PR TITLE
Deduplicate SVCB records in DDR responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,12 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- Discovery of Designated Resolvers responses no longer contain duplicate
+  service records for listeners sharing the same protocol and port ([#7804]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#7804]: https://github.com/AdguardTeam/AdGuardHome/issues/7804
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/internal/dnsforward/process.go
+++ b/internal/dnsforward/process.go
@@ -209,10 +209,17 @@ func (s *Server) makeDDRResponse(req *dns.Msg) (resp *dns.Msg) {
 	// name somewhere.
 	domainName := dns.Fqdn(s.conf.TLSConf.ServerName)
 
+	seenDoHPorts := map[uint16]struct{}{}
 	for _, addr := range s.conf.TLSConf.HTTPSListenAddrs {
+		port := addr.Port()
+		if _, ok := seenDoHPorts[port]; ok {
+			continue
+		}
+
+		seenDoHPorts[port] = struct{}{}
 		values := []dns.SVCBKeyValue{
 			&dns.SVCBAlpn{Alpn: []string{"h2"}},
-			&dns.SVCBPort{Port: addr.Port()},
+			&dns.SVCBPort{Port: port},
 			&dns.SVCBDoHPath{Template: "/dns-query{?dns}"},
 		}
 
@@ -228,10 +235,17 @@ func (s *Server) makeDDRResponse(req *dns.Msg) (resp *dns.Msg) {
 
 	s.appendDoTResolvers(req, resp, domainName)
 
+	seenDoQPorts := map[uint16]struct{}{}
 	for _, addr := range s.dnsProxy.QUICListenAddr {
+		port := uint16(addr.Port)
+		if _, ok := seenDoQPorts[port]; ok {
+			continue
+		}
+
+		seenDoQPorts[port] = struct{}{}
 		values := []dns.SVCBKeyValue{
 			&dns.SVCBAlpn{Alpn: []string{"doq"}},
-			&dns.SVCBPort{Port: uint16(addr.Port)},
+			&dns.SVCBPort{Port: port},
 		}
 
 		ans := &dns.SVCB{
@@ -258,10 +272,17 @@ func (s *Server) appendDoTResolvers(req, resp *dns.Msg, domainName string) {
 		// addresses.
 		//
 		// See https://github.com/AdguardTeam/AdGuardHome/issues/4927.
+		seenDoTPorts := map[uint16]struct{}{}
 		for _, addr := range s.dnsProxy.TLSListenAddr {
+			port := uint16(addr.Port)
+			if _, ok := seenDoTPorts[port]; ok {
+				continue
+			}
+
+			seenDoTPorts[port] = struct{}{}
 			values := []dns.SVCBKeyValue{
 				&dns.SVCBAlpn{Alpn: []string{"dot"}},
-				&dns.SVCBPort{Port: uint16(addr.Port)},
+				&dns.SVCBPort{Port: port},
 			}
 
 			ans := &dns.SVCB{

--- a/internal/dnsforward/process_internal_test.go
+++ b/internal/dnsforward/process_internal_test.go
@@ -231,6 +231,15 @@ func TestServer_ProcessDDRQuery(t *testing.T) {
 			&dns.SVCBDoHPath{Template: "/dns-query{?dns}"},
 		},
 	}
+	dohSVCBAltPort := &dns.SVCB{
+		Priority: 1,
+		Target:   ddrTestFQDN,
+		Value: []dns.SVCBKeyValue{
+			&dns.SVCBAlpn{Alpn: []string{"h2"}},
+			&dns.SVCBPort{Port: 8144},
+			&dns.SVCBDoHPath{Template: "/dns-query{?dns}"},
+		},
+	}
 
 	dotSVCB := &dns.SVCB{
 		Priority: 1,
@@ -238,6 +247,14 @@ func TestServer_ProcessDDRQuery(t *testing.T) {
 		Value: []dns.SVCBKeyValue{
 			&dns.SVCBAlpn{Alpn: []string{"dot"}},
 			&dns.SVCBPort{Port: 8043},
+		},
+	}
+	dotSVCBAltPort := &dns.SVCB{
+		Priority: 1,
+		Target:   ddrTestFQDN,
+		Value: []dns.SVCBKeyValue{
+			&dns.SVCBAlpn{Alpn: []string{"dot"}},
+			&dns.SVCBPort{Port: 8143},
 		},
 	}
 
@@ -249,10 +266,33 @@ func TestServer_ProcessDDRQuery(t *testing.T) {
 			&dns.SVCBPort{Port: 8042},
 		},
 	}
+	doqSVCBAltPort := &dns.SVCB{
+		Priority: 1,
+		Target:   ddrTestFQDN,
+		Value: []dns.SVCBKeyValue{
+			&dns.SVCBAlpn{Alpn: []string{"doq"}},
+			&dns.SVCBPort{Port: 8142},
+		},
+	}
 
 	addrsDoH := []netip.AddrPort{netip.AddrPortFrom(netutil.IPv4Localhost(), 8044)}
 	addrsDoT := []*net.TCPAddr{{Port: 8043}}
 	addrsDoQ := []*net.UDPAddr{{Port: 8042}}
+	duplicateAddrsDoH := []netip.AddrPort{
+		netip.AddrPortFrom(netutil.IPv4Localhost(), 8044),
+		netip.AddrPortFrom(netutil.IPv6Localhost(), 8044),
+		netip.AddrPortFrom(netutil.IPv4Localhost(), 8144),
+	}
+	duplicateAddrsDoT := []*net.TCPAddr{
+		net.TCPAddrFromAddrPort(netip.AddrPortFrom(netutil.IPv4Localhost(), 8043)),
+		net.TCPAddrFromAddrPort(netip.AddrPortFrom(netutil.IPv6Localhost(), 8043)),
+		net.TCPAddrFromAddrPort(netip.AddrPortFrom(netutil.IPv4Localhost(), 8143)),
+	}
+	duplicateAddrsDoQ := []*net.UDPAddr{
+		net.UDPAddrFromAddrPort(netip.AddrPortFrom(netutil.IPv4Localhost(), 8042)),
+		net.UDPAddrFromAddrPort(netip.AddrPortFrom(netutil.IPv6Localhost(), 8042)),
+		net.UDPAddrFromAddrPort(netip.AddrPortFrom(netutil.IPv4Localhost(), 8142)),
+	}
 
 	testCases := []struct {
 		name       string
@@ -271,6 +311,30 @@ func TestServer_ProcessDDRQuery(t *testing.T) {
 		qtype:      dns.TypeSVCB,
 		ddrEnabled: true,
 		addrsDoH:   addrsDoH,
+	}, {
+		name:       "dot_deduplicate",
+		wantRes:    resultCodeFinish,
+		want:       []*dns.SVCB{dotSVCB, dotSVCBAltPort},
+		host:       ddrHostFQDN,
+		qtype:      dns.TypeSVCB,
+		ddrEnabled: true,
+		addrsDoT:   duplicateAddrsDoT,
+	}, {
+		name:       "doh_deduplicate",
+		wantRes:    resultCodeFinish,
+		want:       []*dns.SVCB{dohSVCB, dohSVCBAltPort},
+		host:       ddrHostFQDN,
+		qtype:      dns.TypeSVCB,
+		ddrEnabled: true,
+		addrsDoH:   duplicateAddrsDoH,
+	}, {
+		name:       "doq_deduplicate",
+		wantRes:    resultCodeFinish,
+		want:       []*dns.SVCB{doqSVCB, doqSVCBAltPort},
+		host:       ddrHostFQDN,
+		qtype:      dns.TypeSVCB,
+		ddrEnabled: true,
+		addrsDoQ:   duplicateAddrsDoQ,
 	}, {
 		name:       "pass_qtype",
 		wantRes:    resultCodeFinish,


### PR DESCRIPTION
## Summary

- emit one DDR SVCB record for each unique protocol and port, even when the
  same port is bound on multiple IPv4 or IPv6 addresses
- preserve distinct ports, protocol separation, and the first-seen listener
  order
- add focused DoH, DoT, and DoQ regression coverage and document the fix

DDR service records do not include the listener's bind address.  Within one
protocol, listeners that share a port therefore produce identical SVCB data.
Separate per-protocol port sets remove only those duplicates, without merging
DoH, DoT, and DoQ records or changing the order of distinct ports.

Fixes #7804.

## Testing

- `go test -race -count=1 -run '^TestServer_ProcessDDRQuery$' ./internal/dnsforward`
- `go test -race -count=20 -run '^TestServer_ProcessDDRQuery$' ./internal/dnsforward`
- `go test -race -count=1 ./internal/dnsforward`
- `make go-check`
- repository pre-commit hooks: Markdown and text lint, multi-platform `go vet`,
  Go lint and vulnerability analysis, and the race-enabled Go test suite
