### PR TITLE
client: show DHCP status request errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,12 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- Errors loading the DHCP status are now shown instead of reporting DHCP as
+  unavailable ([#3422]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#3422]: https://github.com/AdguardTeam/AdGuardHome/issues/3422
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/client_v2/src/__tests__/dhcp-status-error.test.tsx
+++ b/client_v2/src/__tests__/dhcp-status-error.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@solidjs/testing-library';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    dhcpState: {
+        processing: false,
+        processingStatus: false,
+        processingInterfaces: false,
+        dhcp_available: false,
+        statusError: true,
+        interface_name: '',
+        interfaces: {},
+        enabled: false,
+        check: null as null,
+        v4: {
+            gateway_ip: '',
+            subnet_mask: '',
+            range_start: '',
+            range_end: '',
+            lease_duration: 0,
+        },
+        v6: { range_start: '', lease_duration: 0 },
+    },
+    getDhcpStatus: vi.fn(),
+    getDhcpInterfaces: vi.fn(),
+    setDhcpConfig: vi.fn(),
+    resetDhcp: vi.fn(),
+}));
+
+vi.mock('@solidjs/router', () => ({
+    useNavigate: () => vi.fn(),
+}));
+
+vi.mock('panel/stores/dhcp', () => ({
+    get dhcpState() {
+        return mocks.dhcpState;
+    },
+    getDhcpStatus: mocks.getDhcpStatus,
+    getDhcpInterfaces: mocks.getDhcpInterfaces,
+    setDhcpConfig: mocks.setDhcpConfig,
+    resetDhcp: mocks.resetDhcp,
+}));
+
+vi.mock('panel/common/intl', () => ({
+    default: {
+        getMessage: (key: string) => key,
+    },
+}));
+
+import { Dhcp } from 'panel/components/Dhcp/Dhcp';
+
+describe('Dhcp status error', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.dhcpState.processing = false;
+        mocks.dhcpState.processingInterfaces = false;
+        mocks.dhcpState.processingStatus = false;
+        mocks.dhcpState.dhcp_available = false;
+        mocks.dhcpState.statusError = true;
+    });
+
+    it('shows a retryable error instead of reporting DHCP as unavailable', () => {
+        render(() => <Dhcp />);
+
+        expect(screen.getByText('error')).toBeInTheDocument();
+        expect(screen.getByText('dhcp_error')).toBeInTheDocument();
+        expect(screen.getByText('try_again')).toBeInTheDocument();
+        expect(screen.queryByText('unavailable_dhcp')).not.toBeInTheDocument();
+    });
+
+    it('shows the page loader while a retry is in progress', () => {
+        mocks.dhcpState.statusError = false;
+        mocks.dhcpState.processingStatus = true;
+
+        const { container } = render(() => <Dhcp />);
+
+        expect(container.querySelector('use[href="#loader"]')).toBeInTheDocument();
+        expect(screen.queryByText('unavailable_dhcp')).not.toBeInTheDocument();
+    });
+
+    it('does not fetch interfaces after a status error with stale availability', async () => {
+        const statusRequest = Promise.resolve();
+
+        mocks.dhcpState.dhcp_available = true;
+        mocks.getDhcpStatus.mockReturnValueOnce(statusRequest);
+
+        render(() => <Dhcp />);
+
+        await statusRequest;
+        await Promise.resolve();
+
+        expect(mocks.getDhcpStatus).toHaveBeenCalledOnce();
+        expect(mocks.getDhcpInterfaces).not.toHaveBeenCalled();
+        expect(screen.getByText('error')).toBeInTheDocument();
+    });
+});

--- a/client_v2/src/__tests__/dhcp-store-status-error.test.ts
+++ b/client_v2/src/__tests__/dhcp-store-status-error.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    status: vi.fn(),
+    addErrorToast: vi.fn(),
+}));
+
+vi.mock('panel/api/generated', () => ({
+    status: mocks.status,
+    dhcpStatus: vi.fn(),
+    dhcpInterfaces: vi.fn(),
+    checkActiveDhcp: vi.fn(),
+    dhcpSetConfig: vi.fn(),
+    dhcpReset: vi.fn(),
+    dhcpResetLeases: vi.fn(),
+    dhcpAddStaticLease: vi.fn(),
+    dhcpRemoveStaticLease: vi.fn(),
+    dhcpUpdateStaticLease: vi.fn(),
+}));
+
+vi.mock('panel/stores/toasts', () => ({
+    addErrorToast: mocks.addErrorToast,
+    addSuccessToast: vi.fn(),
+}));
+
+import { dhcpState, getDhcpStatus } from 'panel/stores/dhcp';
+
+describe('getDhcpStatus errors', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('distinguishes a request failure from an unavailable DHCP server', async () => {
+        const requestError = new Error('network unavailable');
+        mocks.status.mockRejectedValueOnce(requestError);
+
+        await getDhcpStatus();
+
+        expect(dhcpState.statusError).toBe(true);
+        expect(dhcpState.processing).toBe(false);
+        expect(dhcpState.processingStatus).toBe(false);
+        expect(mocks.addErrorToast).toHaveBeenCalledWith({ error: requestError });
+
+        let resolveStatus!: (value: { dhcp_available: boolean }) => void;
+        mocks.status.mockReturnValueOnce(
+            new Promise((resolve) => {
+                resolveStatus = resolve;
+            }),
+        );
+
+        const retry = getDhcpStatus();
+        expect(dhcpState.statusError).toBe(false);
+        expect(dhcpState.processingStatus).toBe(true);
+
+        resolveStatus({ dhcp_available: false });
+        await retry;
+
+        expect(dhcpState.statusError).toBe(false);
+        expect(dhcpState.dhcp_available).toBe(false);
+        expect(dhcpState.processing).toBe(false);
+        expect(dhcpState.processingStatus).toBe(false);
+    });
+});

--- a/client_v2/src/components/Dhcp/Dhcp.tsx
+++ b/client_v2/src/components/Dhcp/Dhcp.tsx
@@ -7,6 +7,7 @@ import { Icon } from 'panel/common/ui/Icon';
 import { PageLoader } from 'panel/common/ui/Loader';
 import { SettingRow } from 'panel/common/ui/SettingRow';
 import { ConfirmDialog } from 'panel/common/ui/ConfirmDialog';
+import { Button } from 'panel/common/ui/Button';
 import intl from 'panel/common/intl';
 import theme from 'panel/lib/theme';
 import { useDialog } from 'panel/hooks/useDialog';
@@ -44,17 +45,19 @@ export const Dhcp = () => {
         }
     });
 
-    onMount(async () => {
+    const loadDhcp = async () => {
         await getDhcpStatus();
 
-        if (dhcpState.dhcp_available) {
+        if (!dhcpState.statusError && dhcpState.dhcp_available) {
             await getDhcpInterfaces();
             if (!selectedInterface() && dhcpState.interfaces) {
                 const firstIface = Object.keys(dhcpState.interfaces)[0];
                 if (firstIface) setSelectedInterface(firstIface);
             }
         }
-    });
+    };
+
+    onMount(loadDhcp);
 
     const handleSaveV4Config = (values: V4Config) => {
         setDhcpConfig({ interface_name: selectedInterface(), v4: values });
@@ -102,13 +105,24 @@ export const Dhcp = () => {
         </div>
     );
 
-    const isLoaded = () => !dhcpState.processing && !dhcpState.processingInterfaces;
+    const isLoaded = () =>
+        !dhcpState.processing && !dhcpState.processingStatus && !dhcpState.processingInterfaces;
 
     return (
         <div class={theme.layout.container}>
             <div class={cn(theme.layout.containerIn, theme.layout.containerIn_one_col)}>
                 <Show when={isLoaded()} fallback={<PageLoader />}>
-                    <Show when={!dhcpState.dhcp_available}>
+                    <Show when={dhcpState.statusError}>
+                        <div class={s.unavailable}>
+                            <h1 class={cn(theme.title.h4, theme.title.h3_tablet)}>
+                                {intl.getMessage('error')}
+                            </h1>
+                            <div class={theme.text.t2}>{intl.getMessage('dhcp_error')}</div>
+                            <Button onClick={loadDhcp}>{intl.getMessage('try_again')}</Button>
+                        </div>
+                    </Show>
+
+                    <Show when={!dhcpState.statusError && !dhcpState.dhcp_available}>
                         <div class={s.unavailable}>
                             <h1 class={cn(theme.title.h4, theme.title.h3_tablet)}>
                                 {intl.getMessage('unavailable_dhcp')}
@@ -119,7 +133,7 @@ export const Dhcp = () => {
                         </div>
                     </Show>
 
-                    <Show when={dhcpState.dhcp_available}>
+                    <Show when={!dhcpState.statusError && dhcpState.dhcp_available}>
                         <div class={s.header}>
                             <h1
                                 class={cn(

--- a/client_v2/src/stores/dhcp.ts
+++ b/client_v2/src/stores/dhcp.ts
@@ -36,6 +36,7 @@ type DhcpState = {
     processingDeleting: boolean;
     processingUpdating: boolean;
     processingReset: boolean;
+    statusError: boolean;
     enabled: boolean;
     interface_name: string;
     check: DhcpSearchResult | null;
@@ -70,6 +71,7 @@ const initialState: DhcpState = {
     processingDeleting: false,
     processingUpdating: false,
     processingReset: false,
+    statusError: false,
     enabled: false,
     interface_name: '',
     check: null,
@@ -97,7 +99,7 @@ const initialState: DhcpState = {
 const [state, setState] = createStore<DhcpState>(initialState);
 
 export const getDhcpStatus = async () => {
-    setState('processingStatus', true);
+    setState({ processingStatus: true, statusError: false });
     try {
         const globalStatus = await status();
         if (globalStatus.dhcp_available) {
@@ -132,7 +134,7 @@ export const getDhcpStatus = async () => {
         }
     } catch (error) {
         addErrorToast({ error });
-        setState({ processingStatus: false, processing: false });
+        setState({ processingStatus: false, processing: false, statusError: true });
     }
 };
 


### PR DESCRIPTION
## Summary

- distinguish DHCP status request failures from an unsupported DHCP server;
- show a retryable error instead of the incorrect unavailable screen;
- keep the loading state visible during retries and avoid fetching interfaces
  after a failed status request.

## Validation

- Test-only baseline against `upstream/master`: 2 files and 4 tests failed for
  the expected missing error, loading, stale-interface, and store-state
  behavior.
- Focused patched tests: 2 files and 4 tests passed.
- `npm run check`: lint, type-check, 60 test files, and 623 tests passed.
- `npm run build-prod`: production Webpack build passed (55 assets and 2,345
  modules; one existing Webpack deprecation warning was emitted).
- `make js-lint js-typecheck`, `make md-lint`, and `make txt-lint` passed.

Environment: Node.js v26.5.1 and npm 11.17.0.  Vitest used
`NODE_OPTIONS=--localstorage-file=/private/tmp/agh-3422-localstorage` to provide
the explicit localStorage backing file required by this Node 26 environment.

Not run: Playwright end-to-end tests or the manual stop-the-backend scenario.
Go checks were skipped because this patch only changes the frontend and
changelog.

Closes #3422.
