### PR TITLE
home: return bad request for invalid mobileconfig client id

### DIFF
--- a/internal/home/mobileconfig.go
+++ b/internal/home/mobileconfig.go
@@ -165,8 +165,8 @@ func encodeMobileConfig(d *dnsSettings, clientID string) ([]byte, error) {
 	return plist.MarshalIndent(data, plist.XMLFormat, "\t")
 }
 
-// respondJSONError writes an internal server error to the header and responds
-// to the client with an error.  l and w must not be nil.
+// respondJSONError writes status to the header and responds to the client with
+// an error.  l and w must not be nil.
 func respondJSONError(
 	ctx context.Context,
 	l *slog.Logger,
@@ -174,7 +174,7 @@ func respondJSONError(
 	status int,
 	msg string,
 ) {
-	w.WriteHeader(http.StatusInternalServerError)
+	w.WriteHeader(status)
 	err := json.NewEncoder(w).Encode(&jsonError{
 		Message: msg,
 	})

--- a/internal/home/mobileconfig_internal_test.go
+++ b/internal/home/mobileconfig_internal_test.go
@@ -100,6 +100,20 @@ func TestMobileConfigHandler_HandleMobileConfigDoH(t *testing.T) {
 		assert.Empty(t, s.ServerName)
 		assert.Equal(t, "https://example.org/dns-query/cli42", s.ServerURL)
 	})
+
+	t.Run("invalid_client_id", func(t *testing.T) {
+		r, err := http.NewRequest(
+			http.MethodGet,
+			"https://example.com:12345/apple/doh.mobileconfig?host=example.org&client_id=invalid/client",
+			nil,
+		)
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+
+		mobileConfHandler.handleMobileConfigDoH(w, r)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
 }
 
 func TestMobileConfigHandler_HandleMobileConfigDoT(t *testing.T) {
@@ -170,5 +184,19 @@ func TestMobileConfigHandler_HandleMobileConfigDoT(t *testing.T) {
 
 		assert.Equal(t, "cli42.example.org", s.ServerName)
 		assert.Empty(t, s.ServerURL)
+	})
+
+	t.Run("invalid_client_id", func(t *testing.T) {
+		r, err := http.NewRequest(
+			http.MethodGet,
+			"https://example.com:12345/apple/dot.mobileconfig?host=example.org&client_id=invalid/client",
+			nil,
+		)
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+
+		mobileConfHandler.handleMobileConfigDoT(w, r)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
 }


### PR DESCRIPTION
## Summary

- make the mobile-config JSON error helper honor the status supplied by its caller
- restore HTTP 400 for invalid client IDs while preserving the existing HTTP 500 paths
- cover invalid client IDs through both the DoH and DoT mobile-config endpoints

Closes #8508.

## Validation

- `make go-check`
- `go test -race -count=1 ./internal/home`
- `go test -race -count=20 -run "^TestMobileConfigHandler_HandleMobileConfigDo(H|T)$/invalid_client_id$" ./internal/home`
- `git diff --check`