### PR TITLE
client: add DHCP static lease search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Added
 
+- Search by MAC address, IP address, or hostname in the DHCP static leases
+  table ([#6884]).
+
 - Bootstrap servers configuration now supports comments.
 
 - New property `"language"` in `POST /control/install/check_config` and `POST /control/install/configure` HTTP APIs.
@@ -44,6 +47,7 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#6884]: https://github.com/AdguardTeam/AdGuardHome/issues/6884
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/client_v2/src/__tests__/static-leases-table.test.tsx
+++ b/client_v2/src/__tests__/static-leases-table.test.tsx
@@ -1,8 +1,26 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, fireEvent } from '@solidjs/testing-library';
+import { render, fireEvent, screen, waitFor } from '@solidjs/testing-library';
+import { createSignal } from 'solid-js';
 import { StaticLeasesTable } from 'panel/components/Dhcp/LeasesPage/StaticLeasesTable';
 
 const LEASES = [{ mac: 'AA:BB:CC:DD:EE:FF', ip: '192.168.1.100', hostname: 'host1' }];
+const SEARCH_LEASES = [
+    { mac: 'AA:BB:CC:DD:EE:FF', ip: '192.168.1.1', hostname: 'Office Router' },
+    { mac: '11:22:33:44:55:66', ip: '192.168.1.25', hostname: 'Printer' },
+    { mac: 'DE:AD:BE:EF:00:01', ip: '192.168.1.50', hostname: 'Storage' },
+];
+
+const renderSearchableTable = () =>
+    render(() => (
+        <StaticLeasesTable
+            staticLeases={SEARCH_LEASES}
+            processingDeleting={false}
+            processingUpdating={false}
+            onEdit={() => {}}
+            onDelete={() => {}}
+            onRefresh={() => {}}
+        />
+    ));
 
 describe('StaticLeasesTable', () => {
     it('renders mobile action buttons for all three actions', () => {
@@ -86,5 +104,112 @@ describe('StaticLeasesTable', () => {
 
         fireEvent.click(getByTestId('static-lease-delete-button'));
         expect(onDelete).toHaveBeenCalledWith(LEASES[0]);
+    });
+
+    it.each([
+        ['router', 'Office Router', ['Printer', 'Storage']],
+        ['192.168.1.25', 'Printer', ['Office Router', 'Storage']],
+        ['de:ad:be:ef', 'Storage', ['Office Router', 'Printer']],
+    ])('filters leases by hostname, IP, or MAC for %s', (query, expected, hidden) => {
+        renderSearchableTable();
+
+        fireEvent.input(screen.getByRole('searchbox', { name: 'Search' }), {
+            target: { value: query },
+        });
+
+        expect(screen.getByText(expected)).toBeInTheDocument();
+        hidden.forEach((hostname) => {
+            expect(screen.queryByText(hostname)).not.toBeInTheDocument();
+        });
+    });
+
+    it('restores all leases when the search is cleared', () => {
+        renderSearchableTable();
+
+        const searchInput = screen.getByRole('searchbox', { name: 'Search' });
+        fireEvent.input(searchInput, {
+            target: { value: 'router' },
+        });
+
+        expect(searchInput.className).toContain('hideNativeSearchClear');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Clear input' }));
+
+        SEARCH_LEASES.forEach(({ hostname }) => {
+            expect(screen.getByText(hostname)).toBeInTheDocument();
+        });
+    });
+
+    it('shows an empty state when no static lease matches', () => {
+        renderSearchableTable();
+
+        fireEvent.input(screen.getByRole('searchbox', { name: 'Search' }), {
+            target: { value: 'missing' },
+        });
+
+        expect(screen.getByText('Nothing found')).toBeInTheDocument();
+    });
+
+    it('shows matches from the full lease list after changing pages', () => {
+        const paginatedLeases = Array.from({ length: 11 }, (_, index) => ({
+            mac: `AA:BB:CC:DD:EE:${String(index).padStart(2, '0')}`,
+            ip: `192.168.1.${index + 1}`,
+            hostname: index === 0 ? 'Target lease' : `Host ${index + 1}`,
+        }));
+
+        render(() => (
+            <StaticLeasesTable
+                staticLeases={paginatedLeases}
+                processingDeleting={false}
+                processingUpdating={false}
+                onEdit={() => {}}
+                onDelete={() => {}}
+                onRefresh={() => {}}
+            />
+        ));
+
+        fireEvent.click(screen.getByRole('button', { name: '2' }));
+        expect(screen.queryByText('Target lease')).not.toBeInTheDocument();
+
+        fireEvent.input(screen.getByRole('searchbox', { name: 'Search' }), {
+            target: { value: 'target' },
+        });
+
+        expect(screen.getByText('Target lease')).toBeInTheDocument();
+    });
+
+    it('resets the page when the filtered lease count shrinks', async () => {
+        const initialLeases = Array.from({ length: 11 }, (_, index) => ({
+            mac: `AA:BB:CC:DD:EE:${String(index).padStart(2, '0')}`,
+            ip: `192.168.1.${index + 1}`,
+            hostname: `Matching host ${index + 1}`,
+        }));
+        const [leases, setLeases] = createSignal(initialLeases);
+
+        const TestTable = () => (
+            <StaticLeasesTable
+                staticLeases={leases()}
+                processingDeleting={false}
+                processingUpdating={false}
+                onEdit={() => {}}
+                onDelete={() => {}}
+                onRefresh={() => {}}
+            />
+        );
+
+        render(() => <TestTable />);
+
+        fireEvent.input(screen.getByRole('searchbox', { name: 'Search' }), {
+            target: { value: 'matching' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: '2' }));
+        expect(screen.getByText('Matching host 11')).toBeInTheDocument();
+
+        setLeases((current) => current.slice(0, 10));
+
+        await waitFor(() => {
+            expect(screen.getByText('Matching host 1')).toBeInTheDocument();
+        });
+        expect(screen.queryByText('Nothing found')).not.toBeInTheDocument();
     });
 });

--- a/client_v2/src/common/controls/Input/Input.module.pcss
+++ b/client_v2/src/common/controls/Input/Input.module.pcss
@@ -85,6 +85,11 @@
             caret-color: var(--default-main-text);
             transition: background-color 5000s ease-in-out 0s;
         }
+
+        &.hideNativeSearchClear::-webkit-search-cancel-button {
+            -webkit-appearance: none;
+            appearance: none;
+        }
     }
 }
 

--- a/client_v2/src/common/controls/Input/Input.tsx
+++ b/client_v2/src/common/controls/Input/Input.tsx
@@ -132,6 +132,7 @@ export const Input = (props: Props) => {
                     class={cn(s.input, props.innerClass, {
                         [s.prefix]: props.prefixIcon,
                         [s.postfix]: hasActions(),
+                        [s.hideNativeSearchClear]: props.type === 'search' && showClearButton(),
                     })}
                     onChange={handleChange}
                     onInput={(e) => (props.onInput as any)?.(e)}

--- a/client_v2/src/common/ui/Table/Table.tsx
+++ b/client_v2/src/common/ui/Table/Table.tsx
@@ -1,4 +1,4 @@
-import { type JSX, createMemo, For, Show, untrack } from 'solid-js';
+import { type JSX, createEffect, createMemo, For, Show, untrack } from 'solid-js';
 import { createStore } from 'solid-js/store';
 import cn from 'clsx';
 
@@ -51,6 +51,7 @@ export interface TableProps<T = any> {
     onRowClick?: (row: T) => void;
     tableHeaderClass?: string;
     tableRowClass?: string;
+    pageResetKey?: string | number;
 }
 
 export const Table = <T extends Record<string, any>>(props: TableProps<T>) => {
@@ -59,6 +60,12 @@ export const Table = <T extends Record<string, any>>(props: TableProps<T>) => {
         pageSize: untrack(() => props.pageSize) ?? DEFAULT_PAGE_SIZE_OPTIONS[0],
         sortKey: props.defaultSort?.key ?? (null as string | null),
         sortDirection: props.defaultSort?.direction ?? ('asc' as 'asc' | 'desc'),
+    });
+
+    createEffect(() => {
+        if (props.pageResetKey !== undefined) {
+            setState('currentPage', 0);
+        }
     });
 
     const sortedData = createMemo(() => {

--- a/client_v2/src/components/Dhcp/LeasesPage/LeasesTable.module.pcss
+++ b/client_v2/src/components/Dhcp/LeasesPage/LeasesTable.module.pcss
@@ -34,6 +34,8 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    gap: 16px;
+    padding: 48px 16px;
 }
 
 .emptyTableIcon {
@@ -43,6 +45,20 @@
 
 .emptyTableDesc {
     color: var(--default-description-text);
+}
+
+.search {
+    width: 100%;
+    max-width: 360px;
+    margin-bottom: 24px;
+
+    @media (min-width: 768px) {
+        margin-left: auto;
+    }
+}
+
+.searchIcon {
+    margin-left: 8px;
 }
 
 .staticTable {

--- a/client_v2/src/components/Dhcp/LeasesPage/StaticLeasesTable.tsx
+++ b/client_v2/src/components/Dhcp/LeasesPage/StaticLeasesTable.tsx
@@ -3,6 +3,7 @@ import cn from 'clsx';
 
 import intl from 'panel/common/intl';
 import theme from 'panel/lib/theme';
+import { Input } from 'panel/common/controls/Input';
 import { Table, type TableColumn } from 'panel/common/ui/Table';
 import { Icon } from 'panel/common/ui/Icon';
 import { Dropdown } from 'panel/common/ui/Dropdown';
@@ -26,6 +27,29 @@ type Props = {
 
 export const StaticLeasesTable = (props: Props) => {
     const [openMenuId, setOpenMenuId] = createSignal<string | null>(null);
+    const [search, setSearch] = createSignal('');
+    const searchTerm = createMemo(() => search().trim().toLowerCase());
+
+    const filteredLeases = createMemo(() => {
+        const term = searchTerm();
+        if (!term) {
+            return props.staticLeases;
+        }
+
+        return props.staticLeases.filter((lease) =>
+            [lease.mac, lease.ip, lease.hostname].some((value) =>
+                value.toLowerCase().includes(term),
+            ),
+        );
+    });
+
+    const handleSearchChange = (event: Event) => {
+        setSearch((event.target as HTMLInputElement).value);
+    };
+
+    const handleSearchClear = () => {
+        setSearch('');
+    };
 
     const handleEdit = (row: StaticLease) => {
         props.onEdit(row);
@@ -214,12 +238,39 @@ export const StaticLeasesTable = (props: Props) => {
         },
     ]);
 
+    const emptyTableContent = () => (
+        <div class={s.emptyTableContent}>
+            <Icon icon="not_found_search" color="gray" class={s.emptyTableIcon} />
+            <div class={cn(theme.text.t3, s.emptyTableDesc)}>
+                {intl.getMessage('nothing_found')}
+            </div>
+        </div>
+    );
+
     return (
-        <Table
-            data={props.staticLeases}
-            class={s.staticTable}
-            columns={columns()}
-            getRowId={(row: StaticLease) => `${row.mac}-${row.ip}`}
-        />
+        <>
+            <div class={s.search}>
+                <Input
+                    id="dhcp-static-leases-search"
+                    type="search"
+                    label={intl.getMessage('search_placeholder')}
+                    value={search()}
+                    onInput={handleSearchChange}
+                    isClearable
+                    onClear={handleSearchClear}
+                    placeholder={intl.getMessage('search_placeholder')}
+                    prefixIcon={<Icon icon="search" class={s.searchIcon} color="gray" />}
+                />
+            </div>
+
+            <Table
+                data={filteredLeases()}
+                class={s.staticTable}
+                columns={columns()}
+                emptyTable={emptyTableContent()}
+                pageResetKey={`${searchTerm()}:${filteredLeases().length}`}
+                getRowId={(row: StaticLease) => `${row.mac}-${row.ip}`}
+            />
+        </>
     );
 };


### PR DESCRIPTION
Closes #6884.

## Summary

- add an accessible responsive search field for static DHCP leases
- match MAC addresses, IP addresses, and hostnames case-insensitively before pagination
- reset pagination whenever the search result set changes, including same-term lease updates
- suppress the native WebKit search clear control only when the shared input renders its own clear button
- cover matching, clearing, empty results, pagination, dynamic result changes, and clear-control behavior

## Validation

- `NODE_OPTIONS=--no-experimental-webstorage npm run test -- src/__tests__/static-leases-table.test.tsx` (12 tests)
- `NODE_OPTIONS=--no-experimental-webstorage npm run check` (58 files, 626 tests)
- `NODE_OPTIONS=--no-experimental-webstorage npm run build-prod`
- `make md-lint`
- `git diff --check`