### PR TITLE
client: match scoped ipv6 identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,11 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- Client-specific settings and upstreams for scoped IPv6 requests ([#6872]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#6872]: https://github.com/AdguardTeam/AdGuardHome/issues/6872
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/internal/client/index.go
+++ b/internal/client/index.go
@@ -257,6 +257,13 @@ func (ci *index) findByIP(ip netip.Addr) (c *Persistent, found bool) {
 	}
 
 	ipWithoutZone := ip.WithZone("")
+	if ipWithoutZone != ip {
+		uid, found = ci.ipToUID[ipWithoutZone]
+		if found {
+			return ci.uidToClient[uid], true
+		}
+	}
+
 	ci.subnetToUID.Range(func(pref netip.Prefix, id UID) (cont bool) {
 		// Remove zone before checking because prefixes strip zones.
 		if pref.Contains(ipWithoutZone) {

--- a/internal/client/index_internal_test.go
+++ b/internal/client/index_internal_test.go
@@ -289,6 +289,56 @@ func TestIndex_FindByIPWithoutZone(t *testing.T) {
 	}
 }
 
+func TestIndex_FindByIPScopedFallback(t *testing.T) {
+	ip := netip.MustParseAddr("fe80::1")
+	scopedIP := ip.WithZone("eth0")
+	clientNoZone := &Persistent{
+		Name: "client_no_zone",
+		IPs:  []netip.Addr{ip},
+	}
+	clientScoped := &Persistent{
+		Name: "client_scoped",
+		IPs:  []netip.Addr{scopedIP},
+	}
+	clientSubnet := &Persistent{
+		Name:    "client_subnet",
+		Subnets: []netip.Prefix{netip.MustParsePrefix("fe80::/64")},
+	}
+	ci := newIDIndex([]*Persistent{clientNoZone, clientScoped, clientSubnet})
+
+	testCases := []struct {
+		ip   netip.Addr
+		want *Persistent
+		name string
+	}{
+		{
+			name: "without_zone",
+			ip:   ip,
+			want: clientNoZone,
+		}, {
+			name: "exact_scoped",
+			ip:   scopedIP,
+			want: clientScoped,
+		}, {
+			name: "scoped_fallback",
+			ip:   ip.WithZone("eth1"),
+			want: clientNoZone,
+		}, {
+			name: "subnet",
+			ip:   netip.MustParseAddr("fe80::2%eth1"),
+			want: clientSubnet,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ci.findByIP(tc.ip)
+			require.True(t, ok)
+			assert.Same(t, tc.want, got)
+		})
+	}
+}
+
 func TestClientIndex_RangeByName(t *testing.T) {
 	sortedClients := []*Persistent{{
 		Name:      "clientA",

--- a/internal/client/storage.go
+++ b/internal/client/storage.go
@@ -768,6 +768,10 @@ func (s *Storage) ClearUpstreamCache() {
 // ClientID or client IP address, and applies it to the filtering settings.
 // setts must not be nil.
 func (s *Storage) ApplyClientFiltering(id string, addr netip.Addr, setts *filtering.Settings) {
+	// Filtering rules match addresses without IPv6 zones, while client lookup
+	// below still needs the original address to prefer exact scoped identifiers.
+	setts.ClientIP = addr.WithZone("")
+
 	c, ok := s.index.findByClientID(ClientID(id))
 	if !ok {
 		c, ok = s.index.findByIP(addr)

--- a/internal/client/storage_test.go
+++ b/internal/client/storage_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/AdguardTeam/AdGuardHome/internal/dhcpd"
 	"github.com/AdguardTeam/AdGuardHome/internal/dhcpsvc"
 	"github.com/AdguardTeam/AdGuardHome/internal/dnsforward"
+	"github.com/AdguardTeam/AdGuardHome/internal/filtering"
 	"github.com/AdguardTeam/AdGuardHome/internal/whois"
 	"github.com/AdguardTeam/golibs/errors"
 	"github.com/AdguardTeam/golibs/hostsfile"
@@ -24,6 +25,7 @@ import (
 	"github.com/AdguardTeam/golibs/testutil/faketime"
 	"github.com/AdguardTeam/golibs/testutil/servicetest"
 	"github.com/AdguardTeam/golibs/timeutil"
+	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -658,6 +660,62 @@ func newStorage(tb testing.TB, m []*client.Persistent) (s *client.Storage) {
 	return s
 }
 
+func TestStorage_ApplyClientFilteringScopedIP(t *testing.T) {
+	const (
+		clientName   = "client"
+		filteredHost = "filtered.example"
+	)
+
+	clientIP := netip.MustParseAddr("fe80::1")
+	s := newStorage(t, []*client.Persistent{{
+		Name: clientName,
+		IPs:  []netip.Addr{clientIP},
+	}})
+
+	dnsFilter, err := filtering.New(&filtering.Config{
+		Logger:                testLogger,
+		DataDir:               t.TempDir(),
+		SafeBrowsingCacheSize: 10000,
+		ParentalCacheSize:     10000,
+		SafeSearchCacheSize:   1000,
+		CacheTime:             30,
+	}, []filtering.Filter{{
+		ID:   0,
+		Data: []byte("||" + filteredHost + "^$client=" + clientIP.String()),
+	}})
+	require.NoError(t, err)
+	t.Cleanup(dnsFilter.Close)
+
+	testCases := []struct {
+		addr netip.Addr
+		name string
+	}{
+		{
+			name: "without_zone",
+			addr: clientIP,
+		}, {
+			name: "with_zone",
+			addr: clientIP.WithZone("eth0"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			setts := &filtering.Settings{
+				ClientIP:          tc.addr,
+				ProtectionEnabled: true,
+				FilteringEnabled:  true,
+			}
+			s.ApplyClientFiltering("", tc.addr, setts)
+			assert.Equal(t, clientName, setts.ClientName)
+
+			res, checkErr := dnsFilter.CheckHostRules(filteredHost, dns.TypeA, setts)
+			require.NoError(t, checkErr)
+			assert.True(t, res.Reason.Matched(), "result: %#v", res)
+		})
+	}
+}
+
 func TestStorage_Add(t *testing.T) {
 	const (
 		existingName     = "existing_name"
@@ -1166,6 +1224,7 @@ func TestStorage_CustomUpstreamConfig(t *testing.T) {
 	var (
 		existingIP    = netip.MustParseAddr("192.0.2.1")
 		nonExistingIP = netip.MustParseAddr("192.0.2.255")
+		scopedIP      = netip.MustParseAddr("fe80::1")
 
 		dhcpCliIP  = netip.MustParseAddr("192.0.2.2")
 		dhcpCliMAC = errors.Must(net.ParseMAC("02:00:00:00:00:00"))
@@ -1213,7 +1272,7 @@ func TestStorage_CustomUpstreamConfig(t *testing.T) {
 
 	err = s.Add(ctx, &client.Persistent{
 		Name:      "client_first",
-		IPs:       []netip.Addr{existingIP},
+		IPs:       []netip.Addr{existingIP, scopedIP},
 		ClientIDs: []client.ClientID{existingClientID},
 		UID:       client.MustNewUID(),
 		Upstreams: []string{"192.0.2.0"},
@@ -1242,6 +1301,11 @@ func TestStorage_CustomUpstreamConfig(t *testing.T) {
 		name:        "client_addr",
 		cliID:       "",
 		cliAddr:     existingIP,
+		wantNilConf: assert.NotNil,
+	}, {
+		name:        "client_addr_scoped",
+		cliID:       "",
+		cliAddr:     scopedIP.WithZone("eth0"),
 		wantNilConf: assert.NotNil,
 	}, {
 		name:        "client_dhcp",


### PR DESCRIPTION
## Summary

Match scoped IPv6 request addresses to persistent client identifiers stored
without an interface zone, while still preferring an exact scoped identifier
when one exists.

This restores client-specific upstreams and filtering settings for link-local
IPv6 requests such as `fe80::1%eth0`.  Filtering receives the zone-free address
form expected by `$client` rules; exact scoped clients retain precedence over
the fallback and subnet matches.

## Reproduction

Two deterministic tests failed on unmodified current `master`:

- a scoped address resolved to a broader subnet client instead of the exact
  zone-free IP client;
- `CustomUpstreamConfig` returned `nil` for a scoped request whose configured
  client identifier was the same IPv6 address without a zone.

## Testing

- focused lookup, custom-upstream, and filtering regressions under `-race`,
  repeated 20 times;
- complete `internal/client` package under `-race`;
- `go vet ./internal/client`;
- `make go-check`;
- `make go-os-check`;
- `make md-lint txt-lint`;
- formatting, diff checks, and repository commit hooks.

Closes #6872.
