### PR TITLE
client: prefill DHCP gateway address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Added
 
+- Automatic gateway address selection for DHCP interfaces ([#3530]).
+
 - Bootstrap servers configuration now supports comments.
 
 - New property `"language"` in `POST /control/install/check_config` and `POST /control/install/configure` HTTP APIs.
@@ -44,6 +46,7 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#3530]: https://github.com/AdguardTeam/AdGuardHome/issues/3530
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/client_v2/src/__tests__/dhcp-v4-modal.test.tsx
+++ b/client_v2/src/__tests__/dhcp-v4-modal.test.tsx
@@ -1,0 +1,86 @@
+import { render, waitFor } from '@solidjs/testing-library';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    dhcpState: {
+        interfaces: {
+            eth0: {
+                flags: 'up|broadcast',
+                gateway_ip: '192.168.1.1',
+                hardware_address: '00:11:22:33:44:55',
+                ipv4_addresses: ['192.168.1.2'],
+                ipv6_addresses: [] as string[],
+                name: 'eth0',
+            },
+        },
+        processingConfig: false,
+        v4: {
+            gateway_ip: '',
+            subnet_mask: '',
+            range_start: '',
+            range_end: '',
+            lease_duration: 0,
+        },
+    },
+}));
+
+vi.mock('panel/stores/dhcp', () => ({
+    get dhcpState() {
+        return mocks.dhcpState;
+    },
+}));
+
+import { DhcpV4Modal } from 'panel/components/Dhcp/blocks/DhcpV4Modal';
+
+describe('DhcpV4Modal', () => {
+    beforeEach(() => {
+        mocks.dhcpState.interfaces.eth0.gateway_ip = '192.168.1.1';
+        mocks.dhcpState.interfaces.eth0.ipv4_addresses = ['192.168.1.2'];
+        mocks.dhcpState.v4.gateway_ip = '';
+    });
+
+    const renderModal = () =>
+        render(() => (
+            <DhcpV4Modal
+                open={true}
+                selectedInterface={() => 'eth0'}
+                onClose={vi.fn()}
+                onSave={vi.fn()}
+            />
+        ));
+
+    it('prefills a blank gateway from the selected interface', async () => {
+        const { container } = renderModal();
+
+        const gatewayInput = container.querySelector('#v4_gateway_ip') as HTMLInputElement;
+
+        await waitFor(() => expect(gatewayInput.value).toBe('192.168.1.1'));
+    });
+
+    it('uses the interface IPv4 when it has no reported gateway', async () => {
+        mocks.dhcpState.interfaces.eth0.gateway_ip = '';
+
+        const { container } = renderModal();
+        const gatewayInput = container.querySelector('#v4_gateway_ip') as HTMLInputElement;
+
+        await waitFor(() => expect(gatewayInput.value).toBe('192.168.1.2'));
+    });
+
+    it('preserves a saved gateway', async () => {
+        mocks.dhcpState.v4.gateway_ip = '192.168.1.254';
+
+        const { container } = renderModal();
+        const gatewayInput = container.querySelector('#v4_gateway_ip') as HTMLInputElement;
+
+        await waitFor(() => expect(gatewayInput.value).toBe('192.168.1.254'));
+    });
+
+    it('does not invent a gateway without an interface IPv4', async () => {
+        mocks.dhcpState.interfaces.eth0.ipv4_addresses = [];
+
+        const { container } = renderModal();
+        const gatewayInput = container.querySelector('#v4_gateway_ip') as HTMLInputElement;
+
+        await waitFor(() => expect(gatewayInput.value).toBe(''));
+    });
+});

--- a/client_v2/src/components/Dhcp/blocks/DhcpV4Modal/DhcpV4Modal.tsx
+++ b/client_v2/src/components/Dhcp/blocks/DhcpV4Modal/DhcpV4Modal.tsx
@@ -47,10 +47,17 @@ export const DhcpV4Modal = (props: Props) => {
     const [rangeEndError, setRangeEndError] = createSignal('');
     const [leaseDurationError, setLeaseDurationError] = createSignal('');
 
+    const interfaceV4Defaults = createMemo(() => {
+        const iface = dhcpState.interfaces?.[props.selectedInterface()];
+        const firstIpv4 = iface?.ipv4_addresses?.[0];
+
+        return firstIpv4 ? calculateDhcpPlaceholdersIpv4(firstIpv4, iface.gateway_ip) : undefined;
+    });
+
     createEffect(() => {
         if (props.open) {
             const v4 = dhcpState.v4;
-            setGatewayIp(v4?.gateway_ip || '');
+            setGatewayIp(v4?.gateway_ip || interfaceV4Defaults()?.gateway_ip || '');
             setSubnetMask(v4?.subnet_mask || '');
             setRangeStart(v4?.range_start || '');
             setRangeEnd(v4?.range_end || '');
@@ -63,14 +70,7 @@ export const DhcpV4Modal = (props: Props) => {
         }
     });
 
-    const v4Placeholders = createMemo(() => {
-        const iface = dhcpState.interfaces?.[props.selectedInterface()];
-        const firstIpv4 = iface?.ipv4_addresses?.[0];
-        if (firstIpv4) {
-            return calculateDhcpPlaceholdersIpv4(firstIpv4, iface.gateway_ip);
-        }
-        return DHCP_VALUES_PLACEHOLDERS.ipv4;
-    });
+    const v4Placeholders = createMemo(() => interfaceV4Defaults() || DHCP_VALUES_PLACEHOLDERS.ipv4);
 
     const hasIpv4 = createMemo(
         () =>


### PR DESCRIPTION
Closes #3530.

## Summary

- prefill an empty DHCPv4 gateway from the selected interface reported gateway
- fall back to the interface first IPv4 address when no gateway is reported
- preserve an existing saved gateway and leave the field empty when no IPv4 exists
- add deterministic frontend regression coverage and a changelog entry

## Validation

- `NODE_OPTIONS=--no-experimental-webstorage npm run test -- src/__tests__/dhcp-v4-modal.test.tsx`
- `NODE_OPTIONS=--no-experimental-webstorage npm run check`
- `NODE_OPTIONS=--no-experimental-webstorage npm run build-prod`
- `make md-lint`
- `git diff --check`