### PR TITLE
client: allow removing the first client identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,12 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- Client identifiers can now be removed from any row when more than one is
+  configured ([#8082]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#8082]: https://github.com/AdguardTeam/AdGuardHome/issues/8082
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/client_v2/src/__tests__/clientForm/Identifiers.test.tsx
+++ b/client_v2/src/__tests__/clientForm/Identifiers.test.tsx
@@ -45,17 +45,26 @@ describe('Identifiers', () => {
         expect(clientFormState.ids).toEqual(['1.2.3.4', '']);
     });
 
-    it('removes an identifier row (except the first one which has no remove button)', () => {
+    it('removes the first identifier when multiple rows remain', () => {
+        initClientForm({ ids: ['first-client', 'second-client'] });
         render(() => <Identifiers />);
-        fireEvent.click(screen.getByTestId('client-form-add-identifier'));
-        expect(document.querySelectorAll('input[type="text"]')).toHaveLength(2);
 
-        // The remove button is the suffix of the second row.
-        const removeBtn = document.querySelector('[aria-label]') as HTMLElement;
-        fireEvent.click(removeBtn);
+        const removeButtons = document.querySelectorAll('button[aria-label]');
+        expect(removeButtons).toHaveLength(2);
 
-        expect(document.querySelectorAll('input[type="text"]')).toHaveLength(1);
-        expect(clientFormState.ids).toEqual(['']);
+        fireEvent.click(removeButtons[0]);
+
+        const inputs = document.querySelectorAll('input[type="text"]');
+        expect(inputs).toHaveLength(1);
+        expect((inputs[0] as HTMLInputElement).value).toBe('second-client');
+        expect(document.querySelectorAll('button[aria-label]')).toHaveLength(0);
+        expect(clientFormState.ids).toEqual(['second-client']);
+    });
+
+    it('does not remove the sole identifier row', () => {
+        render(() => <Identifiers />);
+
+        expect(document.querySelectorAll('button[aria-label]')).toHaveLength(0);
     });
 
     it('shows a validation error on blur for an invalid identifier', async () => {

--- a/client_v2/src/components/Clients/AddClient/blocks/Identifiers/Identifiers.tsx
+++ b/client_v2/src/components/Clients/AddClient/blocks/Identifiers/Identifiers.tsx
@@ -114,7 +114,7 @@ export const Identifiers = () => {
                                     errorMessage={activeError()}
                                     size="large"
                                     suffixIcon={
-                                        index > 0 ? (
+                                        clientFormState.ids.length > 1 ? (
                                             <button
                                                 type="button"
                                                 class={s.removeSuffixBtn}


### PR DESCRIPTION
## Summary

- Show a delete control for every client identifier while multiple rows remain.
- Keep the final required identifier row non-removable.
- Add regression coverage for removing the first row and preserving the sole row.

## Reproduction

On current `master`, configure a client with two identifiers and reopen its settings.  Only the second row has a delete control, so the first identifier cannot be removed directly.

The new regression test was applied without the production change in an isolated current-`master` checkout.  It failed at the expected assertion: two delete buttons were expected, but only one was rendered.

## Fix

Render the existing delete button based on the number of identifier rows instead of the row index.  This makes every row removable when another row remains while preserving the required final row.

## Validation

- `npm run test -- src/__tests__/clientForm/Identifiers.test.tsx --reporter=verbose --no-color` — 7 tests passed.
- `NODE_OPTIONS=--localstorage-file=<temporary-file> npm run check` — lint and type-check passed; 58 test files and 620 tests passed.
- `make js-lint` — passed.
- `make md-lint txt-lint` — passed.
- `git diff --check` — passed.
- Pre-commit documentation hooks — passed.

Closes #8082