### PR TITLE
filtering: classify custom host rules as rewrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,12 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- Custom filtering rules in `/etc/hosts` format are now reported as rewrites
+  in the query log ([#7659]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#7659]: https://github.com/AdguardTeam/AdGuardHome/issues/7659
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/internal/dnsforward/dnsforward_internal_test.go
+++ b/internal/dnsforward/dnsforward_internal_test.go
@@ -1235,6 +1235,39 @@ func TestBlockedCustomIP(t *testing.T) {
 }
 
 func TestBlockedByHosts(t *testing.T) {
+	customIPv4 := netip.MustParseAddr("192.0.2.1")
+	testCases := []struct {
+		name      string
+		mode      filtering.BlockingMode
+		wantIP    netip.Addr
+		wantRCode int
+	}{
+		{
+			name:      "default",
+			mode:      filtering.BlockingModeDefault,
+			wantIP:    netutil.IPv4Localhost(),
+			wantRCode: dns.RcodeSuccess,
+		}, {
+			name:      "null_ip",
+			mode:      filtering.BlockingModeNullIP,
+			wantIP:    netip.IPv4Unspecified(),
+			wantRCode: dns.RcodeSuccess,
+		}, {
+			name:      "nxdomain",
+			mode:      filtering.BlockingModeNXDOMAIN,
+			wantRCode: dns.RcodeNameError,
+		}, {
+			name:      "refused",
+			mode:      filtering.BlockingModeREFUSED,
+			wantRCode: dns.RcodeRefused,
+		}, {
+			name:      "custom_ip",
+			mode:      filtering.BlockingModeCustomIP,
+			wantIP:    customIPv4,
+			wantRCode: dns.RcodeSuccess,
+		},
+	}
+
 	forwardConf := ServerConfig{
 		UDPListenAddrs: []*net.UDPAddr{{}},
 		TCPListenAddrs: []*net.TCPAddr{{}},
@@ -1248,45 +1281,33 @@ func TestBlockedByHosts(t *testing.T) {
 		},
 		ServePlainDNS: true,
 	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := createTestServer(t, &filtering.Config{
+				ProtectionEnabled: true,
+				BlockingMode:      tc.mode,
+				BlockingIPv4:      customIPv4,
+				BlockingIPv6:      netip.MustParseAddr("2001:db8::1"),
+			}, forwardConf, testTLSConfigProvider)
+			startDeferStop(t, s)
 
-	s := createTestServer(
-		t,
-		&filtering.Config{ProtectionEnabled: true, BlockingMode: filtering.BlockingModeDefault},
-		forwardConf,
-		testTLSConfigProvider,
-	)
-	startDeferStop(t, s)
-	addr := s.dnsProxy.Addr(proxy.ProtoUDP)
+			addr := s.dnsProxy.Addr(proxy.ProtoUDP)
+			req := createTestMessage("host.example.org.")
+			reply, err := dns.Exchange(req, addr.String())
+			require.NoErrorf(t, err, "couldn't talk to server %s: %s", addr, err)
 
-	// Hosts blocking.
-	req := createTestMessage("host.example.org.")
+			assert.Equal(t, tc.wantRCode, reply.Rcode)
+			if !tc.wantIP.IsValid() {
+				assert.Empty(t, reply.Answer)
 
-	reply, err := dns.Exchange(req, addr.String())
-	require.NoErrorf(t, err, "couldn't talk to server %s: %s", addr, err)
-	require.Lenf(
-		t,
-		reply.Answer,
-		1,
-		"dns server %s returned reply with wrong number of answers - %d",
-		addr,
-		len(reply.Answer),
-	)
-	a, ok := reply.Answer[0].(*dns.A)
-	require.Truef(
-		t,
-		ok,
-		"dns server %s returned wrong answer type instead of A: %v",
-		addr,
-		reply.Answer[0],
-	)
-	assert.Equalf(
-		t,
-		net.IP{127, 0, 0, 1},
-		a.A,
-		"dns server %s returned wrong answer instead of 8.8.8.8: %v",
-		addr,
-		a.A,
-	)
+				return
+			}
+
+			require.Len(t, reply.Answer, 1)
+			a := testutil.RequireTypeAssert[*dns.A](t, reply.Answer[0])
+			assert.Equal(t, tc.wantIP.String(), a.A.String())
+		})
+	}
 }
 
 func TestBlockedBySafeBrowsing(t *testing.T) {

--- a/internal/filtering/filtering.go
+++ b/internal/filtering/filtering.go
@@ -845,24 +845,31 @@ func (d *DNSFilter) matchHostProcessDNSResult(
 // [matchHostProcessDNSResult].  dnsres must not be nil.
 func resultFromHostRules(qtype uint16, dnsres *urlfilter.DNSResult) (res Result, ok bool) {
 	if qtype == dns.TypeA && dnsres.HostRulesV4 != nil {
-		res = makeResult(hostRulesToRules(dnsres.HostRulesV4), FilteredBlockList)
-		for i, hr := range dnsres.HostRulesV4 {
-			res.Rules[i].IP = hr.IP
-		}
-
-		return res, true
+		return resultForHostRules(dnsres.HostRulesV4), true
 	}
 
 	if qtype == dns.TypeAAAA && dnsres.HostRulesV6 != nil {
-		res = makeResult(hostRulesToRules(dnsres.HostRulesV6), FilteredBlockList)
-		for i, hr := range dnsres.HostRulesV6 {
-			res.Rules[i].IP = hr.IP
-		}
-
-		return res, true
+		return resultForHostRules(dnsres.HostRulesV6), true
 	}
 
 	return Result{}, false
+}
+
+// resultForHostRules returns the filtering result for matched hostRules.
+// hostRules must not be nil.
+func resultForHostRules(hostRules []*rules.HostRule) (res Result) {
+	res = makeResult(hostRulesToRules(hostRules), FilteredBlockList)
+	for i, hr := range hostRules {
+		ip := hr.IP
+		res.Rules[i].IP = ip
+		if hr.GetFilterListID() == rulelist.IDCustom && !ip.IsUnspecified() {
+			res.Reason = RewrittenRule
+		}
+	}
+
+	// Keep IsFiltered set so that the configured blocking mode is applied to
+	// the response.  The reason is used to classify the query as a rewrite.
+	return res
 }
 
 // hostResultForOtherQType returns a result based on the host rules in dnsres,

--- a/internal/filtering/filtering_internal_test.go
+++ b/internal/filtering/filtering_internal_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/AdguardTeam/AdGuardHome/internal/aghtest"
 	"github.com/AdguardTeam/AdGuardHome/internal/filtering/hashprefix"
+	"github.com/AdguardTeam/AdGuardHome/internal/filtering/rulelist"
 	"github.com/AdguardTeam/golibs/logutil/slogutil"
 	"github.com/AdguardTeam/golibs/netutil"
 	"github.com/AdguardTeam/golibs/testutil"
@@ -113,7 +114,7 @@ func TestDNSFilter_CheckHost_hostRules(t *testing.T) {
 `,
 		addr, addr6)
 	filters := []Filter{{
-		ID: 0, Data: []byte(text),
+		ID: 1, Data: []byte(text),
 	}}
 	d, setts := newForTest(t, nil, filters)
 	t.Cleanup(d.Close)
@@ -171,6 +172,133 @@ func TestDNSFilter_CheckHost_hostRules(t *testing.T) {
 	require.Len(t, res.Rules, 1)
 
 	assert.Equal(t, res.Rules[0].IP, netutil.IPv6Localhost())
+}
+
+func TestDNSFilter_CheckHost_customHostRules(t *testing.T) {
+	const (
+		customIPv4Rule  = "192.0.2.1 v4.example"
+		customIPv6Rule  = "2001:db8::1 v6.example"
+		customMixedRule = "192.0.2.2 mixed.example"
+		zeroIPv4Rule    = "0.0.0.0 zero-v4.example"
+		zeroIPv6Rule    = ":: zero-v6.example"
+
+		downloadedRule          = "198.51.100.1 downloaded.example"
+		downloadedMixedRule     = "198.51.100.2 mixed.example"
+		downloadedDuplicateRule = "192.0.2.2 mixed.example"
+	)
+
+	filters := []Filter{{
+		ID: rulelist.IDCustom,
+		Data: []byte(customIPv4Rule + "\n" +
+			customIPv6Rule + "\n" +
+			customMixedRule + "\n" +
+			zeroIPv4Rule + "\n" +
+			zeroIPv6Rule + "\n"),
+	}, {
+		ID: 1,
+		Data: []byte(downloadedRule + "\n" +
+			downloadedDuplicateRule + "\n" +
+			downloadedMixedRule + "\n"),
+	}}
+	d, setts := newForTest(t, nil, filters)
+	t.Cleanup(d.Close)
+
+	t.Run("ipv4", func(t *testing.T) {
+		wantIP := netip.MustParseAddr("192.0.2.1")
+		res, err := d.CheckHost("v4.example", dns.TypeA, setts)
+		require.NoError(t, err)
+
+		assert.True(t, res.IsFiltered)
+		assert.Equal(t, RewrittenRule, res.Reason)
+		require.Len(t, res.Rules, 1)
+		assert.Equal(t, customIPv4Rule, res.Rules[0].Text)
+		assert.Equal(t, rulelist.APIIDCustom, res.Rules[0].FilterListID)
+		assert.Equal(t, wantIP, res.Rules[0].IP)
+		assert.Nil(t, res.DNSRewriteResult)
+	})
+
+	t.Run("ipv6", func(t *testing.T) {
+		wantIP := netip.MustParseAddr("2001:db8::1")
+		res, err := d.CheckHost("v6.example", dns.TypeAAAA, setts)
+		require.NoError(t, err)
+
+		assert.True(t, res.IsFiltered)
+		assert.Equal(t, RewrittenRule, res.Reason)
+		require.Len(t, res.Rules, 1)
+		assert.Equal(t, customIPv6Rule, res.Rules[0].Text)
+		assert.Equal(t, rulelist.APIIDCustom, res.Rules[0].FilterListID)
+		assert.Equal(t, wantIP, res.Rules[0].IP)
+		assert.Nil(t, res.DNSRewriteResult)
+	})
+
+	t.Run("downloaded", func(t *testing.T) {
+		res, err := d.CheckHost("downloaded.example", dns.TypeA, setts)
+		require.NoError(t, err)
+
+		assert.True(t, res.IsFiltered)
+		assert.Equal(t, FilteredBlockList, res.Reason)
+		assert.Nil(t, res.DNSRewriteResult)
+	})
+
+	t.Run("mixed", func(t *testing.T) {
+		wantCustomIP := netip.MustParseAddr("192.0.2.2")
+		wantDownloadedIP := netip.MustParseAddr("198.51.100.2")
+		res, err := d.CheckHost("mixed.example", dns.TypeA, setts)
+		require.NoError(t, err)
+
+		assert.True(t, res.IsFiltered)
+		assert.Equal(t, RewrittenRule, res.Reason)
+		require.Len(t, res.Rules, 3)
+
+		type ruleData struct {
+			text string
+			id   rulelist.APIID
+			ip   netip.Addr
+		}
+
+		gotRules := make([]ruleData, len(res.Rules))
+		for i, r := range res.Rules {
+			gotRules[i] = ruleData{
+				text: r.Text,
+				id:   r.FilterListID,
+				ip:   r.IP,
+			}
+		}
+
+		assert.ElementsMatch(t, []ruleData{
+			{text: customMixedRule, id: rulelist.APIIDCustom, ip: wantCustomIP},
+			{text: downloadedDuplicateRule, id: 1, ip: wantCustomIP},
+			{text: downloadedMixedRule, id: 1, ip: wantDownloadedIP},
+		}, gotRules)
+		assert.Nil(t, res.DNSRewriteResult)
+	})
+
+	t.Run("zero_ipv4", func(t *testing.T) {
+		res, err := d.CheckHost("zero-v4.example", dns.TypeA, setts)
+		require.NoError(t, err)
+
+		assert.True(t, res.IsFiltered)
+		assert.Equal(t, FilteredBlockList, res.Reason)
+		assert.Nil(t, res.DNSRewriteResult)
+	})
+
+	t.Run("zero_ipv6", func(t *testing.T) {
+		res, err := d.CheckHost("zero-v6.example", dns.TypeAAAA, setts)
+		require.NoError(t, err)
+
+		assert.True(t, res.IsFiltered)
+		assert.Equal(t, FilteredBlockList, res.Reason)
+		assert.Nil(t, res.DNSRewriteResult)
+	})
+
+	t.Run("qtype_mismatch", func(t *testing.T) {
+		res, err := d.CheckHost("v4.example", dns.TypeAAAA, setts)
+		require.NoError(t, err)
+
+		assert.True(t, res.IsFiltered)
+		assert.Equal(t, FilteredBlockList, res.Reason)
+		assert.Nil(t, res.DNSRewriteResult)
+	})
 }
 
 // Safe Browsing.

--- a/internal/filtering/reason.go
+++ b/internal/filtering/reason.go
@@ -47,7 +47,8 @@ const (
 	// RewrittenAutoHosts is returned when there was a rewrite by /etc/hosts.
 	RewrittenAutoHosts
 
-	// RewrittenRule is returned when a $dnsrewrite filter rule was applied.
+	// RewrittenRule is returned when a $dnsrewrite filter rule or a custom
+	// hosts-file-style rule was applied.
 	//
 	// TODO(a.garipov): Remove [Rewritten] and [RewrittenAutoHosts] by merging
 	// their functionality into RewrittenRule.


### PR DESCRIPTION
Closes #7659.

## Summary

- Classify non-zero `/etc/hosts`-style rules from the custom filtering list as `RewriteRule`, so the query log presents them as rewrites.
- Keep downloaded host rules, zero-address blocking rules, and query-type mismatches classified as blocked.
- Preserve `IsFiltered` so the configured blocking mode continues to determine the DNS response.
- Document the user-visible correction in the changelog.

## Tests

Coverage includes IPv4 and IPv6 custom rewrites, mixed custom and downloaded matches, zero-address rules, query-type mismatches, and every configured blocking mode.

Validation completed:

- `go test -race -count=20 -run '^TestDNSFilter_CheckHost_customHostRules$' ./internal/filtering`
- `go test -race -count=20 -run '^TestBlockedByHosts$' ./internal/dnsforward`
- `go test -race -count=1 ./internal/filtering ./internal/dnsforward`
- `go vet ./internal/filtering ./internal/dnsforward`
- `make go-check`
- Cross-compilation for Linux amd64, Linux arm64, and Windows amd64
