### PR TITLE
filtering: return all wildcard rewrite IPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,11 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- Multiple IP address answers for wildcard DNS rewrites ([#7652]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#7652]: https://github.com/AdguardTeam/AdGuardHome/issues/7652
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/internal/filtering/rewrites.go
+++ b/internal/filtering/rewrites.go
@@ -195,24 +195,44 @@ func findRewrites(
 		return nil, matched
 	}
 
-	return finalizeRewrites(rewrites), matched
+	return finalizeRewrites(rewrites, qtype), matched
 }
 
 // finalizeRewrites sorts rewrites and truncates wildcard ones.
-func finalizeRewrites(rewrites []*LegacyRewrite) (resRewrites []*LegacyRewrite) {
+func finalizeRewrites(rewrites []*LegacyRewrite, qtype uint16) (resRewrites []*LegacyRewrite) {
 	slices.SortFunc(rewrites, (*LegacyRewrite).Compare)
 
-	for i, r := range rewrites {
-		if isWildcard(r.Domain) {
-			// Don't use rewrites[:0], because we need to return at least one
-			// item here.
-			rewrites = rewrites[:max(1, i)]
-
-			break
-		}
+	wildcardIdx := slices.IndexFunc(rewrites, func(r *LegacyRewrite) (ok bool) {
+		return isWildcard(r.Domain)
+	})
+	if wildcardIdx == -1 {
+		return rewrites
+	} else if wildcardIdx > 0 {
+		// Exact entries take priority over wildcard entries.
+		return rewrites[:wildcardIdx]
 	}
 
-	return rewrites
+	// Preserve all IP answers from the most-specific wildcard.  CNAME rewrites
+	// must remain singular.
+	first := rewrites[0]
+	if first.Type == dns.TypeCNAME {
+		return rewrites[:1]
+	}
+
+	for _, r := range rewrites {
+		if r.Domain != first.Domain || r.Type != qtype {
+			continue
+		}
+
+		if !r.IP.IsValid() {
+			// An A or AAAA exception takes priority over IP answers.
+			return []*LegacyRewrite{r}
+		}
+
+		resRewrites = append(resRewrites, r)
+	}
+
+	return resRewrites
 }
 
 // setRewriteResult sets the Reason or IPList of res if necessary.  res must not

--- a/internal/filtering/rewrites_internal_test.go
+++ b/internal/filtering/rewrites_internal_test.go
@@ -249,6 +249,119 @@ func TestRewrites(t *testing.T) {
 	}
 }
 
+func TestRewritesWildcardMultipleAnswers(t *testing.T) {
+	addr1 := netip.MustParseAddr("192.0.2.1")
+	addr2 := netip.MustParseAddr("192.0.2.2")
+	addr3 := netip.MustParseAddr("192.0.2.3")
+	addr4 := netip.MustParseAddr("192.0.2.4")
+	addr1v6 := netip.MustParseAddr("2001:db8::1")
+	addr2v6 := netip.MustParseAddr("2001:db8::2")
+	newRewrite := func(domain, answer string) *LegacyRewrite {
+		return &LegacyRewrite{Domain: domain, Answer: answer, Enabled: true}
+	}
+
+	testCases := []struct {
+		name       string
+		host       string
+		rewrites   []*LegacyRewrite
+		wantIPs    []netip.Addr
+		qtype      uint16
+		wantReason Reason
+	}{{
+		name: "ipv4",
+		host: "host.example.com",
+		rewrites: []*LegacyRewrite{
+			newRewrite("*.example.com", addr1.String()),
+			newRewrite("*.example.com", addr2.String()),
+		},
+		wantIPs:    []netip.Addr{addr1, addr2},
+		qtype:      dns.TypeA,
+		wantReason: Rewritten,
+	}, {
+		name: "ipv6",
+		host: "host.example.com",
+		rewrites: []*LegacyRewrite{
+			newRewrite("*.example.com", addr1v6.String()),
+			newRewrite("*.example.com", addr2v6.String()),
+		},
+		wantIPs:    []netip.Addr{addr1v6, addr2v6},
+		qtype:      dns.TypeAAAA,
+		wantReason: Rewritten,
+	}, {
+		name: "most_specific",
+		host: "host.sub.example.com",
+		rewrites: []*LegacyRewrite{
+			newRewrite("*.example.com", addr3.String()),
+			newRewrite("*.sub.example.com", addr1.String()),
+			newRewrite("*.sub.example.com", addr2.String()),
+		},
+		wantIPs:    []netip.Addr{addr1, addr2},
+		qtype:      dns.TypeA,
+		wantReason: Rewritten,
+	}, {
+		name: "exact",
+		host: "host.example.com",
+		rewrites: []*LegacyRewrite{
+			newRewrite("*.example.com", addr1.String()),
+			newRewrite("*.example.com", addr2.String()),
+			newRewrite("host.example.com", addr3.String()),
+			newRewrite("host.example.com", addr4.String()),
+		},
+		wantIPs:    []netip.Addr{addr3, addr4},
+		qtype:      dns.TypeA,
+		wantReason: Rewritten,
+	}, {
+		name: "opposite_type_exception",
+		host: "host.example.com",
+		rewrites: []*LegacyRewrite{
+			newRewrite("*.example.com", "AAAA"),
+			newRewrite("*.example.com", addr1.String()),
+			newRewrite("*.example.com", addr2.String()),
+		},
+		wantIPs:    []netip.Addr{addr1, addr2},
+		qtype:      dns.TypeA,
+		wantReason: Rewritten,
+	}, {
+		name: "opposite_type_only",
+		host: "host.example.com",
+		rewrites: []*LegacyRewrite{
+			newRewrite("*.example.com", "AAAA"),
+		},
+		wantIPs:    nil,
+		qtype:      dns.TypeA,
+		wantReason: Rewritten,
+	}, {
+		name: "same_type_exception",
+		host: "host.example.com",
+		rewrites: []*LegacyRewrite{
+			newRewrite("*.example.com", addr1.String()),
+			newRewrite("*.example.com", addr2.String()),
+			newRewrite("*.example.com", "A"),
+		},
+		wantIPs:    nil,
+		qtype:      dns.TypeA,
+		wantReason: NotFilteredNotFound,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, _ := newForTest(t, &Config{
+				DataDir:         t.TempDir(),
+				RewritesEnabled: true,
+			}, nil)
+			t.Cleanup(d.Close)
+
+			d.conf.Rewrites = tc.rewrites
+			ctx := testutil.ContextWithTimeout(t, testTimeout)
+			require.NoError(t, d.prepareRewrites(ctx))
+
+			res := d.processRewrites(tc.host, tc.qtype)
+			assert.Equal(t, tc.wantReason, res.Reason)
+			assert.ElementsMatch(t, tc.wantIPs, res.IPList)
+		})
+	}
+}
+
 func TestRewritesLevels(t *testing.T) {
 	d, _ := newForTest(t, nil, nil)
 	t.Cleanup(d.Close)


### PR DESCRIPTION
## Summary

- Return every A or AAAA answer from the most-specific matching wildcard DNS
  rewrite instead of truncating the result to one entry.
- Preserve exact-match and CNAME priority while making A/AAAA exception
  handling deterministic for wildcard groups.
- Add integration coverage for IPv4, IPv6, wildcard specificity, exact
  precedence, and same/opposite-family exceptions.

## Reproduction

On untouched `5f6cb57df9d54d8a89afc9200d813411f9ce4f7a`, with only the
final test matrix copied into an isolated checkout:

```sh
GOCACHE="$red_root/gocache" GOTELEMETRY=off go test -race -count=1 \
  -run '^TestRewritesWildcardMultipleAnswers$' ./internal/filtering
```

Result: the IPv4, IPv6, most-specific wildcard, and exception-interaction
subtests failed.  The core issue returned only one of two configured wildcard
IP answers.

## Validation

```sh
go test -race -count=20 \
  -run '^TestRewritesWildcardMultipleAnswers$' ./internal/filtering
go test -race -count=1 ./internal/filtering
go vet ./internal/filtering
make go-check
make go-os-check
make md-lint txt-lint
git diff --check
```

All passed.  `make go-check` completed the project linters, vulnerability scan,
and full race-enabled shuffled test suite.  `make go-os-check` passed for
Darwin, FreeBSD, OpenBSD, Windows, and both 32-bit and 64-bit Linux.  The
commit hooks reran the documentation, cross-platform vet, lint, and full Go
test gates successfully.

Closes #7652.
