### PR TITLE
dnsforward: respect blocked-host exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,11 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- Blocked-host rules now respect AdBlock-style exception rules ([#7764]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#7764]: https://github.com/AdguardTeam/AdGuardHome/issues/7764
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/internal/dnsforward/access.go
+++ b/internal/dnsforward/access.go
@@ -128,12 +128,12 @@ func (a *accessManager) isBlockedClientID(id string) (ok bool) {
 
 // isBlockedHost returns true if host should be blocked.
 func (a *accessManager) isBlockedHost(host string, qt rules.RRType) (ok bool) {
-	_, ok = a.blockedHostsEng.MatchRequest(&urlfilter.DNSRequest{
+	res, ok := a.blockedHostsEng.MatchRequest(&urlfilter.DNSRequest{
 		Hostname: host,
 		DNSType:  qt,
 	})
 
-	return ok
+	return ok && (res.NetworkRule == nil || !res.NetworkRule.Whitelist)
 }
 
 // isBlockedIP returns the status of the IP address blocking as well as the rule

--- a/internal/dnsforward/access_internal_test.go
+++ b/internal/dnsforward/access_internal_test.go
@@ -109,6 +109,27 @@ func TestIsBlockedHost(t *testing.T) {
 	}
 }
 
+func TestIsBlockedHostException(t *testing.T) {
+	t.Run("network_rule", func(t *testing.T) {
+		a, err := newAccessCtx(nil, nil, []string{
+			"||*^",
+			"@@||google.com^$important",
+		})
+		require.NoError(t, err)
+
+		assert.False(t, a.isBlockedHost("google.com", dns.TypeA))
+		assert.False(t, a.isBlockedHost("sub.google.com", dns.TypeA))
+		assert.True(t, a.isBlockedHost("example.org", dns.TypeA))
+	})
+
+	t.Run("host_rule", func(t *testing.T) {
+		a, err := newAccessCtx(nil, nil, []string{"0.0.0.0 hosts-file.example"})
+		require.NoError(t, err)
+
+		assert.True(t, a.isBlockedHost("hosts-file.example", dns.TypeA))
+	})
+}
+
 func TestIsBlockedIP(t *testing.T) {
 	clients := []string{
 		"1.2.3.4",


### PR DESCRIPTION
Fixes #7764.

The access blocklist treated every successful urlfilter match as blocked, including exception rules. Inspect the matched network rule and allow whitelist matches while preserving blocking for hosts-file rules.

Regression coverage verifies exact and subdomain exceptions, an unrelated blocked domain, and hosts-file rule behavior.

Validation:

- `go test -race -count=20 -run "^(TestIsBlockedHost|TestIsBlockedHostException)$" ./internal/dnsforward`
- `go test -race -count=1 ./internal/dnsforward`
- `go vet ./internal/dnsforward`
- `make go-check`