### PR TITLE
dnsforward: use system hosts for internal lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,12 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- Filter downloads now honor addresses from the system hosts file ([#8460]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
+[#8460]: https://github.com/AdguardTeam/AdGuardHome/issues/8460
 
 <!--
 NOTE: Add new changes ABOVE THIS COMMENT.

--- a/internal/dnsforward/dnsforward.go
+++ b/internal/dnsforward/dnsforward.go
@@ -338,12 +338,28 @@ func (s *Server) UpstreamTimeout() (t time.Duration) {
 	return s.conf.UpstreamTimeout
 }
 
-// Resolve gets IP addresses by host name from an upstream server.  No
-// request/response filtering is performed.  Query log and Stats are not
-// updated.  This method may be called before [Server.Start].
+// Resolve gets IP addresses by host name from the system hosts files or an
+// upstream server.  No request/response filtering is performed.  Query log and
+// Stats are not updated.  This method may be called before [Server.Start].
 func (s *Server) Resolve(ctx context.Context, net, host string) (addr []netip.Addr, err error) {
 	s.serverLock.RLock()
 	defer s.serverLock.RUnlock()
+
+	if s.etcHosts != nil {
+		hostsNet := "ip"
+		switch net {
+		case "tcp4", "udp4", "ip4":
+			hostsNet = "ip4"
+		case "tcp6", "udp6", "ip6":
+			hostsNet = "ip6"
+		}
+
+		return upstream.ConsequentResolver{s.etcHosts, s.internalProxy}.LookupNetIP(
+			ctx,
+			hostsNet,
+			host,
+		)
+	}
 
 	return s.internalProxy.LookupNetIP(ctx, net, host)
 }

--- a/internal/dnsforward/resolve_internal_test.go
+++ b/internal/dnsforward/resolve_internal_test.go
@@ -1,0 +1,150 @@
+package dnsforward
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/AdguardTeam/AdGuardHome/internal/aghtest"
+	"github.com/AdguardTeam/dnsproxy/proxy"
+	"github.com/AdguardTeam/dnsproxy/upstream"
+	"github.com/AdguardTeam/golibs/hostsfile"
+	"github.com/AdguardTeam/golibs/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServer_Resolve_systemHosts(t *testing.T) {
+	const (
+		host                 = "filter.example"
+		upstreamOnlyHost     = "upstream.example"
+		dualStackHost        = "dual-stack.example"
+		upstreamIPv4OnlyHost = "upstream-ipv4.example"
+		upstreamIPv6OnlyHost = "upstream-ipv6.example"
+	)
+
+	ctx := testutil.ContextWithTimeout(t, testTimeout)
+	hosts, err := hostsfile.NewDefaultStorage(ctx, &hostsfile.DefaultStorageConfig{
+		Logger: testLogger,
+	})
+	require.NoError(t, err)
+
+	hostsIPv4 := netip.MustParseAddr("192.0.2.1")
+	hostsIPv6 := netip.MustParseAddr("2001:db8::1")
+	hosts.Add(ctx, &hostsfile.Record{
+		Addr:  hostsIPv4,
+		Names: []string{host},
+	})
+	hosts.Add(ctx, &hostsfile.Record{
+		Addr:  hostsIPv4,
+		Names: []string{dualStackHost, upstreamIPv6OnlyHost},
+	})
+	hosts.Add(ctx, &hostsfile.Record{
+		Addr:  hostsIPv6,
+		Names: []string{dualStackHost, upstreamIPv4OnlyHost},
+	})
+
+	upstreamIPv4 := netip.MustParseAddr("192.0.2.2")
+	upstreamIPv6 := netip.MustParseAddr("2001:db8::2")
+	internalProxy, err := proxy.New(&proxy.Config{
+		UpstreamConfig: &proxy.UpstreamConfig{
+			Upstreams: []upstream.Upstream{&aghtest.Upstream{
+				IPv4: map[string][]net.IP{
+					host + ".":                 {upstreamIPv4.AsSlice()},
+					upstreamOnlyHost + ".":     {upstreamIPv4.AsSlice()},
+					upstreamIPv4OnlyHost + ".": {upstreamIPv4.AsSlice()},
+				},
+				IPv6: map[string][]net.IP{
+					upstreamIPv6OnlyHost + ".": {upstreamIPv6.AsSlice()},
+				},
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	s := &Server{
+		etcHosts:      upstream.NewHostsResolver(hosts),
+		internalProxy: internalProxy,
+	}
+
+	testCases := []struct {
+		name    string
+		network string
+		host    string
+		want    []netip.Addr
+	}{
+		{
+			name:    "system_hosts",
+			network: "tcp",
+			host:    host,
+			want:    []netip.Addr{hostsIPv4},
+		},
+		{
+			name:    "upstream_fallback",
+			network: "tcp",
+			host:    upstreamOnlyHost,
+			want:    []netip.Addr{upstreamIPv4},
+		},
+		{
+			name:    "tcp_dual_stack_system_hosts",
+			network: "tcp",
+			host:    dualStackHost,
+			want:    []netip.Addr{hostsIPv4, hostsIPv6},
+		},
+		{
+			name:    "tcp4_system_hosts",
+			network: "tcp4",
+			host:    dualStackHost,
+			want:    []netip.Addr{hostsIPv4},
+		},
+		{
+			name:    "udp4_system_hosts",
+			network: "udp4",
+			host:    dualStackHost,
+			want:    []netip.Addr{hostsIPv4},
+		},
+		{
+			name:    "ip4_system_hosts",
+			network: "ip4",
+			host:    dualStackHost,
+			want:    []netip.Addr{hostsIPv4},
+		},
+		{
+			name:    "tcp6_system_hosts",
+			network: "tcp6",
+			host:    dualStackHost,
+			want:    []netip.Addr{hostsIPv6},
+		},
+		{
+			name:    "udp6_system_hosts",
+			network: "udp6",
+			host:    dualStackHost,
+			want:    []netip.Addr{hostsIPv6},
+		},
+		{
+			name:    "ip6_system_hosts",
+			network: "ip6",
+			host:    dualStackHost,
+			want:    []netip.Addr{hostsIPv6},
+		},
+		{
+			name:    "tcp4_opposite_family_fallback",
+			network: "tcp4",
+			host:    upstreamIPv4OnlyHost,
+			want:    []netip.Addr{upstreamIPv4},
+		},
+		{
+			name:    "tcp6_opposite_family_fallback",
+			network: "tcp6",
+			host:    upstreamIPv6OnlyHost,
+			want:    []netip.Addr{upstreamIPv6},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			addrs, resolveErr := s.Resolve(ctx, tc.network, tc.host)
+			require.NoError(t, resolveErr)
+			require.Equal(t, tc.want, addrs)
+		})
+	}
+}


### PR DESCRIPTION
Updates #8460.

The shared HTTP client resolves download hosts through `Server.DialContext`. Make `Server.Resolve` consult the system hosts resolver first, then fall back to the configured internal DNS proxy when no matching hosts-file address is available.

Normalize transport-specific network names for the hosts resolver so IPv4 and IPv6 lookups preserve their requested address family. Regression coverage exercises system-host precedence, upstream fallback, dual-stack results, and the supported transport network forms.

Validation:

- `go test -race -count=20 -run "^TestServer_Resolve_systemHosts$" ./internal/dnsforward`
- `go test -race -count=1 ./internal/dnsforward`
- `go vet ./internal/dnsforward`
- `make go-check`