### PR TITLE
filtering: apply blocked-service dns rewrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,11 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- DNS rewrite responses from blocked-service rules ([#5286]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#5286]: https://github.com/AdguardTeam/AdGuardHome/issues/5286
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/internal/dnsforward/filter.go
+++ b/internal/dnsforward/filter.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/AdguardTeam/AdGuardHome/internal/filtering"
+	"github.com/AdguardTeam/dnsproxy/proxy"
 	"github.com/AdguardTeam/urlfilter/rules"
 	"github.com/miekg/dns"
 )
@@ -51,8 +52,9 @@ func (s *Server) filterDNSRequest(
 		req.Question[0].Name = dns.Fqdn(res.CanonName)
 		checkReason = false
 	} else if res.IsFiltered {
-		l.DebugContext(ctx, "host is filtered", "reason", res.Reason)
-		pctx.Res = s.genDNSFilterMessage(ctx, l, pctx, res)
+		if err = s.setFilteredResponse(ctx, l, pctx, res); err != nil {
+			return nil, err
+		}
 		checkReason = false
 	}
 
@@ -74,6 +76,25 @@ func (s *Server) filterDNSRequest(
 	}
 
 	return res, err
+}
+
+// setFilteredResponse sets the response in pctx for the filtering result res.
+// l, pctx, and res must not be nil.
+func (s *Server) setFilteredResponse(
+	ctx context.Context,
+	l *slog.Logger,
+	pctx *proxy.DNSContext,
+	res *filtering.Result,
+) (err error) {
+	l.DebugContext(ctx, "host is filtered", "reason", res.Reason)
+
+	if res.Reason == filtering.FilteredBlockedService && res.DNSRewriteResult != nil {
+		return s.filterDNSRewrite(ctx, pctx.Req, res, pctx)
+	}
+
+	pctx.Res = s.genDNSFilterMessage(ctx, l, pctx, res)
+
+	return nil
 }
 
 // isRewrittenCNAME returns true if the request considered to be rewritten with

--- a/internal/dnsforward/filter_internal_test.go
+++ b/internal/dnsforward/filter_internal_test.go
@@ -15,6 +15,53 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestServer_filterDNSRequest_blockedServiceDNSRewrite(t *testing.T) {
+	const serviceID = "icloud_private_relay"
+
+	ctx := testutil.ContextWithTimeout(t, testTimeout)
+	filtering.InitModule(ctx, testLogger)
+
+	blockedServices := emptyFilteringBlockedServices()
+	blockedServices.IDs = []string{serviceID}
+	s := createTestServer(
+		t,
+		&filtering.Config{
+			BlockedServices: blockedServices,
+			BlockingMode:    filtering.BlockingModeDefault,
+		},
+		ServerConfig{
+			TLSConf: &TLSConfig{},
+			Config: Config{
+				UpstreamMode:     UpstreamModeLoadBalance,
+				EDNSClientSubnet: &EDNSClientSubnet{Enabled: false},
+				ClientsContainer: EmptyClientsContainer{},
+			},
+			ServePlainDNS: true,
+		},
+		testTLSConfigProvider,
+	)
+
+	dctx := &dnsContext{
+		proxyCtx: &proxy.DNSContext{
+			Req:  createTestMessageWithType("mask.icloud.com.", dns.TypeA),
+			Addr: testClientAddrPort,
+		},
+		protectionEnabled: true,
+	}
+	dctx.setts = s.clientRequestFilteringSettings(dctx)
+
+	res, err := s.filterDNSRequest(ctx, testLogger, dctx)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	assert.Equal(t, filtering.FilteredBlockedService, res.Reason)
+	assert.Equal(t, serviceID, res.ServiceName)
+
+	resp := dctx.proxyCtx.Res
+	require.NotNil(t, resp)
+	assert.Equal(t, dns.RcodeNameError, resp.Rcode)
+}
+
 func TestServer_filterDNSResponse(t *testing.T) {
 	const (
 		passedIPv4Str  = "1.1.1.1"

--- a/internal/filtering/blocked_internal_test.go
+++ b/internal/filtering/blocked_internal_test.go
@@ -1,0 +1,61 @@
+package filtering
+
+import (
+	"testing"
+
+	"github.com/AdguardTeam/golibs/testutil"
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDNSFilter_CheckHost_blockedServiceDNSRewrite(t *testing.T) {
+	const (
+		serviceID = "icloud_private_relay"
+		host      = "mask.icloud.com"
+	)
+
+	ctx := testutil.ContextWithTimeout(t, testTimeout)
+	initBlockedServices(ctx, testLogger)
+
+	d, setts := newForTest(t, nil, nil)
+	t.Cleanup(d.Close)
+	d.ApplyBlockedServicesList(setts, []string{serviceID})
+
+	res, err := d.CheckHost(host, dns.TypeA, setts)
+	require.NoError(t, err)
+
+	assert.Equal(t, FilteredBlockedService, res.Reason)
+	assert.Equal(t, serviceID, res.ServiceName)
+
+	require.NotNil(t, res.DNSRewriteResult)
+	assert.Equal(t, dns.RcodeNameError, res.DNSRewriteResult.RCode)
+}
+
+func TestDNSFilter_CheckHost_blockedServicePrecedence(t *testing.T) {
+	const (
+		serviceID = "facebook"
+		host      = "facebook.com"
+		rule      = "||facebook.com^"
+	)
+
+	ctx := testutil.ContextWithTimeout(t, testTimeout)
+	initBlockedServices(ctx, testLogger)
+
+	d, setts := newForTest(t, nil, []Filter{{
+		ID:   1,
+		Data: []byte(rule),
+	}})
+	t.Cleanup(d.Close)
+	d.ApplyBlockedServicesList(setts, []string{serviceID})
+
+	res, err := d.CheckHost(host, dns.TypeA, setts)
+	require.NoError(t, err)
+
+	assert.Equal(t, FilteredBlockList, res.Reason)
+	assert.Empty(t, res.ServiceName)
+	assert.Nil(t, res.DNSRewriteResult)
+
+	require.Len(t, res.Rules, 1)
+	assert.Equal(t, rule, res.Rules[0].Text)
+}

--- a/internal/filtering/filtering.go
+++ b/internal/filtering/filtering.go
@@ -617,6 +617,18 @@ func (d *DNSFilter) handleRewriteLoop(
 	return *res
 }
 
+// blockedServiceDNSRewriteResult returns the processed DNS rewrite for rule, if
+// any.  rule must not be nil.
+func (d *DNSFilter) blockedServiceDNSRewriteResult(
+	rule *rules.NetworkRule,
+) (res *DNSRewriteResult) {
+	if rule.DNSRewrite == nil {
+		return nil
+	}
+
+	return d.processDNSRewrites([]*rules.NetworkRule{rule}).DNSRewriteResult
+}
+
 // matchBlockedServicesRules checks the host against the blocked services rules
 // in settings, if any.  err is always nil, it is only there to make this a
 // valid hostChecker function.
@@ -641,6 +653,7 @@ func (d *DNSFilter) matchBlockedServicesRules(
 				res.Reason = FilteredBlockedService
 				res.IsFiltered = true
 				res.ServiceName = s.Name
+				res.DNSRewriteResult = d.blockedServiceDNSRewriteResult(rule)
 
 				ruleText := rule.Text()
 				res.Rules = []*ResultRule{{


### PR DESCRIPTION
## Summary

Apply `$dnsrewrite` responses embedded in blocked-service rules instead of
discarding them and generating the configured generic blocking response.

This makes the built-in iCloud Private Relay service return its declared
`NXDOMAIN` response, matching the same rules when entered manually and letting
Apple clients promptly recognize that Private Relay is unavailable.

Non-rewrite blocked-service rules keep the existing blocking-mode behavior,
and ordinary filter rules keep their established precedence.

## Reproduction

On unmodified current `master`, the new end-to-end test returned DNS rcode `0`
(`NOERROR`) for `mask.icloud.com`; it expected rcode `3` (`NXDOMAIN`).

## Testing

- focused filtering and DNS-forwarding regressions under `-race`, repeated 20
  times;
- complete `internal/filtering` and `internal/dnsforward` packages under
  `-race`;
- `go vet ./internal/filtering ./internal/dnsforward`;
- `make go-check`;
- `make go-os-check`;
- `make md-lint txt-lint`;
- formatting and `git diff --check`;
- repository commit hooks.

Closes #5286.
