### PR TITLE
filtering: lock custom rule updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,12 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- A data race when updating custom filtering rules ([#8507]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
+[#8507]: https://github.com/AdguardTeam/AdGuardHome/issues/8507
 
 <!--
 NOTE: Add new changes ABOVE THIS COMMENT.

--- a/internal/filtering/http.go
+++ b/internal/filtering/http.go
@@ -358,7 +358,10 @@ func (d *DNSFilter) handleFilteringSetRules(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	d.conf.filtersMu.Lock()
 	d.conf.UserRules = req.Rules
+	d.conf.filtersMu.Unlock()
+
 	d.conf.ConfModifier.Apply(ctx)
 	d.EnableFilters(true)
 }

--- a/internal/filtering/http_internal_test.go
+++ b/internal/filtering/http_internal_test.go
@@ -8,7 +8,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
+	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,6 +21,58 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDNSFilter_handleFilteringSetRulesConcurrent(t *testing.T) {
+	confModifier := &aghtest.ConfigModifier{
+		OnApply: func(_ context.Context) {},
+	}
+	d, err := New(&Config{
+		Logger:       testLogger,
+		ConfModifier: confModifier,
+		DataDir:      t.TempDir(),
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(d.Close)
+
+	// Avoid starting background work while allowing EnableFilters to enqueue
+	// its asynchronous update.
+	d.filtersInitializerChan = make(chan filtersInitializerParams, 1)
+
+	const iterations = 1_000
+
+	start := make(chan struct{})
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		<-start
+
+		for range iterations {
+			r := httptest.NewRequest(
+				http.MethodPost,
+				"http://example.org/control/filtering/set_rules",
+				strings.NewReader(`{"rules":["||example.org^"]}`),
+			)
+
+			d.handleFilteringSetRules(httptest.NewRecorder(), r)
+			runtime.Gosched()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		<-start
+
+		for range iterations {
+			d.EnableFilters(true)
+			runtime.Gosched()
+		}
+	}()
+
+	close(start)
+	wg.Wait()
+}
 
 func TestDNSFilter_handleFilteringSetURL(t *testing.T) {
 	filtersDir := t.TempDir()


### PR DESCRIPTION
## Summary

Serialize updates to custom filtering rules with the same `filtersMu` lock
used by filter-engine rebuilds.

Without the lock, `/control/filtering/set_rules` can replace `UserRules` while
an overlapping rebuild reads the slice through `strings.Join`, producing a
confirmed data race.

## Reproduction

The new handler-level test failed under the race detector on unmodified current
`master`, with the write in `handleFilteringSetRules` racing the read in
`enableFiltersLocked`.

## Testing

- focused race regression, repeated 20 times;
- complete `internal/filtering` package under `-race`;
- `go vet ./internal/filtering`;
- `make go-check`;
- `make go-os-check`;
- `make md-lint txt-lint`;
- formatting, diff checks, and repository commit hooks.

Closes #8507.
