### PR TITLE
client: restore five-day TLS expiry warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,11 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- TLS certificate expiration warnings appearing too early ([#1400]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#1400]: https://github.com/AdguardTeam/AdGuardHome/issues/1400
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/client_v2/src/__tests__/common/ui/Banners.test.tsx
+++ b/client_v2/src/__tests__/common/ui/Banners.test.tsx
@@ -101,15 +101,25 @@ describe('Banners', () => {
         expect(screen.getByText('Your TLS certificate has expired')).toBeInTheDocument();
     });
 
-    it('shows TLS expiring banner when cert expires within 30 days', () => {
+    it('shows TLS expiring banner when cert expires within 5 days', () => {
         mockEncryptionState.enabled = true;
         mockEncryptionState.valid_cert = true;
-        mockEncryptionState.not_after = new Date(Date.now() + 15 * 86400000).toISOString(); // 15 days
+        mockEncryptionState.not_after = new Date(Date.now() + 4 * 86400000).toISOString();
 
         renderBanners();
 
         expect(screen.getByTestId('banner-tls-expiring')).toBeInTheDocument();
         expect(screen.getByText('Your TLS certificate is about to expire')).toBeInTheDocument();
+    });
+
+    it('does not show TLS expiring banner more than 5 days before expiry', () => {
+        mockEncryptionState.enabled = true;
+        mockEncryptionState.valid_cert = true;
+        mockEncryptionState.not_after = new Date(Date.now() + 15 * 86400000).toISOString();
+
+        renderBanners();
+
+        expect(screen.queryByTestId('banner-tls-expiring')).not.toBeInTheDocument();
     });
 
     it('shows auto-update banner when update available and can auto-update', () => {
@@ -218,7 +228,7 @@ describe('Banners', () => {
         expect(screen.queryByTestId('banner-tls-expired')).not.toBeInTheDocument();
 
         // Change condition: now cert is valid but expiring soon
-        mockEncryptionState.not_after = new Date(Date.now() + 15 * 86400000).toISOString(); // 15 days
+        mockEncryptionState.not_after = new Date(Date.now() + 4 * 86400000).toISOString();
         // Re-render
         renderBanners();
 

--- a/client_v2/src/common/ui/Banners/Banners.tsx
+++ b/client_v2/src/common/ui/Banners/Banners.tsx
@@ -19,7 +19,7 @@ import {
 
 import s from './Banners.module.pcss';
 
-const TLS_EXPIRY_WARNING_MS = 30 * 24 * 60 * 60 * 1000;
+const TLS_EXPIRY_WARNING_MS = 5 * 24 * 60 * 60 * 1000;
 
 type Props = {
     forceBanner?: BannerSpec;


### PR DESCRIPTION
Updates #1400.

The legacy UI reduced the TLS certificate-expiry warning threshold from 30
days to five days in `88d44b43`, following the maintainer decision in #1400.
The SolidJS migration unintentionally restored the old 30-day threshold.

This change restores the established five-day behavior in `client_v2` and adds
coverage on both sides of the threshold:

- a certificate expiring in four days shows the warning;
- a certificate expiring in 15 days does not show the warning.

This deliberately does not add a configurable or adaptive threshold.  #8196
and #8227 are related future policy work, but #8227 only changes the removed
legacy UI and does not overlap this `client_v2` regression fix.

Validation:

```text
# Red first: 15-day certificate incorrectly showed the warning.
NODE_OPTIONS=--no-experimental-webstorage npm test -- \
  src/__tests__/common/ui/Banners.test.tsx
1 failed, 15 passed

# Green focused test.
NODE_OPTIONS=--no-experimental-webstorage npm test -- \
  src/__tests__/common/ui/Banners.test.tsx
16 passed

NODE_OPTIONS=--no-experimental-webstorage npm run check
58 test files passed, 620 tests passed

NODE_OPTIONS=--no-experimental-webstorage npm run build-prod
webpack compiled successfully, 2345 modules

make md-lint
git diff --check
```
