### PR TITLE
schedule: use wall clock across dst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,12 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- Blocked-service schedule evaluation on daylight-saving transition days
+  ([#7404]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#7404]: https://github.com/AdguardTeam/AdGuardHome/issues/7404
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/internal/schedule/schedule.go
+++ b/internal/schedule/schedule.go
@@ -71,12 +71,14 @@ func (w *Weekly) Contains(t time.Time) (ok bool) {
 	wd := t.Weekday()
 	dr := w.days[wd]
 
-	// Calculate the offset of the day range.
-	//
-	// NOTE: Do not use [time.Truncate] since it requires UTC time zone.
-	y, m, d := t.Date()
-	day := time.Date(y, m, d, 0, 0, 0, 0, w.location)
-	offset := t.Sub(day)
+	// Calculate the wall-clock offset of the day range.  Using the elapsed time
+	// since midnight would shift the offset on daylight-saving time transition
+	// days.
+	h, m, s := t.Clock()
+	offset := time.Duration(h)*time.Hour +
+		time.Duration(m)*time.Minute +
+		time.Duration(s)*time.Second +
+		time.Duration(t.Nanosecond())
 
 	return dr.contains(offset)
 }

--- a/internal/schedule/schedule_internal_test.go
+++ b/internal/schedule/schedule_internal_test.go
@@ -123,6 +123,54 @@ func TestWeekly_Contains(t *testing.T) {
 	}
 }
 
+func TestWeekly_Contains_wallClock(t *testing.T) {
+	denver, err := time.LoadLocation("America/Denver")
+	require.NoError(t, err)
+
+	london, err := time.LoadLocation("Europe/London")
+	require.NoError(t, err)
+
+	testCases := []struct {
+		at   time.Time
+		name string
+		day  dayRange
+		want bool
+	}{
+		{
+			name: "fall_back",
+			at:   time.Date(2024, 11, 3, 21, 0, 0, 0, denver),
+			day: dayRange{
+				start: 18 * time.Hour,
+				end:   21*time.Hour + 30*time.Minute,
+			},
+			want: true,
+		},
+		{
+			name: "spring_forward",
+			at:   time.Date(2025, 3, 30, 8, 30, 0, 0, london),
+			day: dayRange{
+				start: 0,
+				end:   8 * time.Hour,
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			days := [7]dayRange{}
+			days[tc.at.Weekday()] = tc.day
+
+			weekly := &Weekly{
+				location: tc.at.Location(),
+				days:     days,
+			}
+
+			assert.Equal(t, tc.want, weekly.Contains(tc.at))
+		})
+	}
+}
+
 const brusselsSundayYAML = `
 sun:
     start: 12h


### PR DESCRIPTION
## Summary

Fix blocked-service schedule evaluation on daylight-saving transition days by
comparing configured ranges with the local wall-clock time instead of elapsed
time since local midnight.

The elapsed duration is one hour ahead after a fall-back transition and one
hour behind after a spring-forward transition, so valid ranges could start or
end at the wrong local time.

## Testing

The new deterministic test failed on unmodified current `master` for both
transition directions:

- Denver fall-back: `21:00` was incorrectly outside `18:00-21:30`.
- London spring-forward: `08:30` was incorrectly inside `00:00-08:00`.

After the fix, the following passed:

- focused schedule test under `-race`, repeated 20 times;
- the complete `internal/schedule` package under `-race`;
- `go vet ./internal/schedule`;
- `make go-check`;
- `make go-os-check`;
- `make md-lint txt-lint`;
- `git diff --check` and formatting inspection.

Closes #7404.
