### PR TITLE
client: skip whois for private networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,11 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- WHOIS lookups for client addresses from configured private networks ([#3817]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#3817]: https://github.com/AdguardTeam/AdGuardHome/issues/3817
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/internal/client/addrproc.go
+++ b/internal/client/addrproc.go
@@ -289,7 +289,7 @@ func (p *DefaultAddrProc) shouldResolve(ip netip.Addr) (ok bool) {
 // WHOIS databases.  info is nil if there were errors or if the information
 // hasn't changed.
 func (p *DefaultAddrProc) processWHOIS(ctx context.Context, ip netip.Addr) (info *whois.Info) {
-	if p.privateSubnets.Contains(ip) {
+	if p.privateSubnets.Contains(ip.Unmap()) {
 		return nil
 	}
 

--- a/internal/client/addrproc.go
+++ b/internal/client/addrproc.go
@@ -289,6 +289,10 @@ func (p *DefaultAddrProc) shouldResolve(ip netip.Addr) (ok bool) {
 // WHOIS databases.  info is nil if there were errors or if the information
 // hasn't changed.
 func (p *DefaultAddrProc) processWHOIS(ctx context.Context, ip netip.Addr) (info *whois.Info) {
+	if p.privateSubnets.Contains(ip) {
+		return nil
+	}
+
 	start := time.Now()
 	p.logger.DebugContext(ctx, "processing whois", "ip", ip)
 	defer func() {

--- a/internal/client/addrproc_test.go
+++ b/internal/client/addrproc_test.go
@@ -264,6 +264,84 @@ func TestDefaultAddrProc_Process_WHOIS(t *testing.T) {
 	}
 }
 
+func TestDefaultAddrProc_Process_WHOIS_PrivateSubnets(t *testing.T) {
+	t.Parallel()
+
+	privateSubnet := netip.MustParsePrefix("2606:4700:4700::/64")
+	wantInfo := &whois.Info{
+		City: testWHOISCity,
+	}
+
+	testCases := []struct {
+		ip       netip.Addr
+		wantInfo *whois.Info
+		name     string
+		wantDial bool
+	}{
+		{
+			ip:       netip.MustParseAddr("2606:4700:4700::1111"),
+			name:     "private_network",
+			wantInfo: nil,
+			wantDial: false,
+		},
+		{
+			ip:       netip.MustParseAddr("2001:4860:4860::8888"),
+			name:     "public",
+			wantInfo: wantInfo,
+			wantDial: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var dialed bool
+			whoisConn := &fakenet.Conn{
+				OnClose: func() (err error) { return nil },
+				OnRead: func(b []byte) (n int, err error) {
+					data := "city: " + testWHOISCity + "\n"
+					copy(b, data)
+
+					return len(data), io.EOF
+				},
+				OnSetDeadline: func(_ time.Time) (err error) { return nil },
+				OnWrite:       func(b []byte) (n int, err error) { return len(b), nil },
+			}
+
+			updInfoCh := make(chan *whois.Info, 1)
+			p := client.NewDefaultAddrProc(&client.DefaultAddrProcConfig{
+				BaseLogger: slogutil.NewDiscardLogger(),
+				DialContext: func(_ context.Context, _, _ string) (conn net.Conn, err error) {
+					dialed = true
+
+					return whoisConn, nil
+				},
+				PrivateSubnets: privateSubnet,
+				AddressUpdater: &aghtest.AddressUpdater{
+					OnUpdateAddress: func(
+						_ context.Context,
+						_ netip.Addr,
+						_ string,
+						info *whois.Info,
+					) {
+						updInfoCh <- info
+					},
+				},
+				UseWHOIS: true,
+			})
+			testutil.CleanupAndRequireSuccess(t, p.Close)
+
+			ctx := testutil.ContextWithTimeout(t, testTimeout)
+			p.Process(ctx, tc.ip)
+
+			gotInfo, _ := testutil.RequireReceive(t, updInfoCh, testTimeout)
+			assert.Equal(t, tc.wantInfo, gotInfo)
+			assert.Equal(t, tc.wantDial, dialed)
+		})
+	}
+}
+
 func TestDefaultAddrProc_Close(t *testing.T) {
 	t.Parallel()
 

--- a/internal/client/addrproc_test.go
+++ b/internal/client/addrproc_test.go
@@ -267,28 +267,44 @@ func TestDefaultAddrProc_Process_WHOIS(t *testing.T) {
 func TestDefaultAddrProc_Process_WHOIS_PrivateSubnets(t *testing.T) {
 	t.Parallel()
 
-	privateSubnet := netip.MustParsePrefix("2606:4700:4700::/64")
 	wantInfo := &whois.Info{
 		City: testWHOISCity,
 	}
 
 	testCases := []struct {
-		ip       netip.Addr
-		wantInfo *whois.Info
-		name     string
-		wantDial bool
+		privateSubnet netip.Prefix
+		ip            netip.Addr
+		wantInfo      *whois.Info
+		name          string
+		wantDial      bool
 	}{
 		{
-			ip:       netip.MustParseAddr("2606:4700:4700::1111"),
-			name:     "private_network",
-			wantInfo: nil,
-			wantDial: false,
+			privateSubnet: netip.MustParsePrefix("2606:4700:4700::/64"),
+			ip:            netip.MustParseAddr("2606:4700:4700::1111"),
+			name:          "private_network",
+			wantInfo:      nil,
+			wantDial:      false,
 		},
 		{
-			ip:       netip.MustParseAddr("2001:4860:4860::8888"),
-			name:     "public",
-			wantInfo: wantInfo,
-			wantDial: true,
+			privateSubnet: netip.MustParsePrefix("2606:4700:4700::/64"),
+			ip:            netip.MustParseAddr("2001:4860:4860::8888"),
+			name:          "public",
+			wantInfo:      wantInfo,
+			wantDial:      true,
+		},
+		{
+			privateSubnet: netip.MustParsePrefix("192.168.0.0/16"),
+			ip:            netip.MustParseAddr("::ffff:192.168.0.1"),
+			name:          "private_network_mapped_ipv4",
+			wantInfo:      nil,
+			wantDial:      false,
+		},
+		{
+			privateSubnet: netip.MustParsePrefix("192.168.0.0/16"),
+			ip:            netip.MustParseAddr("::ffff:8.8.8.8"),
+			name:          "public_mapped_ipv4",
+			wantInfo:      wantInfo,
+			wantDial:      true,
 		},
 	}
 
@@ -317,7 +333,7 @@ func TestDefaultAddrProc_Process_WHOIS_PrivateSubnets(t *testing.T) {
 
 					return whoisConn, nil
 				},
-				PrivateSubnets: privateSubnet,
+				PrivateSubnets: tc.privateSubnet,
 				AddressUpdater: &aghtest.AddressUpdater{
 					OnUpdateAddress: func(
 						_ context.Context,


### PR DESCRIPTION
## Summary

- Treat `dns.private_networks` as the privacy boundary for client WHOIS
  processing.
- Skip WHOIS cache access and network dialing for addresses in those networks.
- Preserve WHOIS processing for unrelated public addresses.
- Add a regression covering a globally routed IPv6 prefix configured as
  private and a public IPv6 control.

`local_ptr_upstreams` selects the reverse-DNS resolvers; `private_networks`
defines which address ranges are private.  A globally routed SLAAC prefix must
therefore be listed in `private_networks` to receive this protection.

Fixes #3817.

## Reproduction

Against current `master`, the new focused test failed because the address
`2606:4700:4700::1111`, despite belonging to a configured private `/64`, dialed
the WHOIS server and returned WHOIS data.  The unrelated public IPv6 control
also dialed as expected.

After the fix, the configured-private case performs no WHOIS dial while the
public control retains the existing behavior.

## Validation

- `go test -race -count=20 -run '^TestDefaultAddrProc_Process_WHOIS_PrivateSubnets$' ./internal/client`
- `go test -race -count=1 ./internal/client`
- `make go-check`
- `make md-lint`
- `git diff --check`
- Repository pre-commit hook, including cross-platform `go vet`, lint,
  `govulncheck`, and the full race-enabled Go test suite

An independent read-only review found no blockers.
