### PR TITLE
client: show cached query log responses

### DIFF
--- a/client_v2/src/__locales/en.json
+++ b/client_v2/src/__locales/en.json
@@ -540,6 +540,7 @@
   "query_log_blocked_by_parental_control": "Blocked by parental control",
   "query_log_blocked_services": "Blocked services",
   "query_log_blocked_threats": "Blocked threats",
+  "query_log_cached": "Cached",
   "query_log_custom_filtering_rules": "Custom filtering rules",
   "query_log_detail_address": "Address: <span>%value%</span>",
   "query_log_detail_category": "Category: <span>%value%</span>",

--- a/client_v2/src/__tests__/query-log-cached-indicator.test.tsx
+++ b/client_v2/src/__tests__/query-log-cached-indicator.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@solidjs/testing-library';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { NormalizedQueryLogItem } from 'panel/helpers/helpers';
+import { LogCard } from 'panel/components/QueryLog/blocks/LogCard/LogCard';
+import { StatusCell } from 'panel/components/QueryLog/blocks/LogTable/blocks/StatusCell';
+
+const makeEntry = (cached: boolean): NormalizedQueryLogItem => ({
+    time: '2026-08-02T12:00:00Z',
+    domain: 'example.org',
+    unicodeName: '',
+    type: 'A',
+    response: [],
+    reason: 'NotFilteredNotFound',
+    client: '192.0.2.1',
+    client_info: null,
+    rules: [],
+    originalResponse: [],
+    tracker: null,
+    elapsedMs: '1',
+    cached,
+});
+
+describe('query-log cached indicator', () => {
+    it('shows cached responses in the desktop status cell', () => {
+        render(() => <StatusCell row={makeEntry(true)} />);
+
+        expect(screen.getByText('Cached')).toBeInTheDocument();
+    });
+
+    it('does not label uncached desktop responses', () => {
+        render(() => <StatusCell row={makeEntry(false)} />);
+
+        expect(screen.queryByText('Cached')).not.toBeInTheDocument();
+    });
+
+    it('shows cached responses in the mobile card', () => {
+        render(() => (
+            <LogCard
+                entry={makeEntry(true)}
+                filters={[]}
+                services={[]}
+                whitelistFilters={[]}
+                onRowClick={vi.fn()}
+                onBlock={vi.fn()}
+                onUnblock={vi.fn()}
+                onBlockClient={vi.fn()}
+                onDisallowClient={vi.fn()}
+                onAddPersistentClient={vi.fn()}
+                persistentClientIds={[]}
+                persistentClientsLoaded
+            />
+        ));
+
+        expect(screen.getByText('Cached')).toBeInTheDocument();
+    });
+
+    it('does not label uncached mobile responses', () => {
+        render(() => (
+            <LogCard
+                entry={makeEntry(false)}
+                filters={[]}
+                services={[]}
+                whitelistFilters={[]}
+                onRowClick={vi.fn()}
+                onBlock={vi.fn()}
+                onUnblock={vi.fn()}
+                onBlockClient={vi.fn()}
+                onDisallowClient={vi.fn()}
+                onAddPersistentClient={vi.fn()}
+                persistentClientIds={[]}
+                persistentClientsLoaded
+            />
+        ));
+
+        expect(screen.queryByText('Cached')).not.toBeInTheDocument();
+    });
+});

--- a/client_v2/src/components/QueryLog/blocks/LogCard/LogCard.tsx
+++ b/client_v2/src/components/QueryLog/blocks/LogCard/LogCard.tsx
@@ -146,6 +146,10 @@ export const LogCard = (props: Props) => {
                         )}
                     >
                         {statusLabel()}
+                        <Show when={props.entry.cached}>
+                            {' / '}
+                            <span>{intl.getMessage('query_log_cached')}</span>
+                        </Show>
                     </span>
 
                     <Show when={reasonKey() !== 'none'}>

--- a/client_v2/src/components/QueryLog/blocks/LogTable/blocks/StatusCell.tsx
+++ b/client_v2/src/components/QueryLog/blocks/LogTable/blocks/StatusCell.tsx
@@ -1,6 +1,7 @@
-import { createMemo } from 'solid-js';
+import { createMemo, Show } from 'solid-js';
 import cn from 'clsx';
 
+import intl from 'panel/common/intl';
 import theme from 'panel/lib/theme';
 import type { NormalizedQueryLogItem } from 'panel/helpers/helpers';
 import {
@@ -28,6 +29,10 @@ export const StatusCell = (props: Props) => {
             </span>
             <span class={cn(s.secondaryLine, theme.text.t4)}>
                 {getQueryStatusDetails(props.row.elapsedMs)}
+                <Show when={props.row.cached}>
+                    {' / '}
+                    <span>{intl.getMessage('query_log_cached')}</span>
+                </Show>
             </span>
         </div>
     );


### PR DESCRIPTION
## Summary

- show a localized `Cached` suffix directly in the desktop query-log status cell
- show the same indicator in the mobile query-log card
- keep uncached and missing `cached` values unchanged
- add component coverage for both layouts and both boolean states

Closes #6539.

## Validation

- `NODE_OPTIONS=--no-experimental-webstorage npm run check`
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- src/__tests__/query-log-cached-indicator.test.tsx`
- `npm run translations:check`
- `git diff --check`