### PR TITLE
client: show all install interface addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,12 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- The installation wizard now shows every address for each network interface
+  ([#654]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#654]: https://github.com/AdguardTeam/AdGuardHome/issues/654
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/client_v2/src/__tests__/install-interface-options.test.ts
+++ b/client_v2/src/__tests__/install-interface-options.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildInterfaceOptions } from 'panel/install/Setup/helpers/InterfaceOptions';
+import type { InstallInterface } from 'panel/initialState';
+
+describe('buildInterfaceOptions', () => {
+    it('includes every address of an active interface', () => {
+        const interfaces: InstallInterface[] = [
+            {
+                flags: 'up|broadcast|multicast',
+                hardware_address: '00:11:22:33:44:55',
+                ip_addresses: ['192.0.2.1', '2001:db8::1'],
+                mtu: 1500,
+                name: 'eth0',
+            },
+        ];
+
+        expect(buildInterfaceOptions(interfaces).slice(1)).toStrictEqual([
+            {
+                value: '192.0.2.1',
+                label: 'eth0 – 192.0.2.1',
+            },
+            {
+                value: '2001:db8::1',
+                label: 'eth0 – 2001:db8::1',
+            },
+        ]);
+    });
+});

--- a/client_v2/src/install/Setup/helpers/InterfaceOptions.ts
+++ b/client_v2/src/install/Setup/helpers/InterfaceOptions.ts
@@ -1,6 +1,5 @@
 import intl from 'panel/common/intl';
 
-import { getInterfaceIp } from 'panel/helpers/helpers';
 import { ALL_INTERFACES_IP } from 'panel/helpers/constants';
 import type { InstallInterface } from 'panel/initialState';
 
@@ -32,14 +31,13 @@ export const buildInterfaceOptions = (interfaces: InstallInterface[]): SelectOpt
                   const isUp = iface.flags?.includes('up');
                   return isUp;
               })
-              .map((iface) => {
-                  const ip = getInterfaceIp(iface);
+              .flatMap((iface) => {
                   const displayName = getInterfaceDisplayName(iface);
 
-                  return {
+                  return iface.ip_addresses.map((ip) => ({
                       value: ip,
                       label: `${displayName} – ${ip}`,
-                  };
+                  }));
               })
         : []),
 ];


### PR DESCRIPTION
Updates #654.

The installation API already returns every address discovered for each network
interface, but the current setup wizard reduces every interface to a single
IPv4-preferred option.  This change builds one selectable option per discovered
address, so IPv4 and IPv6 addresses from the same active interface are both
available in the web and DNS selectors.

The regression test uses a dual-stack `eth0` fixture and fails against the
previous implementation because the IPv6 option is absent.

This deliberately does not change the install API's single-address binding
model or implement persistent interface-name binding; that larger feature is
tracked in #3635.

Validation:

- `NODE_OPTIONS=--no-experimental-webstorage npm exec vitest run src/__tests__/install-interface-options.test.ts src/__tests__/helpers/helpers-scalar.spec.ts`
  (23 tests passed)
- `NODE_OPTIONS=--no-experimental-webstorage npm run check`
  (lint, typecheck, and 620 tests passed)
- `NODE_OPTIONS=--no-experimental-webstorage npm run build-prod`
  (production build passed; 2,345 modules)
- `go test -race -count=1 -run '^TestNetInterface_MarshalJSON$' ./internal/aghnet`
- `make md-lint`
- `git diff --check`
