### PR TITLE
filtering: ignore duplicate DNS rewrites

### DIFF
--- a/internal/filtering/rewritehttp.go
+++ b/internal/filtering/rewritehttp.go
@@ -79,11 +79,17 @@ func (d *DNSFilter) handleRewriteAdd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	added := false
 	func() {
 		d.confMu.Lock()
 		defer d.confMu.Unlock()
 
+		if slices.ContainsFunc(d.conf.Rewrites, rw.equal) {
+			return
+		}
+
 		d.conf.Rewrites = append(d.conf.Rewrites, rw)
+		added = true
 		l.DebugContext(
 			ctx,
 			"added rewrite element",
@@ -93,7 +99,9 @@ func (d *DNSFilter) handleRewriteAdd(w http.ResponseWriter, r *http.Request) {
 		)
 	}()
 
-	d.conf.ConfModifier.Apply(ctx)
+	if added {
+		d.conf.ConfModifier.Apply(ctx)
+	}
 }
 
 // handleRewriteDelete is the handler for the POST /control/rewrite/delete HTTP

--- a/internal/filtering/rewritehttp_test.go
+++ b/internal/filtering/rewritehttp_test.go
@@ -105,6 +105,15 @@ func TestDNSFilter_HandleRewriteHTTP(t *testing.T) {
 		wantBody:    append(rewritesJSON, '\n'),
 		wantList:    testRewrites,
 	}, {
+		name:        "add_duplicate_normalized",
+		url:         addURL,
+		method:      http.MethodPost,
+		reqData:     rewriteJSON{Domain: "EXAMPLE.LOCAL", Answer: exampleAnswer},
+		wantConfMod: false,
+		wantStatus:  http.StatusOK,
+		wantBody:    []byte{},
+		wantList:    testRewrites,
+	}, {
 		name:        "add_enabled_null",
 		url:         addURL,
 		method:      http.MethodPost,


### PR DESCRIPTION
## Summary

- make `POST /control/rewrite/add` idempotent for an existing domain-and-answer pair
- compare after normalizing the incoming domain, so case-only repeats are deduplicated
- keep the existing HTTP 200 response while avoiding an unnecessary configuration write
- add an HTTP regression case that verifies the list and config modifier remain unchanged

Closes #6977.

## Validation

- `make go-check`
- `go test -race -count=1 ./internal/filtering`
- `go test -race -count=20 -run "^TestDNSFilter_HandleRewriteHTTP/add_duplicate_normalized$" ./internal/filtering`
- `git diff --check`