### PR TITLE
client: sort rewrite IP results numerically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,12 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- DNS rewrite results in the web UI are now sorted numerically when they are IP
+  addresses ([#8062]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#8062]: https://github.com/AdguardTeam/AdGuardHome/issues/8062
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/client_v2/src/__tests__/rewrites-table.test.tsx
+++ b/client_v2/src/__tests__/rewrites-table.test.tsx
@@ -1,0 +1,127 @@
+import { fireEvent, render } from '@solidjs/testing-library';
+import { describe, expect, it, vi } from 'vitest';
+
+import { RewritesTable } from 'panel/components/FilterLists/blocks/RewritesTable';
+import type { Rewrite } from 'panel/components/FilterLists/DNSRewrites';
+
+vi.mock('panel/common/intl', () => ({
+    default: {
+        getMessage: (key: string) => key,
+    },
+}));
+
+const renderTable = (answers: string[]) => {
+    const answerSet = new Set(answers);
+    const list: Rewrite[] = answers.map((answer, index) => ({
+        answer,
+        domain: `${index}.example`,
+        enabled: true,
+    }));
+    const view = render(() => (
+        <RewritesTable
+            list={list}
+            processing={false}
+            processingAdd={false}
+            processingDelete={false}
+            processingUpdate={false}
+            addRewritesList={vi.fn()}
+            deleteRewrite={vi.fn()}
+            editRewrite={vi.fn()}
+            toggleRewrite={vi.fn()}
+        />
+    ));
+
+    const answersInDocumentOrder = () =>
+        Array.from(view.container.querySelectorAll('span'))
+            .map((element) => element.textContent || '')
+            .filter((text) => answerSet.has(text));
+
+    return {
+        ...view,
+        answersInDocumentOrder,
+    };
+};
+
+describe('RewritesTable', () => {
+    it('sorts IPv4 rewrite results numerically in both directions', () => {
+        const view = renderTable(['172.18.0.10', '172.18.0.2', '172.18.0.5']);
+
+        fireEvent.click(view.getByText('result'));
+
+        expect(view.answersInDocumentOrder()).toEqual(['172.18.0.2', '172.18.0.5', '172.18.0.10']);
+
+        fireEvent.click(view.getByText('result'));
+
+        expect(view.answersInDocumentOrder()).toEqual(['172.18.0.10', '172.18.0.5', '172.18.0.2']);
+    });
+
+    it('sorts IPv4 before IPv6 and orders both families numerically', () => {
+        const view = renderTable(['2001:db8::10', '172.18.0.10', '2001:db8::2', '172.18.0.2']);
+
+        fireEvent.click(view.getByText('result'));
+
+        expect(view.answersInDocumentOrder()).toEqual([
+            '172.18.0.2',
+            '172.18.0.10',
+            '2001:db8::2',
+            '2001:db8::10',
+        ]);
+
+        fireEvent.click(view.getByText('result'));
+
+        expect(view.answersInDocumentOrder()).toEqual([
+            '2001:db8::10',
+            '2001:db8::2',
+            '172.18.0.10',
+            '172.18.0.2',
+        ]);
+    });
+
+    it('sorts IP addresses before text in ascending order', () => {
+        const view = renderTable(['beta.example', '172.18.0.10', 'alpha.example', '172.18.0.2']);
+
+        fireEvent.click(view.getByText('result'));
+
+        expect(view.answersInDocumentOrder()).toEqual([
+            '172.18.0.2',
+            '172.18.0.10',
+            'alpha.example',
+            'beta.example',
+        ]);
+
+        fireEvent.click(view.getByText('result'));
+
+        expect(view.answersInDocumentOrder()).toEqual([
+            'beta.example',
+            'alpha.example',
+            '172.18.0.10',
+            '172.18.0.2',
+        ]);
+    });
+
+    it('sorts text case-insensitively and preserves equal values order', () => {
+        const view = renderTable([
+            'Zeta.Example',
+            'Beta.example',
+            'alpha.example',
+            'beta.EXAMPLE',
+        ]);
+
+        fireEvent.click(view.getByText('result'));
+
+        expect(view.answersInDocumentOrder()).toEqual([
+            'alpha.example',
+            'Beta.example',
+            'beta.EXAMPLE',
+            'Zeta.Example',
+        ]);
+    });
+
+    it('treats noncanonical IPv4-like hostnames as text', () => {
+        const view = renderTable(['250.0.0.1', '0x7f000001', 'alpha.example']);
+
+        fireEvent.click(view.getByText('result'));
+
+        expect(view.answersInDocumentOrder()).toEqual(['250.0.0.1', '0x7f000001', 'alpha.example']);
+    });
+});

--- a/client_v2/src/components/FilterLists/blocks/RewritesTable/RewritesTable.tsx
+++ b/client_v2/src/components/FilterLists/blocks/RewritesTable/RewritesTable.tsx
@@ -1,7 +1,9 @@
 import { createSignal, createMemo } from 'solid-js';
 import cn from 'clsx';
+import ipaddr from 'ipaddr.js';
 
 import intl from 'panel/common/intl';
+import { sortIp } from 'panel/helpers/helpers';
 import { LOCAL_STORAGE_KEYS, LocalStorageHelper } from 'panel/helpers/localStorageHelper';
 import { Table, type TableColumn } from 'panel/common/ui/Table';
 import { Icon } from 'panel/common/ui/Icon';
@@ -22,6 +24,35 @@ type Props = {
     deleteRewrite: (rewrite: Rewrite) => void;
     editRewrite: (rewrite: Rewrite) => void;
     toggleRewrite: (rewrite: Rewrite) => void;
+};
+
+const isIpAddress = (value: string): boolean =>
+    ipaddr.IPv4.isValidFourPartDecimal(value) || ipaddr.IPv6.isValid(value);
+
+const sortAnswer = (a: string, b: string): number => {
+    const aIsIp = isIpAddress(a);
+    const bIsIp = isIpAddress(b);
+
+    if (aIsIp && bIsIp) {
+        return sortIp(a, b);
+    }
+
+    if (aIsIp !== bIsIp) {
+        return aIsIp ? -1 : 1;
+    }
+
+    const normalizedA = a.toLowerCase();
+    const normalizedB = b.toLowerCase();
+
+    if (normalizedA < normalizedB) {
+        return -1;
+    }
+
+    if (normalizedA > normalizedB) {
+        return 1;
+    }
+
+    return 0;
 };
 
 export const RewritesTable = (props: Props) => {
@@ -99,6 +130,7 @@ export const RewritesTable = (props: Props) => {
             },
             accessor: 'answer',
             sortable: true,
+            sortFn: sortAnswer,
             render: (value: string) => (
                 <div class={theme.table.cell}>
                     <div class={theme.table.cellValueText}>


### PR DESCRIPTION
## Summary

- Sort valid DNS rewrite IP answers numerically instead of lexicographically.
- Keep a consistent total order for mixed answers: IPv4, IPv6, then text;
  text remains case-insensitive and stable for equal values.
- Add focused table tests for ascending and descending IPv4/IPv6, mixed
  IP/text answers, stable text ties, and noncanonical IPv4-like hostnames.

## Reproduction

On untouched `5f6cb57df9d54d8a89afc9200d813411f9ce4f7a`, with only the
new test file copied into an isolated checkout:

```sh
NODE_OPTIONS="--localstorage-file=$red_root/localstorage" npm run test -- \
  src/__tests__/rewrites-table.test.tsx --reporter=verbose --no-color
```

Result: **4 failed, 1 passed**.  The issue example sorted as
`172.18.0.10`, `172.18.0.2`, `172.18.0.5`.

## Validation

```sh
NODE_OPTIONS="--localstorage-file=$runtime_root/localstorage" npm run test -- \
  src/__tests__/rewrites-table.test.tsx --reporter=verbose --no-color
```

Result: **5 passed**.

```sh
NODE_OPTIONS="--localstorage-file=$runtime_root/localstorage" npm run check
```

Result: ESLint and type-check passed; **59 test files and 624 tests passed**.

```sh
make js-lint
make md-lint txt-lint
git diff --check
```

All passed.  The commit hooks also reran the Markdown and text lint checks
successfully.

Closes #8062.
