### PR TITLE
client: recognize zoned runtime addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,12 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- Runtime client recognition for link-local IPv6 addresses with zone
+  identifiers ([#7836]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#7836]: https://github.com/AdguardTeam/AdGuardHome/issues/7836
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/internal/client/runtimeindex.go
+++ b/internal/client/runtimeindex.go
@@ -21,6 +21,29 @@ func (ri *runtimeIndex) client(ip netip.Addr) (rc *Runtime) {
 	return ri.index[ip]
 }
 
+// clientByIPWithoutZone returns the only saved runtime client whose IP address
+// equals ip after removing its IPv6 zone.  It returns nil if ip is not an
+// unzoned IPv6 address, no client matches, or multiple clients match.
+func (ri *runtimeIndex) clientByIPWithoutZone(ip netip.Addr) (rc *Runtime) {
+	if !ip.Is6() || ip.Zone() != "" {
+		return nil
+	}
+
+	for addr, c := range ri.index {
+		if addr.WithZone("") != ip {
+			continue
+		}
+
+		if rc != nil {
+			return nil
+		}
+
+		rc = c
+	}
+
+	return rc
+}
+
 // add saves the runtime client in the index.  IP address of a client must be
 // unique.  See [Runtime.Client].  rc must not be nil.
 func (ri *runtimeIndex) add(rc *Runtime) {

--- a/internal/client/runtimeindex.go
+++ b/internal/client/runtimeindex.go
@@ -21,6 +21,18 @@ func (ri *runtimeIndex) client(ip netip.Addr) (rc *Runtime) {
 	return ri.index[ip]
 }
 
+// clientByIP returns the exact runtime client for ip.  If there is no
+// non-empty exact client, it returns the only client whose address differs
+// from ip only by its IPv6 zone.
+func (ri *runtimeIndex) clientByIP(ip netip.Addr) (rc *Runtime) {
+	rc = ri.client(ip)
+	if rc != nil && !rc.isEmpty() {
+		return rc
+	}
+
+	return ri.clientByIPWithoutZone(ip)
+}
+
 // clientByIPWithoutZone returns the only saved runtime client whose IP address
 // equals ip after removing its IPv6 zone.  It returns nil if ip is not an
 // unzoned IPv6 address, no client matches, or multiple clients match.
@@ -30,7 +42,7 @@ func (ri *runtimeIndex) clientByIPWithoutZone(ip netip.Addr) (rc *Runtime) {
 	}
 
 	for addr, c := range ri.index {
-		if addr.WithZone("") != ip {
+		if c.isEmpty() || addr.WithZone("") != ip {
 			continue
 		}
 

--- a/internal/client/storage.go
+++ b/internal/client/storage.go
@@ -682,13 +682,19 @@ func (s *Storage) Size() (n int) {
 	return s.index.size()
 }
 
-// ClientRuntime returns a copy of the saved runtime client by ip.  If no such
-// client exists, returns nil.
+// ClientRuntime returns a copy of the saved runtime client by ip.  If an exact
+// client isn't found for an unzoned IPv6 address, it returns the only client
+// whose address differs from ip only by its zone.  If there is no such unique
+// client, it returns nil.
 func (s *Storage) ClientRuntime(ip netip.Addr) (rc *Runtime) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	rc = s.runtimeIndex.client(ip)
+	if rc == nil {
+		rc = s.runtimeIndex.clientByIPWithoutZone(ip)
+	}
+
 	if !s.runtimeSourceDHCP {
 		return rc.clone()
 	}
@@ -704,6 +710,10 @@ func (s *Storage) ClientRuntime(ip netip.Addr) (rc *Runtime) {
 	host := s.dhcp.HostByIP(ip)
 	if host == "" {
 		return rc.clone()
+	}
+
+	if rc != nil {
+		ip = rc.Addr()
 	}
 
 	rc = s.runtimeIndex.setInfo(ip, SourceDHCP, []string{host})

--- a/internal/client/storage.go
+++ b/internal/client/storage.go
@@ -369,7 +369,12 @@ func (s *Storage) UpdateDHCP(ctx context.Context) {
 
 	added := 0
 	for _, l := range s.dhcp.Leases() {
-		s.runtimeIndex.setInfo(l.IP, src, []string{l.Hostname})
+		ip := l.IP
+		if rc := s.runtimeIndex.clientByIP(ip); rc != nil {
+			ip = rc.Addr()
+		}
+
+		s.runtimeIndex.setInfo(ip, src, []string{l.Hostname})
 		added++
 	}
 
@@ -690,10 +695,7 @@ func (s *Storage) ClientRuntime(ip netip.Addr) (rc *Runtime) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	rc = s.runtimeIndex.client(ip)
-	if rc == nil {
-		rc = s.runtimeIndex.clientByIPWithoutZone(ip)
-	}
+	rc = s.runtimeIndex.clientByIP(ip)
 
 	if !s.runtimeSourceDHCP {
 		return rc.clone()

--- a/internal/client/storage_test.go
+++ b/internal/client/storage_test.go
@@ -125,6 +125,99 @@ func compareRuntimeInfo(rc *client.Runtime, src client.Source, host string) (ok 
 	return true
 }
 
+func TestStorage_ClientRuntime_zones(t *testing.T) {
+	const (
+		hostBrLAN  = "client.br-lan"
+		hostDHCP   = "client.dhcp"
+		hostGuest  = "client.guest"
+		hostNoZone = "client.no-zone"
+	)
+
+	var (
+		ip      = netip.MustParseAddr("fe80::1ff:fe23:4567:890a")
+		ipBrLAN = ip.WithZone("br-lan")
+		ipGuest = ip.WithZone("guest")
+		ctx     = testutil.ContextWithTimeout(t, testTimeout)
+	)
+
+	t.Run("unique", func(t *testing.T) {
+		s := newStorage(t, nil)
+		s.UpdateAddress(ctx, ipBrLAN, hostBrLAN, nil)
+
+		rc := s.ClientRuntime(ip)
+		require.NotNil(t, rc)
+		assert.Equal(t, ipBrLAN, rc.Addr())
+		assert.True(t, compareRuntimeInfo(rc, client.SourceRDNS, hostBrLAN))
+	})
+
+	t.Run("exact", func(t *testing.T) {
+		s := newStorage(t, nil)
+		s.UpdateAddress(ctx, ip, hostNoZone, nil)
+		s.UpdateAddress(ctx, ipBrLAN, hostBrLAN, nil)
+
+		rc := s.ClientRuntime(ip)
+		require.NotNil(t, rc)
+		assert.Equal(t, ip, rc.Addr())
+		assert.True(t, compareRuntimeInfo(rc, client.SourceRDNS, hostNoZone))
+	})
+
+	t.Run("unique_with_dhcp", func(t *testing.T) {
+		dhcp := &testDHCP{
+			OnLeases: func() (leases []*dhcpsvc.Lease) { return nil },
+			OnHostBy: func(got netip.Addr) (host string) {
+				assert.Equal(t, ip, got)
+
+				return hostDHCP
+			},
+			OnMACBy: func(_ netip.Addr) (mac net.HardwareAddr) { return nil },
+		}
+
+		s, err := client.NewStorage(ctx, &client.StorageConfig{
+			BaseLogger:        testLogger,
+			Logger:            testLogger,
+			DHCP:              dhcp,
+			RuntimeSourceDHCP: true,
+		})
+		require.NoError(t, err)
+
+		wantWHOIS := &whois.Info{Orgname: "Example Org"}
+		s.UpdateAddress(ctx, ipBrLAN, hostBrLAN, wantWHOIS)
+
+		rc := s.ClientRuntime(ip)
+		require.NotNil(t, rc)
+		assert.Equal(t, ipBrLAN, rc.Addr())
+		assert.True(t, compareRuntimeInfo(rc, client.SourceDHCP, hostDHCP))
+		assert.Equal(t, wantWHOIS, rc.WHOIS())
+
+		count := 0
+		s.RangeRuntime(func(_ *client.Runtime) (cont bool) {
+			count++
+
+			return true
+		})
+		assert.Equal(t, 1, count)
+	})
+
+	t.Run("ambiguous", func(t *testing.T) {
+		s := newStorage(t, nil)
+		s.UpdateAddress(ctx, ipBrLAN, hostBrLAN, nil)
+		s.UpdateAddress(ctx, ipGuest, hostGuest, nil)
+
+		assert.Nil(t, s.ClientRuntime(ip))
+		assert.Nil(t, s.ClientRuntime(ip.WithZone("other")))
+
+		rcBrLAN := s.ClientRuntime(ipBrLAN)
+		require.NotNil(t, rcBrLAN)
+		assert.Equal(t, ipBrLAN, rcBrLAN.Addr())
+		assert.True(t, compareRuntimeInfo(rcBrLAN, client.SourceRDNS, hostBrLAN))
+
+		rcGuest := s.ClientRuntime(ipGuest)
+		require.NotNil(t, rcGuest)
+		assert.Equal(t, ipGuest, rcGuest.Addr())
+		assert.True(t, compareRuntimeInfo(rcGuest, client.SourceRDNS, hostGuest))
+	})
+}
+
 func TestStorage_Add_hostsfile(t *testing.T) {
 	var (
 		cliIP1   = netip.MustParseAddr("1.1.1.1")

--- a/internal/client/storage_test.go
+++ b/internal/client/storage_test.go
@@ -198,6 +198,57 @@ func TestStorage_ClientRuntime_zones(t *testing.T) {
 		assert.Equal(t, 1, count)
 	})
 
+	t.Run("unique_with_dhcp_refresh", func(t *testing.T) {
+		leases := []*dhcpsvc.Lease{{
+			IP:       ip,
+			Hostname: hostDHCP,
+		}}
+		dhcp := &testDHCP{
+			OnLeases: func() (got []*dhcpsvc.Lease) { return leases },
+			OnHostBy: func(_ netip.Addr) (host string) { return "" },
+			OnMACBy:  func(_ netip.Addr) (mac net.HardwareAddr) { return nil },
+		}
+
+		s, err := client.NewStorage(ctx, &client.StorageConfig{
+			BaseLogger:        testLogger,
+			Logger:            testLogger,
+			DHCP:              dhcp,
+			RuntimeSourceDHCP: true,
+		})
+		require.NoError(t, err)
+
+		// Seed an unzoned DHCP-only client to ensure that clearing the DHCP
+		// source doesn't leave an empty exact match that prevents convergence.
+		s.UpdateDHCP(ctx)
+
+		wantWHOIS := &whois.Info{Orgname: "Example Org"}
+		s.UpdateAddress(ctx, ipBrLAN, hostBrLAN, wantWHOIS)
+		s.UpdateDHCP(ctx)
+
+		count := 0
+		s.RangeRuntime(func(_ *client.Runtime) (cont bool) {
+			count++
+
+			return true
+		})
+		require.Equal(t, 1, count)
+
+		rc := s.ClientRuntime(ip)
+		require.NotNil(t, rc)
+		assert.Equal(t, ipBrLAN, rc.Addr())
+		assert.True(t, compareRuntimeInfo(rc, client.SourceDHCP, hostDHCP))
+		assert.Equal(t, wantWHOIS, rc.WHOIS())
+
+		leases = nil
+		s.UpdateDHCP(ctx)
+
+		rc = s.ClientRuntime(ip)
+		require.NotNil(t, rc)
+		assert.Equal(t, ipBrLAN, rc.Addr())
+		assert.True(t, compareRuntimeInfo(rc, client.SourceRDNS, hostBrLAN))
+		assert.Equal(t, wantWHOIS, rc.WHOIS())
+	})
+
 	t.Run("ambiguous", func(t *testing.T) {
 		s := newStorage(t, nil)
 		s.UpdateAddress(ctx, ipBrLAN, hostBrLAN, nil)


### PR DESCRIPTION
## Summary

Recognize an unzoned link-local IPv6 address as an existing runtime client when
exactly one saved client differs only by its interface zone.

Exact matches remain preferred.  Multiple zone matches stay ambiguous, and a
zoned query never borrows another zone's client.  DHCP enrichment updates the
original zoned record, preserving its WHOIS data instead of creating a second
unzoned runtime client.

## Reproduction

On unmodified current `master`, repeated deterministic tests showed that an
unzoned lookup returned no existing client.  With DHCP enrichment enabled, it
created a duplicate unzoned client and returned data that lost the original
zoned client's WHOIS information.

## Testing

- focused zone-resolution and DHCP regression matrix under `-race`, repeated
  20 times;
- complete `internal/client` package under `-race`;
- `go vet ./internal/client`;
- `make go-check`;
- `make go-os-check`;
- `make md-lint txt-lint`;
- formatting, diff checks, and the repository's staged pre-commit hook.

Closes #7836.
