### PR TITLE
home: allow certificate-less DoH and DNSCrypt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,12 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- Starting AdGuard Home with DNSCrypt or unencrypted DNS-over-HTTPS enabled
+  without a TLS certificate ([#7773]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#7773]: https://github.com/AdguardTeam/AdGuardHome/issues/7773
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/internal/dnsforward/config.go
+++ b/internal/dnsforward/config.go
@@ -711,15 +711,15 @@ func (s *Server) prepareTLS(ctx context.Context, proxyConf *proxy.Config) {
 		return
 	}
 
-	proxyConf.TLSListenAddr = s.conf.TLSConf.TLSListenAddrs
-	proxyConf.QUICListenAddr = s.conf.TLSConf.QUICListenAddrs
-
 	proxyConf.TLSConfig = s.tlsConfigProvider.TLSConfig()
 	if proxyConf.TLSConfig == nil {
 		s.logger.WarnContext(ctx, "tls configuration is not set")
 
 		return
 	}
+
+	proxyConf.TLSListenAddr = s.conf.TLSConf.TLSListenAddrs
+	proxyConf.QUICListenAddr = s.conf.TLSConf.QUICListenAddrs
 
 	if s.conf.TLSConf.StrictSNICheck && proxyConf.TLSConfig.GetCertificate != nil {
 		s.replaceGetCertificate(proxyConf.TLSConfig)

--- a/internal/dnsforward/dnsforward_internal_test.go
+++ b/internal/dnsforward/dnsforward_internal_test.go
@@ -501,6 +501,36 @@ func TestServer_timeout(t *testing.T) {
 	})
 }
 
+func TestServerPrepareCertlessTLS(t *testing.T) {
+	s, err := NewServer(DNSCreateParams{
+		Logger:            testLogger,
+		TLSConfigProvider: aghtls.EmptyTLSConfigProvider{},
+	})
+	require.NoError(t, err)
+
+	conf := &ServerConfig{
+		TLSConf: &TLSConfig{
+			TLSListenAddrs:  []*net.TCPAddr{{IP: net.IPv4(127, 0, 0, 1), Port: 5445}},
+			QUICListenAddrs: []*net.UDPAddr{{IP: net.IPv4(127, 0, 0, 1), Port: 5446}},
+		},
+		Config: Config{
+			UpstreamMode:     UpstreamModeLoadBalance,
+			EDNSClientSubnet: &EDNSClientSubnet{},
+			ClientsContainer: EmptyClientsContainer{},
+		},
+		ServePlainDNS: true,
+	}
+
+	err = s.Prepare(testutil.ContextWithTimeout(t, testTimeout), conf)
+	require.NoError(t, err)
+	assert.Nil(t, s.dnsProxy.TLSListenAddr)
+	assert.Nil(t, s.dnsProxy.QUICListenAddr)
+
+	req := (&dns.Msg{}).SetQuestion(ddrHostFQDN, dns.TypeSVCB)
+	resp := s.makeDDRResponse(req)
+	assert.Empty(t, resp.Answer)
+}
+
 func TestServer_Prepare_fallbacks(t *testing.T) {
 	srvConf := &ServerConfig{
 		TLSConf: &TLSConfig{},

--- a/internal/home/control.go
+++ b/internal/home/control.go
@@ -79,7 +79,7 @@ func collectDNSAddresses(tlsMgr *tlsManager) (addrs []string, err error) {
 		}
 	}
 
-	de := getDNSEncryption(tlsMgr)
+	de := getDNSEncryption(tlsMgr, config.HTTPConfig.DoH.InsecureEnabled)
 	if de.https != "" {
 		addrs = append(addrs, de.https)
 	}
@@ -359,7 +359,7 @@ func (web *webAPI) preInstallHandler(handler http.Handler) (wrapped http.Handler
 // HTTPS-related headers.  If proceed is true, the middleware must continue
 // handling the request.
 func (web *webAPI) handleHTTPSRedirect(w http.ResponseWriter, r *http.Request) (proceed bool) {
-	if web.httpsServer.server == nil {
+	if !web.httpsServer.isEnabled() {
 		return true
 	}
 

--- a/internal/home/dns.go
+++ b/internal/home/dns.go
@@ -273,6 +273,9 @@ func newServerConfig(
 	if err != nil {
 		return nil, fmt.Errorf("constructing tls config: %w", err)
 	}
+	if tlsConfProvider.TLSConfig() == nil && !dohConf.InsecureEnabled {
+		intTLSConf.HTTPSListenAddrs = nil
+	}
 
 	newConf = &dnsforward.ServerConfig{
 		UDPListenAddrs:         ipsToUDPAddrs(hosts, dnsConf.Port),
@@ -403,15 +406,16 @@ type dnsEncryption struct {
 
 // getDNSEncryption returns the TLS encryption addresses that AdGuard Home
 // listens on.  tlsMgr must not be nil.
-func getDNSEncryption(tlsMgr *tlsManager) (de dnsEncryption) {
+func getDNSEncryption(tlsMgr *tlsManager, allowUnencryptedDoH bool) (de dnsEncryption) {
 	extTLSConf := tlsMgr.extendedTLSConfig()
 
 	if !extTLSConf.Enabled || extTLSConf.ServerName == "" {
 		return dnsEncryption{}
 	}
 
+	hasTLS := tlsMgr.TLSConfig() != nil
 	hostname := extTLSConf.ServerName
-	if extTLSConf.PortHTTPS != 0 {
+	if extTLSConf.PortHTTPS != 0 && (hasTLS || allowUnencryptedDoH) {
 		addr := hostname
 		if p := extTLSConf.PortHTTPS; p != defaultPortHTTPS {
 			addr = netutil.JoinHostPort(addr, p)
@@ -424,7 +428,7 @@ func getDNSEncryption(tlsMgr *tlsManager) (de dnsEncryption) {
 		}).String()
 	}
 
-	if tlsMgr.TLSConfig() == nil {
+	if !hasTLS {
 		return de
 	}
 

--- a/internal/home/dns.go
+++ b/internal/home/dns.go
@@ -424,6 +424,10 @@ func getDNSEncryption(tlsMgr *tlsManager) (de dnsEncryption) {
 		}).String()
 	}
 
+	if tlsMgr.TLSConfig() == nil {
+		return de
+	}
+
 	if p := extTLSConf.PortDNSOverTLS; p != 0 {
 		de.tls = (&url.URL{
 			Scheme: "tls",

--- a/internal/home/dns_internal_test.go
+++ b/internal/home/dns_internal_test.go
@@ -89,3 +89,26 @@ func TestNewServerConfigCertlessEncryption(t *testing.T) {
 	require.NoError(t, dnsSrv.Prepare(ctx, serverConf))
 	dnsSrv.Close(ctx)
 }
+
+func TestGetDNSEncryptionCertless(t *testing.T) {
+	ctx := testutil.ContextWithTimeout(t, testTimeout)
+	tlsMgr, err := newTLSManager(ctx, &tlsManagerConfig{
+		logger:       testLogger,
+		confModifier: agh.EmptyConfigModifier{},
+		manager:      aghtls.EmptyManager{},
+		tlsSettings: tlsConfigSettings{
+			Enabled:         true,
+			ServerName:      "dns.example",
+			PortHTTPS:       defaultPortHTTPS,
+			PortDNSOverTLS:  853,
+			PortDNSOverQUIC: 853,
+		},
+	})
+	require.NoError(t, err)
+	require.Nil(t, tlsMgr.TLSConfig())
+
+	de := getDNSEncryption(tlsMgr)
+	assert.Equal(t, "https://dns.example/dns-query", de.https)
+	assert.Empty(t, de.tls)
+	assert.Empty(t, de.quic)
+}

--- a/internal/home/dns_internal_test.go
+++ b/internal/home/dns_internal_test.go
@@ -88,6 +88,27 @@ func TestNewServerConfigCertlessEncryption(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, dnsSrv.Prepare(ctx, serverConf))
 	dnsSrv.Close(ctx)
+
+	serverConf, err = newServerConfig(
+		&dnsConfig{
+			BindHosts: []netip.Addr{netutil.IPv4Localhost()},
+			Config: dnsforward.Config{
+				UpstreamMode:     dnsforward.UpstreamModeLoadBalance,
+				EDNSClientSubnet: &dnsforward.EDNSClientSubnet{},
+			},
+			ServePlainDNS:   true,
+			PendingRequests: &pendingRequests{},
+		},
+		&clientSourcesConfig{},
+		tlsMgr.extendedTLSConfig(),
+		&doHConfig{},
+		tlsMgr,
+		aghhttp.EmptyRegistrar{},
+		dnsforward.EmptyClientsContainer{},
+		agh.EmptyConfigModifier{},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, serverConf.TLSConf.HTTPSListenAddrs)
 }
 
 func TestGetDNSEncryptionCertless(t *testing.T) {
@@ -107,7 +128,12 @@ func TestGetDNSEncryptionCertless(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, tlsMgr.TLSConfig())
 
-	de := getDNSEncryption(tlsMgr)
+	de := getDNSEncryption(tlsMgr, false)
+	assert.Empty(t, de.https)
+	assert.Empty(t, de.tls)
+	assert.Empty(t, de.quic)
+
+	de = getDNSEncryption(tlsMgr, true)
 	assert.Equal(t, "https://dns.example/dns-query", de.https)
 	assert.Empty(t, de.tls)
 	assert.Empty(t, de.quic)

--- a/internal/home/dns_internal_test.go
+++ b/internal/home/dns_internal_test.go
@@ -1,0 +1,91 @@
+package home
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/AdguardTeam/AdGuardHome/internal/agh"
+	"github.com/AdguardTeam/AdGuardHome/internal/aghhttp"
+	"github.com/AdguardTeam/AdGuardHome/internal/aghtls"
+	"github.com/AdguardTeam/AdGuardHome/internal/dnsforward"
+	"github.com/AdguardTeam/dnscrypt"
+	"github.com/AdguardTeam/golibs/netutil"
+	"github.com/AdguardTeam/golibs/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yaml "go.yaml.in/yaml/v4"
+)
+
+func TestNewServerConfigCertlessEncryption(t *testing.T) {
+	privateKey := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{1}, ed25519.SeedSize))
+	dnsCryptConf := &dnscrypt.ResolverConfig{
+		ProviderName: dnscrypt.DNSCryptV2Prefix + "example.org",
+		PublicKey:    dnscrypt.HexEncodeKey(privateKey.Public().(ed25519.PublicKey)),
+		PrivateKey:   dnscrypt.HexEncodeKey(privateKey),
+		ResolverSk:   dnscrypt.HexEncodeKey(bytes.Repeat([]byte{2}, dnscrypt.KeySize)),
+		ResolverPk:   dnscrypt.HexEncodeKey(bytes.Repeat([]byte{3}, dnscrypt.KeySize)),
+		ESVersion:    dnscrypt.XSalsa20Poly1305,
+	}
+
+	dnsCryptData, err := yaml.Marshal(dnsCryptConf)
+	require.NoError(t, err)
+
+	dnsCryptPath := filepath.Join(t.TempDir(), "dnscrypt.yaml")
+	require.NoError(t, os.WriteFile(dnsCryptPath, dnsCryptData, 0o600))
+
+	ctx := testutil.ContextWithTimeout(t, testTimeout)
+	tlsMgr, err := newTLSManager(ctx, &tlsManagerConfig{
+		logger:       testLogger,
+		confModifier: agh.EmptyConfigModifier{},
+		manager:      aghtls.EmptyManager{},
+		tlsSettings: tlsConfigSettings{
+			Enabled:            true,
+			PortHTTPS:          5443,
+			PortDNSCrypt:       5444,
+			PortDNSOverTLS:     5445,
+			PortDNSOverQUIC:    5446,
+			DNSCryptConfigFile: dnsCryptPath,
+		},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, tlsMgr.TLSConfig())
+
+	serverConf, err := newServerConfig(
+		&dnsConfig{
+			BindHosts: []netip.Addr{netutil.IPv4Localhost()},
+			Config: dnsforward.Config{
+				UpstreamMode:     dnsforward.UpstreamModeLoadBalance,
+				EDNSClientSubnet: &dnsforward.EDNSClientSubnet{},
+			},
+			ServePlainDNS:   true,
+			PendingRequests: &pendingRequests{},
+		},
+		&clientSourcesConfig{},
+		tlsMgr.extendedTLSConfig(),
+		&doHConfig{InsecureEnabled: true},
+		tlsMgr,
+		aghhttp.EmptyRegistrar{},
+		dnsforward.EmptyClientsContainer{},
+		agh.EmptyConfigModifier{},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, serverConf.TLSConf.DNSCryptConf)
+	assert.NotEmpty(t, serverConf.TLSConf.HTTPSListenAddrs)
+	assert.NotEmpty(t, serverConf.TLSConf.TLSListenAddrs)
+	assert.NotEmpty(t, serverConf.TLSConf.QUICListenAddrs)
+	assert.True(t, serverConf.TLSAllowUnencryptedDoH)
+	assert.Nil(t, tlsMgr.TLSConfig())
+
+	serverConf.AddrProcConf = nil
+	dnsSrv, err := dnsforward.NewServer(dnsforward.DNSCreateParams{
+		Logger:            testLogger,
+		TLSConfigProvider: tlsMgr,
+	})
+	require.NoError(t, err)
+	require.NoError(t, dnsSrv.Prepare(ctx, serverConf))
+	dnsSrv.Close(ctx)
+}

--- a/internal/home/tls.go
+++ b/internal/home/tls.go
@@ -911,6 +911,9 @@ func (m *tlsManager) updateTLSCert(extTLSConf *tlsConfigSettings) (err error) {
 		len(extTLSConf.PrivateKeyData) == 0 &&
 		extTLSConf.CertificatePath == "" &&
 		extTLSConf.PrivateKeyPath == "" {
+		m.tlsConf = nil
+		m.tlsCert = nil
+
 		return nil
 	}
 

--- a/internal/home/tls.go
+++ b/internal/home/tls.go
@@ -156,24 +156,14 @@ func newTLSManager(ctx context.Context, conf *tlsManagerConfig) (m *tlsManager, 
 		// Don't wrap the error, because it's informative enough as is.
 		return m, err
 	}
-
-	cert, err := tls.X509KeyPair(m.extTLSConf.CertificateChainData, m.extTLSConf.PrivateKeyData)
+	err = m.updateTLSCert(m.extTLSConf)
 	if err != nil {
 		m.extTLSConf.Enabled = false
 
-		return m, fmt.Errorf("parsing tls certificate: %w", err)
+		// Don't wrap the error, because it's informative enough as is.
+		return m, err
 	}
 
-	slices.Sort(cert.Leaf.DNSNames)
-
-	m.tlsConf = &tls.Config{
-		RootCAs:        m.rootCerts,
-		CipherSuites:   m.customCipherIDs,
-		MinVersion:     tls.VersionTLS12,
-		GetCertificate: m.onGetCertificate,
-	}
-
-	m.tlsCert = &cert
 	m.setCertFileTime(ctx)
 
 	return m, nil
@@ -868,6 +858,10 @@ func (m *tlsManager) TLSConfig() (conf *tls.Config) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	if m.tlsConf == nil {
+		return nil
+	}
+
 	return m.tlsConf.Clone()
 }
 
@@ -913,7 +907,10 @@ func (m *tlsManager) onGetCertificate(chi *tls.ClientHelloInfo) (cert *tls.Certi
 // m.tlsConf is nil, it will be initialized.  extTLSConf must not be nil.  m.mu
 // must be locked.
 func (m *tlsManager) updateTLSCert(extTLSConf *tlsConfigSettings) (err error) {
-	if len(extTLSConf.CertificateChainData) == 0 || len(extTLSConf.PrivateKeyData) == 0 {
+	if len(extTLSConf.CertificateChainData) == 0 &&
+		len(extTLSConf.PrivateKeyData) == 0 &&
+		extTLSConf.CertificatePath == "" &&
+		extTLSConf.PrivateKeyPath == "" {
 		return nil
 	}
 

--- a/internal/home/tls_internal_test.go
+++ b/internal/home/tls_internal_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/AdguardTeam/AdGuardHome/internal/agh"
+	"github.com/AdguardTeam/AdGuardHome/internal/aghalg"
 	"github.com/AdguardTeam/AdGuardHome/internal/aghtls"
 	"github.com/AdguardTeam/AdGuardHome/internal/client"
 	"github.com/AdguardTeam/AdGuardHome/internal/dnsforward"
@@ -120,6 +121,29 @@ func TestNewTLSManagerCertificatePair(t *testing.T) {
 			assert.Equal(t, tc.wantTLS, m.TLSConfig() != nil)
 		})
 	}
+}
+
+func TestTLSManagerCertlessTransition(t *testing.T) {
+	ctx := testutil.ContextWithTimeout(t, testTimeout)
+	m, err := newTLSManager(ctx, &tlsManagerConfig{
+		logger:       testLogger,
+		confModifier: agh.EmptyConfigModifier{},
+		manager:      aghtls.EmptyManager{},
+		tlsSettings: tlsConfigSettings{
+			Enabled:         true,
+			CertificatePath: testCertificatePath,
+			PrivateKeyPath:  testPrivateKeyPath,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, m.TLSConfig())
+	require.NotNil(t, m.tlsCert)
+
+	_, err = m.setConfig(ctx, &tlsConfigSettings{Enabled: true}, aghalg.NBNull)
+	require.NoError(t, err)
+	assert.Nil(t, m.TLSConfig())
+	assert.Nil(t, m.tlsCert)
+	assert.False(t, m.HasIPAddrs())
 }
 
 func TestValidateCertificates(t *testing.T) {

--- a/internal/home/tls_internal_test.go
+++ b/internal/home/tls_internal_test.go
@@ -29,6 +29,99 @@ const (
 	testPrivateKeyPath  = "./testdata/key.pem"
 )
 
+func TestNewTLSManagerCertlessDNSCrypt(t *testing.T) {
+	ctx := testutil.ContextWithTimeout(t, testTimeout)
+
+	m, err := newTLSManager(ctx, &tlsManagerConfig{
+		logger:       testLogger,
+		confModifier: agh.EmptyConfigModifier{},
+		manager:      aghtls.EmptyManager{},
+		tlsSettings: tlsConfigSettings{
+			Enabled:            true,
+			PortDNSCrypt:       5443,
+			DNSCryptConfigFile: "testdata/dnscrypt.yaml",
+		},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, m.TLSConfig())
+	assert.True(t, m.extendedTLSConfig().Enabled)
+}
+
+func TestNewTLSManagerCertificatePair(t *testing.T) {
+	emptyDir := t.TempDir()
+	emptyCertPath := filepath.Join(emptyDir, "cert.pem")
+	emptyKeyPath := filepath.Join(emptyDir, "key.pem")
+	require.NoError(t, os.WriteFile(emptyCertPath, nil, 0o600))
+	require.NoError(t, os.WriteFile(emptyKeyPath, nil, 0o600))
+
+	testCases := []struct {
+		name     string
+		certPath string
+		keyPath  string
+		certData string
+		keyData  string
+
+		wantErr bool
+		wantTLS bool
+	}{
+		{
+			name:     "certificate_only",
+			certPath: testCertificatePath,
+			wantErr:  true,
+		},
+		{
+			name:    "private_key_only",
+			keyPath: testPrivateKeyPath,
+			wantErr: true,
+		},
+		{
+			name:     "malformed_pair",
+			certData: "bad certificate",
+			keyData:  "bad key",
+			wantErr:  true,
+		},
+		{
+			name:     "empty_files",
+			certPath: emptyCertPath,
+			keyPath:  emptyKeyPath,
+			wantErr:  true,
+		},
+		{
+			name:     "valid_pair",
+			certPath: testCertificatePath,
+			keyPath:  testPrivateKeyPath,
+			wantTLS:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testutil.ContextWithTimeout(t, testTimeout)
+			m, err := newTLSManager(ctx, &tlsManagerConfig{
+				logger:       testLogger,
+				confModifier: agh.EmptyConfigModifier{},
+				manager:      aghtls.EmptyManager{},
+				tlsSettings: tlsConfigSettings{
+					Enabled:          true,
+					CertificateChain: tc.certData,
+					PrivateKey:       tc.keyData,
+					CertificatePath:  tc.certPath,
+					PrivateKeyPath:   tc.keyPath,
+				},
+			})
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.False(t, m.extendedTLSConfig().Enabled)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantTLS, m.TLSConfig() != nil)
+		})
+	}
+}
+
 func TestValidateCertificates(t *testing.T) {
 	ctx := testutil.ContextWithTimeout(t, testTimeout)
 

--- a/internal/home/tls_internal_test.go
+++ b/internal/home/tls_internal_test.go
@@ -55,6 +55,12 @@ func TestNewTLSManagerCertificatePair(t *testing.T) {
 	require.NoError(t, os.WriteFile(emptyCertPath, nil, 0o600))
 	require.NoError(t, os.WriteFile(emptyKeyPath, nil, 0o600))
 
+	mismatchDir := t.TempDir()
+	mismatchCertPath := filepath.Join(mismatchDir, "cert.pem")
+	mismatchKeyPath := filepath.Join(mismatchDir, "key.pem")
+	mismatchCert, mismatchKey := newCertAndKey(t, 2)
+	writeCertAndKey(t, mismatchCert, mismatchCertPath, mismatchKey, mismatchKeyPath)
+
 	testCases := []struct {
 		name     string
 		certPath string
@@ -79,6 +85,12 @@ func TestNewTLSManagerCertificatePair(t *testing.T) {
 			name:     "malformed_pair",
 			certData: "bad certificate",
 			keyData:  "bad key",
+			wantErr:  true,
+		},
+		{
+			name:     "mismatched_pair",
+			certPath: testCertificatePath,
+			keyPath:  mismatchKeyPath,
 			wantErr:  true,
 		},
 		{
@@ -139,11 +151,25 @@ func TestTLSManagerCertlessTransition(t *testing.T) {
 	require.NotNil(t, m.TLSConfig())
 	require.NotNil(t, m.tlsCert)
 
-	_, err = m.setConfig(ctx, &tlsConfigSettings{Enabled: true}, aghalg.NBNull)
+	restartHTTPS, err := m.setConfig(ctx, &tlsConfigSettings{Enabled: true}, aghalg.NBNull)
 	require.NoError(t, err)
+	assert.True(t, restartHTTPS)
 	assert.Nil(t, m.TLSConfig())
 	assert.Nil(t, m.tlsCert)
 	assert.False(t, m.HasIPAddrs())
+	assert.True(t, m.extendedTLSConfig().Enabled)
+
+	restartHTTPS, err = m.setConfig(ctx, &tlsConfigSettings{
+		Enabled:              true,
+		CertificatePath:      testCertificatePath,
+		PrivateKeyPath:       testPrivateKeyPath,
+		CertificateChainData: requireReadFile(t, testCertificatePath),
+		PrivateKeyData:       requireReadFile(t, testPrivateKeyPath),
+	}, aghalg.NBNull)
+	require.NoError(t, err)
+	assert.True(t, restartHTTPS)
+	assert.NotNil(t, m.TLSConfig())
+	assert.NotNil(t, m.tlsCert)
 }
 
 func TestValidateCertificates(t *testing.T) {

--- a/internal/home/web.go
+++ b/internal/home/web.go
@@ -171,6 +171,14 @@ func (srv *httpsServer) inShutdown() (ok bool) {
 	return srv.shutdown
 }
 
+// isEnabled reports whether the HTTPS server is ready to use.
+func (srv *httpsServer) isEnabled() (ok bool) {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	return srv.enabled
+}
+
 // certificate returns a cert used by the server.  cert must not be modified.
 func (srv *httpsServer) certificate() (cert tls.Certificate) {
 	srv.mu.Lock()

--- a/internal/home/web_internal_test.go
+++ b/internal/home/web_internal_test.go
@@ -150,6 +150,44 @@ func TestWebAPI_HandleTLSConfigure(t *testing.T) {
 	}, testTimeout, testTimeout/10)
 }
 
+func TestWebAPI_HandleHTTPSRedirectTLSAvailability(t *testing.T) {
+	storeGlobals(t)
+
+	config = &configuration{
+		TLS: tlsConfigSettings{
+			Enabled:    true,
+			ForceHTTPS: true,
+			PortHTTPS:  defaultPortHTTPS,
+		},
+	}
+
+	web := newTestWeb(t, nil)
+	web.httpsServer.server = &http.Server{}
+
+	ctx := testutil.ContextWithTimeout(t, testTimeout)
+	certless := &tlsConfigSettings{
+		Enabled:    true,
+		ForceHTTPS: true,
+		PortHTTPS:  defaultPortHTTPS,
+	}
+	web.tlsConfigChanged(ctx, certless)
+
+	r := httptest.NewRequest(http.MethodGet, "http://dns.example/", nil)
+	w := httptest.NewRecorder()
+	assert.True(t, web.handleHTTPSRedirect(w, r))
+	assert.Empty(t, w.Header().Get("Location"))
+
+	certful := certless.clone()
+	certful.CertificateChainData = requireReadFile(t, testCertificatePath)
+	certful.PrivateKeyData = requireReadFile(t, testPrivateKeyPath)
+	web.tlsConfigChanged(ctx, certful)
+
+	w = httptest.NewRecorder()
+	assert.False(t, web.handleHTTPSRedirect(w, r))
+	assert.Equal(t, http.StatusTemporaryRedirect, w.Code)
+	assert.Equal(t, "https://dns.example/", w.Header().Get("Location"))
+}
+
 func TestWebAPI_HandleTLSStatus(t *testing.T) {
 	var (
 		ctx = testutil.ContextWithTimeout(t, testTimeout)


### PR DESCRIPTION
Closes #7773.

## Summary

- Allow TLS settings to remain enabled without a certificate for
  reverse-proxied unencrypted DNS-over-HTTPS and DNSCrypt-only configurations.
- Continue rejecting incomplete, empty, malformed, or mismatched certificate
  pairs.
- Clear the active TLS configuration and certificate when a live configuration
  change removes the certificate pair.
- Prepare DNSCrypt independently while leaving DNS-over-TLS and DNS-over-QUIC
  listeners disabled when no usable TLS configuration exists.
- Continue reporting reverse-proxied HTTPS while suppressing unavailable DoT
  and DoQ endpoints in status and DDR.
- Document the restored startup behavior in the changelog.

## Tests

Regression coverage includes certificate-less DNSCrypt manager startup, the
complete certificate-pair validation matrix, a live
valid-certificate-to-certificate-less transition, status reporting for
certificate-less HTTPS/DoT/DoQ settings, end-to-end server configuration with
unencrypted DoH plus DNSCrypt, and certless DNS proxy preparation without
DoT/DoQ listeners or DDR records.

Validation completed:

- `go test -race -count=20 -run '^(TestNewTLSManagerCertlessDNSCrypt|TestNewTLSManagerCertificatePair|TestTLSManagerCertlessTransition|TestNewServerConfigCertlessEncryption|TestGetDNSEncryptionCertless)$' ./internal/home`
- `go test -race -count=20 -run '^TestServerPrepareCertlessTLS$' ./internal/dnsforward`
- `go test -race -count=1 ./internal/home ./internal/dnsforward`
- `go vet ./internal/home ./internal/dnsforward`
- `make go-check`
- `make go-os-check`
- Cross-compilation of both affected packages for Linux amd64, Linux arm64,
  and Windows amd64
