### PR TITLE
client: await manual blocklist addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,12 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- The manual blocklist dialog now remains open while the list is being added
+  ([#5624]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#5624]: https://github.com/AdguardTeam/AdGuardHome/issues/5624
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/client_v2/src/__tests__/configure-blocklist-modal.test.tsx
+++ b/client_v2/src/__tests__/configure-blocklist-modal.test.tsx
@@ -1,0 +1,89 @@
+import { render, waitFor } from '@solidjs/testing-library';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, expect, it, vi } from 'vitest';
+
+import { ConfigureBlocklistModal } from 'panel/components/FilterLists/blocks/ConfigureBlocklistModal';
+import { MODAL_TYPE } from 'panel/helpers/constants';
+
+const mocks = vi.hoisted(() => ({
+    closeModal: vi.fn(),
+    filteringAddURL: vi.fn(),
+    filteringStatus: vi.fn(() => Promise.resolve({ filters: [], whitelist_filters: [] })),
+}));
+
+vi.mock('panel/api/generated', () => ({
+    filteringAddURL: mocks.filteringAddURL,
+    filteringCheckHost: vi.fn(),
+    filteringConfig: vi.fn(),
+    filteringRefresh: vi.fn(),
+    filteringRemoveURL: vi.fn(),
+    filteringSetRules: vi.fn(),
+    filteringSetURL: vi.fn(),
+    filteringStatus: mocks.filteringStatus,
+}));
+
+vi.mock('panel/common/ui/ModalWrapper', () => ({
+    ModalWrapper: (props: { children: unknown }) => <>{props.children}</>,
+}));
+
+vi.mock('panel/common/ui/Dialog/Dialog', () => ({
+    Dialog: (props: { children: unknown }) => <>{props.children}</>,
+}));
+
+vi.mock('panel/common/ui/Tabs', () => ({
+    Tabs: (props: { tabs: Array<{ content: unknown }> }) => <>{props.tabs[1].content}</>,
+}));
+
+vi.mock('panel/stores/modals', () => ({
+    closeModal: mocks.closeModal,
+    modalsState: { modalId: null },
+    openModal: vi.fn(),
+}));
+
+const createDeferred = <T,>() => {
+    let resolve = (_value: T) => {};
+    const promise = new Promise<T>((promiseResolve) => {
+        resolve = promiseResolve;
+    });
+
+    return { promise, resolve };
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+it('keeps the manual blocklist modal open while the add request is pending', async () => {
+    const addRequest = createDeferred<void>();
+    const statusRequest = createDeferred<{ filters: []; whitelist_filters: [] }>();
+    mocks.filteringAddURL.mockReturnValueOnce(addRequest.promise);
+    mocks.filteringStatus.mockReturnValueOnce(statusRequest.promise);
+
+    const user = userEvent.setup();
+    const { container } = render(() => (
+        <ConfigureBlocklistModal modalId={MODAL_TYPE.ADD_BLOCKLIST} />
+    ));
+
+    const nameInput = container.querySelector<HTMLInputElement>('input[name="name"]');
+    const urlInput = container.querySelector<HTMLInputElement>('input[name="url"]');
+    const submit = container.querySelector<HTMLButtonElement>('#filters_save');
+    if (nameInput === null || urlInput === null || submit === null) {
+        throw new Error('expected the manual blocklist form');
+    }
+
+    await user.type(nameInput, 'Slow list');
+    await user.type(urlInput, 'https://example.org/slow.txt');
+    await user.click(submit);
+
+    expect(mocks.filteringAddURL).toHaveBeenCalledTimes(1);
+    expect(mocks.closeModal).not.toHaveBeenCalled();
+    expect(submit).toBeDisabled();
+
+    addRequest.resolve();
+    await waitFor(() => expect(mocks.filteringStatus).toHaveBeenCalledTimes(1));
+    expect(mocks.closeModal).not.toHaveBeenCalled();
+    expect(submit).toBeDisabled();
+
+    statusRequest.resolve({ filters: [], whitelist_filters: [] });
+    await waitFor(() => expect(mocks.closeModal).toHaveBeenCalledTimes(1));
+});

--- a/client_v2/src/components/FilterLists/blocks/ConfigureBlocklistModal/ConfigureBlocklistModal.tsx
+++ b/client_v2/src/components/FilterLists/blocks/ConfigureBlocklistModal/ConfigureBlocklistModal.tsx
@@ -120,7 +120,7 @@ export const ConfigureBlocklistModal = (props: Props) => {
                     if (nameErr || urlErr) {
                         return;
                     }
-                    addFilter(values.url, values.name, false);
+                    await addFilter(values.url, values.name, false);
                 } else {
                     const existingFilterSources = new Set(
                         filteringState.filters.map((filter: Filter) => filter.url),

--- a/client_v2/src/stores/filtering.ts
+++ b/client_v2/src/stores/filtering.ts
@@ -268,7 +268,6 @@ export const addFilter = async (url: string, name: string, whitelist: boolean) =
     setState('processingAddFilter', true);
     try {
         await filteringAddURL({ url, name, whitelist });
-        setState('processingAddFilter', false);
         setState('isModalOpen', false);
         if (whitelist) {
             addSuccessToast({
@@ -280,6 +279,7 @@ export const addFilter = async (url: string, name: string, whitelist: boolean) =
             });
         }
         await getFilteringStatus();
+        setState('processingAddFilter', false);
     } catch (error) {
         addErrorToast({ error });
         setState('processingAddFilter', false);


### PR DESCRIPTION
Updates #5624.

The issue logs show a slow first add request completing successfully and a second request starting immediately afterward.  The manual blocklist form previously launched the add operation without awaiting it and closed immediately, so there was no visible in-progress state while a large list was downloaded and initialized.

This change awaits the manual add, keeps the submit button disabled and its loader active through the add and status refresh, and closes the dialog only after the operation settles.  The backend duplicate rejection remains unchanged and intentional.

A regression test holds both requests pending and verifies that the dialog stays open, only one add request is sent, and submission remains disabled until completion.

Validation:

- Pre-fix regression test failed because the dialog closed while the add request was pending.
- Focused regression test passes.
- Full client_v2 check passes: lint, typecheck, 59 test files, 620 tests.
- Production client_v2 build passes with 2,345 modules.
- Relevant backend race test passes.
- make md-lint and git diff --check pass.