### PR TITLE
filtering: fix refresh retry backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,12 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- Excessive filter update retry intervals after network errors ([#8506]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
+[#8506]: https://github.com/AdguardTeam/AdGuardHome/issues/8506
 
 <!--
 NOTE: Add new changes ABOVE THIS COMMENT.

--- a/internal/filtering/filtering.go
+++ b/internal/filtering/filtering.go
@@ -1126,7 +1126,7 @@ func (d *DNSFilter) periodicallyRefreshFilters(ivl time.Duration) (nextIvl time.
 		ivl = maxInterval
 	} else if isNetErr {
 		ivl *= 2
-		ivl = max(ivl, maxInterval)
+		ivl = min(ivl, maxInterval)
 	}
 
 	return ivl

--- a/internal/filtering/filtering_internal_test.go
+++ b/internal/filtering/filtering_internal_test.go
@@ -4,15 +4,18 @@ import (
 	"bytes"
 	"cmp"
 	"fmt"
+	"net/http"
 	"net/netip"
 	"testing"
 	"time"
 
 	"github.com/AdguardTeam/AdGuardHome/internal/aghtest"
 	"github.com/AdguardTeam/AdGuardHome/internal/filtering/hashprefix"
+	"github.com/AdguardTeam/golibs/errors"
 	"github.com/AdguardTeam/golibs/logutil/slogutil"
 	"github.com/AdguardTeam/golibs/netutil"
 	"github.com/AdguardTeam/golibs/testutil"
+	"github.com/AdguardTeam/golibs/testutil/fakenet/fakehttp"
 	"github.com/AdguardTeam/urlfilter/rules"
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
@@ -29,6 +32,51 @@ const (
 
 // testLogger is the common logger for tests.
 var testLogger = slogutil.NewDiscardLogger()
+
+func TestDNSFilter_PeriodicallyRefreshFilters(t *testing.T) {
+	const errNetwork errors.Error = "test network error"
+
+	d := newDNSFilter(t)
+	t.Cleanup(d.Close)
+
+	d.conf.FiltersUpdateIntervalHours = 1
+	d.conf.Filters = []FilterYAML{{
+		Enabled: true,
+		URL:     "https://example.org/filter.txt",
+		Filter: Filter{
+			ID: 1,
+		},
+	}}
+	d.conf.HTTPClient.Transport = &fakehttp.RoundTripper{
+		OnRoundTrip: func(_ *http.Request) (_ *http.Response, _ error) {
+			return nil, errNetwork
+		},
+	}
+
+	testCases := []struct {
+		name string
+		ivl  time.Duration
+		want time.Duration
+	}{{
+		name: "initial",
+		ivl:  5 * time.Second,
+		want: 10 * time.Second,
+	}, {
+		name: "below_maximum",
+		ivl:  45 * time.Minute,
+		want: time.Hour,
+	}, {
+		name: "at_maximum",
+		ivl:  time.Hour,
+		want: time.Hour,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, d.periodicallyRefreshFilters(tc.ivl))
+		})
+	}
+}
 
 // Helpers.
 


### PR DESCRIPTION
Closes #8506.

## Summary

- Keep filter-refresh retries on exponential backoff after network errors.
- Cap the retry interval at one hour instead of applying a one-hour lower
  bound.
- Add deterministic coverage for initial, below-cap, and at-cap intervals.

The production change is limited to replacing the incorrect lower-bound
operation with the intended upper bound.  There are no API, configuration, or
dependency changes.

## Tests

The regression test was first applied by itself to an isolated checkout of
current `master`.  It failed with these observed intervals:

- `5s`: expected `10s`, received `1h`.
- `45m`: expected `1h`, received `1h30m`.
- `1h`: expected `1h`, received `2h`.

The complete change then passed:

- `go test -race -count=20 -run '^TestDNSFilter_PeriodicallyRefreshFilters$' ./internal/filtering`
- `go test -race -count=1 ./internal/filtering`
- `go vet ./internal/filtering`
- `make go-check`
- `make go-os-check`
- `make md-lint txt-lint`
- `git diff --check`

`govulncheck` reported zero called vulnerabilities.
