### PR TITLE
client: show failed DNS responses as errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Changed
 
+- Failed DNS responses are now shown as errors in the query log ([#4136]).
+
 - The `edge` channel has been switched to the new UI and versioning scheme.
 
 ### Deprecated
@@ -44,6 +46,7 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#4136]: https://github.com/AdguardTeam/AdGuardHome/issues/4136
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/client_v2/src/__tests__/query-log-helpers.test.ts
+++ b/client_v2/src/__tests__/query-log-helpers.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import intl from 'panel/common/intl';
+import theme from 'panel/lib/theme';
 import { FILTERED_STATUS, SPECIAL_FILTER_ID } from '../helpers/constants';
 import {
     filterLogsByStatus,
@@ -9,6 +10,7 @@ import {
     getQueryReasonKey,
     getQueryStatusLabel,
     getQueryStatusKey,
+    getStatusClassName,
 } from '../components/QueryLog/helpers';
 
 afterEach(() => {
@@ -31,6 +33,44 @@ describe('getQueryStatusKey', () => {
             getQueryStatusKey('UnexpectedReason', [{ value: '203.0.113.10', type: 'A', ttl: 300 }]),
         ).toBe('rewritten');
     });
+
+    test.each(['SERVFAIL', 'NXDOMAIN', 'REFUSED', 'FORMERR'])(
+        'maps an unfiltered %s response to error status',
+        (responseStatus) => {
+            expect(
+                getQueryStatusKey(FILTERED_STATUS.NOT_FILTERED_NOT_FOUND, [], responseStatus),
+            ).toBe('error');
+        },
+    );
+
+    test.each(['SERVFAIL', 'NXDOMAIN', 'REFUSED', 'FORMERR'])(
+        'maps an allowlisted %s response to error status',
+        (responseStatus) => {
+            expect(
+                getQueryStatusKey(FILTERED_STATUS.NOT_FILTERED_WHITE_LIST, [], responseStatus),
+            ).toBe('error');
+        },
+    );
+
+    test('keeps successful, blocked, and rewritten responses unchanged', () => {
+        expect(getQueryStatusKey(FILTERED_STATUS.NOT_FILTERED_NOT_FOUND, [], 'NOERROR')).toBe(
+            'processed',
+        );
+        expect(getQueryStatusKey(FILTERED_STATUS.NOT_FILTERED_WHITE_LIST, [], 'NOERROR')).toBe(
+            'allowed',
+        );
+        expect(getQueryStatusKey(FILTERED_STATUS.FILTERED_BLACK_LIST, [], 'SERVFAIL')).toBe(
+            'blocked',
+        );
+        expect(getQueryStatusKey(FILTERED_STATUS.REWRITE, [], 'SERVFAIL')).toBe('rewritten');
+    });
+
+    test.each([FILTERED_STATUS.NOT_FILTERED_NOT_FOUND, FILTERED_STATUS.NOT_FILTERED_WHITE_LIST])(
+        'uses the error color for failed %s responses',
+        (reason) => {
+            expect(getStatusClassName(reason, 'error')).toBe(theme.status.statusRed);
+        },
+    );
 });
 
 describe('getQueryReasonKey', () => {

--- a/client_v2/src/__tests__/query-log-status-cell.test.tsx
+++ b/client_v2/src/__tests__/query-log-status-cell.test.tsx
@@ -1,0 +1,33 @@
+import { render } from '@solidjs/testing-library';
+import { describe, expect, test } from 'vitest';
+
+import intl from 'panel/common/intl';
+import { StatusCell } from 'panel/components/QueryLog/blocks/LogTable/blocks/StatusCell';
+import type { NormalizedQueryLogItem } from 'panel/helpers/helpers';
+import theme from 'panel/lib/theme';
+
+describe('StatusCell', () => {
+    test('presents a failed unfiltered response as an error', () => {
+        const row: NormalizedQueryLogItem = {
+            time: '2026-08-03T00:00:00Z',
+            domain: 'example.org',
+            unicodeName: 'example.org',
+            type: 'A',
+            response: [],
+            reason: 'NotFilteredNotFound',
+            client: '192.0.2.1',
+            client_info: null,
+            rules: [],
+            status: 'SERVFAIL',
+            originalResponse: [],
+            tracker: null,
+            elapsedMs: '1',
+        };
+
+        const { getByText, queryByText } = render(() => <StatusCell row={row} />);
+        const errorStatus = getByText(intl.getMessage('error'));
+
+        expect(errorStatus).toHaveClass(theme.status.statusRed);
+        expect(queryByText(intl.getMessage('query_log_processed'))).not.toBeInTheDocument();
+    });
+});

--- a/client_v2/src/__tests__/queryLogStore.test.ts
+++ b/client_v2/src/__tests__/queryLogStore.test.ts
@@ -114,6 +114,35 @@ describe('queryLogs store', () => {
         expect(queryLogsState.processingGetLogs).toBe(false);
     });
 
+    it('continues processed short-polling past failed responses', async () => {
+        (queryLog as any).mockReset();
+        (queryLog as any)
+            .mockResolvedValueOnce({
+                data: Array.from({ length: 20 }, () => ({
+                    reason: 'NotFilteredNotFound',
+                    status: 'SERVFAIL',
+                    question: {},
+                })),
+                oldest: 'cur',
+            })
+            .mockResolvedValueOnce({
+                data: [{ reason: 'NotFilteredNotFound', status: 'NOERROR', question: {} }],
+                oldest: '',
+            });
+
+        await setFilteredLogs({ search: '', status: 'processed', reason: 'all' });
+
+        expect(queryLog).toHaveBeenCalledTimes(2);
+        expect(queryLog).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                older_than: 'cur',
+                reason: ['NotFilteredNotFound'],
+            }),
+        );
+        expect(queryLogsState.logs).toHaveLength(21);
+        expect(queryLogsState.logs.at(-1)?.status).toBe('NOERROR');
+    });
+
     it('always sends limit=20 to prevent loading all records at once', async () => {
         (queryLog as any).mockReset();
         (queryLog as any)

--- a/client_v2/src/components/QueryLog/blocks/DetailModal/DetailModal.tsx
+++ b/client_v2/src/components/QueryLog/blocks/DetailModal/DetailModal.tsx
@@ -63,7 +63,11 @@ const hasValue = (value: any) =>
 
 export const DetailModal = (props: Props) => {
     const statusKey = () =>
-        getQueryStatusKey(props.entry.reason, props.entry.originalResponse ?? []);
+        getQueryStatusKey(
+            props.entry.reason,
+            props.entry.originalResponse ?? [],
+            props.entry.status,
+        );
     const reasonKey = () => getQueryReasonKey(props.entry.reason, props.entry.rules ?? []);
     const isBlocked = () => isBlockedReason(props.entry.reason);
     const isBlockedService = () => checkBlockedService(props.entry.reason);
@@ -84,7 +88,7 @@ export const DetailModal = (props: Props) => {
             services: props.services,
             whitelistFilters: props.whitelistFilters,
         });
-    const statusClassName = () => getStatusClassName(props.entry.reason);
+    const statusClassName = () => getStatusClassName(props.entry.reason, statusKey());
     const clientName = () => props.entry.client_info?.name || '';
     const protocol = () => getProtocolName(props.entry.client_proto);
     const responseList = () => formatResponses(props.entry.response);

--- a/client_v2/src/components/QueryLog/blocks/LogCard/LogCard.tsx
+++ b/client_v2/src/components/QueryLog/blocks/LogCard/LogCard.tsx
@@ -47,7 +47,11 @@ export const LogCard = (props: Props) => {
     const clientDetails = () => props.entry.client_info?.name || props.entry.client_id;
     const clientLocation = () => getClientLocation(props.entry.client_info?.whois);
     const statusKey = () =>
-        getQueryStatusKey(props.entry.reason, props.entry.originalResponse ?? []);
+        getQueryStatusKey(
+            props.entry.reason,
+            props.entry.originalResponse ?? [],
+            props.entry.status,
+        );
     const reasonKey = () => getQueryReasonKey(props.entry.reason, props.entry.rules ?? []);
     const reasonDetails = () =>
         getQueryReasonDetails({
@@ -142,7 +146,7 @@ export const LogCard = (props: Props) => {
                             s.status,
                             theme.text.t4,
                             theme.text.condenced,
-                            getStatusClassName(props.entry.reason),
+                            getStatusClassName(props.entry.reason, statusKey()),
                         )}
                     >
                         {statusLabel()}

--- a/client_v2/src/components/QueryLog/blocks/LogTable/blocks/StatusCell.tsx
+++ b/client_v2/src/components/QueryLog/blocks/LogTable/blocks/StatusCell.tsx
@@ -18,12 +18,18 @@ type Props = {
 
 export const StatusCell = (props: Props) => {
     const statusKey = createMemo(() =>
-        getQueryStatusKey(props.row.reason, props.row.originalResponse ?? []),
+        getQueryStatusKey(props.row.reason, props.row.originalResponse ?? [], props.row.status),
     );
 
     return (
         <div class={s.statusCell}>
-            <span class={cn(s.status, getStatusClassName(props.row.reason), theme.text.t3)}>
+            <span
+                class={cn(
+                    s.status,
+                    getStatusClassName(props.row.reason, statusKey()),
+                    theme.text.t3,
+                )}
+            >
                 {getQueryStatusLabel(statusKey())}
             </span>
             <span class={cn(s.secondaryLine, theme.text.t4)}>

--- a/client_v2/src/components/QueryLog/helpers.ts
+++ b/client_v2/src/components/QueryLog/helpers.ts
@@ -17,15 +17,21 @@ import {
     getServiceName,
     type Filter,
 } from 'panel/helpers/helpers';
+import {
+    filterLogsByStatus,
+    getQueryStatusKey,
+    type QueryStatusKey,
+} from 'panel/helpers/queryLogStatus';
 import { ResponseEntry, WhoisInfo } from './types';
+
+export { filterLogsByStatus, getQueryStatusKey };
+export type { QueryStatusKey };
 
 const parseLogDate = (time: string): Date | null => {
     const parsedTime = new Date(time);
 
     return isValid(parsedTime) ? parsedTime : null;
 };
-
-export type QueryStatusKey = 'all' | 'allowed' | 'processed' | 'blocked' | 'rewritten' | 'error';
 
 export type QueryReasonKey =
     | 'all'
@@ -139,10 +145,20 @@ const PROTOCOL_LABEL_GETTERS = {
     plain_dns: () => intl.getMessage('plain_dns'),
 } as const;
 
-export const getStatusClassName = (reason?: string): string =>
-    STATUS_COLOR_TO_CLASS[
-        FILTERED_STATUS_TO_COLOR_MAP[reason as keyof typeof FILTERED_STATUS_TO_COLOR_MAP]
-    ] || '';
+export const getStatusClassName = (
+    reason?: string,
+    statusKey?: Exclude<QueryStatusKey, 'all'>,
+): string => {
+    if (statusKey === 'error') {
+        return theme.status.statusRed;
+    }
+
+    return (
+        STATUS_COLOR_TO_CLASS[
+            FILTERED_STATUS_TO_COLOR_MAP[reason as keyof typeof FILTERED_STATUS_TO_COLOR_MAP]
+        ] || ''
+    );
+};
 
 export const isBlockedReason = (reason?: string): boolean =>
     !!reason && reason.startsWith('Filtered') && reason !== 'FilteredSafeSearch';
@@ -191,36 +207,6 @@ type ResponseDetailsParams = {
     serviceName?: string;
     services?: { id: string; name: string }[];
     whitelistFilters: Filter[];
-};
-
-export const getQueryStatusKey = (
-    reason?: string,
-    originalResponse: { value?: string; type?: string; ttl?: number }[] = [],
-): Exclude<QueryStatusKey, 'all'> => {
-    switch (reason) {
-        case FILTERED_STATUS.NOT_FILTERED_WHITE_LIST:
-            return 'allowed';
-        case FILTERED_STATUS.REWRITE:
-        case FILTERED_STATUS.REWRITE_HOSTS:
-        case FILTERED_STATUS.REWRITE_RULE:
-        case FILTERED_STATUS.FILTERED_SAFE_SEARCH:
-            return 'rewritten';
-        case FILTERED_STATUS.NOT_FILTERED_NOT_FOUND:
-            return 'processed';
-        case FILTERED_STATUS.NOT_FILTERED_ERROR:
-        case FILTERED_STATUS.FILTERED_INVALID:
-            return 'error';
-        default:
-            if (originalResponse.length > 0) {
-                return 'rewritten';
-            }
-
-            if (reason && reason.startsWith('Filtered')) {
-                return 'blocked';
-            }
-
-            return 'processed';
-    }
 };
 
 export const getQueryReasonKey = (
@@ -284,23 +270,12 @@ export const getQueryReasonDetails = ({
     }
 };
 
-export const filterLogsByStatus = <
-    T extends { reason?: string; originalResponse?: { type?: string; value?: string }[] },
->(
-    logs: T[],
-    status: QueryStatusKey | string,
-): T[] => {
-    if (status === 'all') {
-        return logs;
-    }
-
-    return logs.filter(
-        (log) => getQueryStatusKey(log.reason ?? '', log.originalResponse ?? []) === status,
-    );
-};
-
 export const hasPersistentClient = (
-    entry: { client: string; client_id?: string; client_info?: { name?: string; ids?: string[] } | null },
+    entry: {
+        client: string;
+        client_id?: string;
+        client_info?: { name?: string; ids?: string[] } | null;
+    },
     persistentClientIds: string[],
 ): boolean => {
     const entryIds = [entry.client, entry.client_id, ...(entry.client_info?.ids ?? [])].filter(

--- a/client_v2/src/helpers/queryLogStatus.ts
+++ b/client_v2/src/helpers/queryLogStatus.ts
@@ -1,0 +1,57 @@
+import { FILTERED_STATUS } from './constants';
+
+export type QueryStatusKey = 'all' | 'allowed' | 'processed' | 'blocked' | 'rewritten' | 'error';
+
+type QueryStatusEntry = {
+    reason?: string;
+    originalResponse?: { type?: string; value?: string }[];
+    status?: string;
+};
+
+const isErrorResponse = (responseStatus?: string): boolean =>
+    !!responseStatus && responseStatus !== 'NOERROR';
+
+export const getQueryStatusKey = (
+    reason?: string,
+    originalResponse: { value?: string; type?: string; ttl?: number }[] = [],
+    responseStatus?: string,
+): Exclude<QueryStatusKey, 'all'> => {
+    switch (reason) {
+        case FILTERED_STATUS.NOT_FILTERED_WHITE_LIST:
+            return isErrorResponse(responseStatus) ? 'error' : 'allowed';
+        case FILTERED_STATUS.REWRITE:
+        case FILTERED_STATUS.REWRITE_HOSTS:
+        case FILTERED_STATUS.REWRITE_RULE:
+        case FILTERED_STATUS.FILTERED_SAFE_SEARCH:
+            return 'rewritten';
+        case FILTERED_STATUS.NOT_FILTERED_NOT_FOUND:
+            return isErrorResponse(responseStatus) ? 'error' : 'processed';
+        case FILTERED_STATUS.NOT_FILTERED_ERROR:
+        case FILTERED_STATUS.FILTERED_INVALID:
+            return 'error';
+        default:
+            if (originalResponse.length > 0) {
+                return 'rewritten';
+            }
+
+            if (reason && reason.startsWith('Filtered')) {
+                return 'blocked';
+            }
+
+            return isErrorResponse(responseStatus) ? 'error' : 'processed';
+    }
+};
+
+export const filterLogsByStatus = <T extends QueryStatusEntry>(
+    logs: T[],
+    status: QueryStatusKey | string,
+): T[] => {
+    if (status === 'all') {
+        return logs;
+    }
+
+    return logs.filter(
+        (log) =>
+            getQueryStatusKey(log.reason ?? '', log.originalResponse ?? [], log.status) === status,
+    );
+};

--- a/client_v2/src/stores/queryLogs.ts
+++ b/client_v2/src/stores/queryLogs.ts
@@ -13,6 +13,7 @@ import {
     type QueryLogFilter,
 } from 'panel/helpers/constants';
 import { normalizeLogs, type NormalizedQueryLogItem } from 'panel/helpers/helpers';
+import { filterLogsByStatus } from 'panel/helpers/queryLogStatus';
 import type { GetQueryLogConfigResponse } from 'panel/api/model/getQueryLogConfigResponse';
 
 type QueryLogsState = {
@@ -105,17 +106,6 @@ const fetchLogsWithParams = async (olderThan: string, filter?: QueryLogFilter) =
     }
     const raw = await queryLog(params);
     return { logs: normalizeLogs(raw.data || []), oldest: raw.oldest || '' };
-};
-
-/** Simple stateless filter: count entries matching the status */
-const filterLogsByStatus = (
-    logs: NormalizedQueryLogItem[],
-    status: string,
-): NormalizedQueryLogItem[] => {
-    if (!status || status === 'all') return logs;
-    const reasons = STATUS_TO_REASONS[status];
-    if (!reasons || reasons.length === 0) return logs;
-    return logs.filter((log) => reasons.includes(log.reason ?? ''));
 };
 
 const shortPollQueryLogs = async (


### PR DESCRIPTION
Closes #4136.

This makes failed DNS responses stand out in the query log instead of presenting
them like successful processed queries.

The change:

- classifies non-`NOERROR` unfiltered and allowlisted responses as errors;
- preserves the existing blocked and rewritten precedence;
- uses the same status classifier for rendering and filtered short-polling, so
  older matching entries cannot be hidden behind a page of failed responses;
- shows the red Error status consistently in the desktop table, mobile card,
  and detail dialog.

Validation:

- `NODE_OPTIONS=--no-experimental-webstorage npm run check` (59 files, 632 tests)
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- src/__tests__/query-log-helpers.test.ts src/__tests__/query-log-status-cell.test.tsx src/__tests__/queryLogStore.test.ts`
- `NODE_OPTIONS=--no-experimental-webstorage npm run build-prod`
- `git diff --check`

The regression coverage includes SERVFAIL, NXDOMAIN, REFUSED, and FORMERR,
allowlisted failures, color selection, and continuation past a full page of
failed responses while the Processed filter is active.
