### PR TITLE
client: cancel stale query log requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,12 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- Query log filters now cancel superseded searches and ignore stale responses
+  ([#1370]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#1370]: https://github.com/AdguardTeam/AdGuardHome/issues/1370
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/client_v2/src/__tests__/queryLogStore.test.ts
+++ b/client_v2/src/__tests__/queryLogStore.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { getAdditionalLogs, setFilteredLogs, queryLogsState } from 'panel/stores/queryLogs';
+import {
+    cancelQueryLogRequests,
+    getAdditionalLogs,
+    setFilteredLogs,
+    queryLogsState,
+} from 'panel/stores/queryLogs';
 import { queryLog } from 'panel/api/generated';
+import { addErrorToast } from 'panel/stores/toasts';
 
 vi.mock('panel/api/generated', () => ({
     queryLog: vi.fn(),
@@ -10,6 +16,24 @@ vi.mock('panel/stores/toasts', () => ({
     addErrorToast: vi.fn(),
     addSuccessToast: vi.fn(),
 }));
+
+const createDeferred = <T>() => {
+    let resolve: (value: T) => void = () => {};
+    let reject: (reason?: unknown) => void = () => {};
+    const promise = new Promise<T>((promiseResolve, promiseReject) => {
+        resolve = promiseResolve;
+        reject = promiseReject;
+    });
+
+    return { promise, reject, resolve };
+};
+
+const filter = (search: string) => ({ search, status: 'rewritten', reason: 'all' });
+
+const response = (domain: string, oldest = '') => ({
+    data: [{ reason: 'Rewrite' as const, question: { name: domain } }],
+    oldest,
+});
 
 describe('queryLogs store', () => {
     beforeEach(() => {
@@ -51,6 +75,7 @@ describe('queryLogs store', () => {
                     'FilteredSafeSearch',
                 ]),
             }),
+            { signal: expect.any(AbortSignal) },
         );
         // Must NOT send the deprecated response_status
         const lastCall = (queryLog as any).mock.calls.at(-1)[0];
@@ -80,6 +105,7 @@ describe('queryLogs store', () => {
                     'FilteredBlockedService',
                 ]),
             }),
+            { signal: expect.any(AbortSignal) },
         );
         expect(lastCall).not.toHaveProperty('response_status');
     });
@@ -141,6 +167,195 @@ describe('queryLogs store', () => {
 
         await getAdditionalLogs();
 
-        expect(queryLog).toHaveBeenCalledWith(expect.objectContaining({ limit: 20 }));
+        expect((queryLog as any).mock.calls.at(-1)[0]).toEqual(
+            expect.objectContaining({ limit: 20 }),
+        );
+    });
+
+    it('keeps the latest filtered response when an older request finishes last', async () => {
+        const older = createDeferred<ReturnType<typeof response>>();
+        const latest = createDeferred<ReturnType<typeof response>>();
+        (queryLog as any).mockImplementation((params: { search: string }) =>
+            params.search === 'older' ? older.promise : latest.promise,
+        );
+
+        const olderRequest = setFilteredLogs(filter('older'));
+        const olderSignal = (queryLog as any).mock.calls[0][1]?.signal as AbortSignal | undefined;
+        const latestRequest = setFilteredLogs(filter('latest'));
+
+        latest.resolve(response('latest.example'));
+        await expect(latestRequest).resolves.toBe(true);
+        expect(queryLogsState.logs[0]?.domain).toBe('latest.example');
+
+        older.resolve(response('older.example'));
+        await expect(olderRequest).resolves.toBe(false);
+
+        expect(olderSignal?.aborted).toBe(true);
+        expect(queryLogsState.filter.search).toBe('latest');
+        expect(queryLogsState.logs[0]?.domain).toBe('latest.example');
+    });
+
+    it('does not show an error toast when a filtered request is aborted', async () => {
+        const older = createDeferred<ReturnType<typeof response>>();
+        const latest = createDeferred<ReturnType<typeof response>>();
+        let olderSignal: AbortSignal | undefined;
+        (queryLog as any).mockImplementation(
+            (params: { search: string }, options?: { signal?: AbortSignal }) => {
+                if (params.search !== 'older') {
+                    return latest.promise;
+                }
+
+                olderSignal = options?.signal;
+                olderSignal?.addEventListener('abort', () => {
+                    older.reject(new DOMException('The operation was aborted.', 'AbortError'));
+                });
+
+                return older.promise;
+            },
+        );
+
+        const olderRequest = setFilteredLogs(filter('older'));
+        const latestRequest = setFilteredLogs(filter('latest'));
+        older.reject(new DOMException('The operation was aborted.', 'AbortError'));
+
+        await expect(olderRequest).resolves.toBe(false);
+        expect(olderSignal?.aborted).toBe(true);
+        expect(addErrorToast).not.toHaveBeenCalled();
+
+        latest.resolve(response('latest.example'));
+        await expect(latestRequest).resolves.toBe(true);
+    });
+
+    it('stops an aborted filtered short-poll chain before requesting another page', async () => {
+        const olderSecondPage = createDeferred<ReturnType<typeof response>>();
+        const olderCalls: Array<{ options?: { signal?: AbortSignal }; olderThan: string }> = [];
+        (queryLog as any).mockImplementation(
+            (params: { older_than: string; search: string }, options?: { signal?: AbortSignal }) => {
+                if (params.search === 'latest') {
+                    return Promise.resolve(response('latest.example'));
+                }
+
+                olderCalls.push({ options, olderThan: params.older_than });
+                if (params.older_than === '') {
+                    return Promise.resolve(response('older-first.example', 'cursor-1'));
+                }
+                if (params.older_than === 'cursor-1') {
+                    return olderSecondPage.promise;
+                }
+
+                return Promise.resolve(response('unexpected.example'));
+            },
+        );
+
+        const olderRequest = setFilteredLogs(filter('older'));
+        await vi.waitFor(() => expect(olderCalls).toHaveLength(2));
+
+        await expect(setFilteredLogs(filter('latest'))).resolves.toBe(true);
+        olderSecondPage.resolve(response('older-second.example', 'cursor-2'));
+        await expect(olderRequest).resolves.toBe(false);
+
+        expect(olderCalls).toHaveLength(2);
+        expect(olderCalls[0].options?.signal).toBeInstanceOf(AbortSignal);
+        expect(olderCalls[1].options?.signal).toBe(olderCalls[0].options?.signal);
+    });
+
+    it('keeps the loading state until the latest filtered request finishes', async () => {
+        const older = createDeferred<ReturnType<typeof response>>();
+        const latest = createDeferred<ReturnType<typeof response>>();
+        (queryLog as any).mockImplementation((params: { search: string }) =>
+            params.search === 'older' ? older.promise : latest.promise,
+        );
+
+        const olderRequest = setFilteredLogs(filter('older'));
+        const latestRequest = setFilteredLogs(filter('latest'));
+
+        older.resolve(response('older.example'));
+        await expect(olderRequest).resolves.toBe(false);
+        expect(queryLogsState.processingGetLogs).toBe(true);
+
+        latest.resolve(response('latest.example'));
+        await expect(latestRequest).resolves.toBe(true);
+        expect(queryLogsState.processingGetLogs).toBe(false);
+    });
+
+    it('discards a pending load-more response when a new filter starts', async () => {
+        (queryLog as any).mockResolvedValueOnce({
+            data: Array.from({ length: 20 }, () => response('filter-a.example').data[0]),
+            oldest: 'filter-a-cursor',
+        });
+        await setFilteredLogs(filter('filter-a'));
+
+        const stalePage = createDeferred<ReturnType<typeof response>>();
+        (queryLog as any).mockReturnValueOnce(stalePage.promise);
+        const loadMoreRequest = getAdditionalLogs();
+        const loadMoreSignal = (queryLog as any).mock.calls.at(-1)[1]?.signal as
+            | AbortSignal
+            | undefined;
+
+        (queryLog as any).mockResolvedValueOnce(response('filter-b.example'));
+        await expect(setFilteredLogs(filter('filter-b'))).resolves.toBe(true);
+        expect(loadMoreSignal?.aborted).toBe(true);
+
+        stalePage.resolve(response('stale-filter-a.example', 'stale-cursor'));
+        await loadMoreRequest;
+
+        expect(queryLogsState.filter.search).toBe('filter-b');
+        expect(queryLogsState.logs).toHaveLength(1);
+        expect(queryLogsState.logs[0]?.domain).toBe('filter-b.example');
+        expect(queryLogsState.oldest).toBe('');
+        expect(queryLogsState.processingAdditionalLogs).toBe(false);
+        expect(addErrorToast).not.toHaveBeenCalled();
+    });
+
+    it('cancels pending filtered work without a toast or stale state update', async () => {
+        const pending = createDeferred<ReturnType<typeof response>>();
+        let signal: AbortSignal | undefined;
+        (queryLog as any).mockImplementation(
+            (_params: unknown, options?: { signal?: AbortSignal }) => {
+                signal = options?.signal;
+                signal?.addEventListener('abort', () => {
+                    pending.reject(new DOMException('The operation was aborted.', 'AbortError'));
+                });
+
+                return pending.promise;
+            },
+        );
+
+        const request = setFilteredLogs(filter('unmounted'));
+        cancelQueryLogRequests();
+        await expect(request).resolves.toBe(false);
+
+        expect(signal?.aborted).toBe(true);
+        expect(queryLogsState.processingGetLogs).toBe(false);
+        expect(queryLogsState.processingAdditionalLogs).toBe(false);
+        expect(addErrorToast).not.toHaveBeenCalled();
+    });
+
+    it('cancels pending load-more work without a toast or stale append', async () => {
+        (queryLog as any).mockResolvedValueOnce(response('kept.example'));
+        await setFilteredLogs(filter('kept'));
+
+        const pending = createDeferred<ReturnType<typeof response>>();
+        let signal: AbortSignal | undefined;
+        (queryLog as any).mockImplementation(
+            (_params: unknown, options?: { signal?: AbortSignal }) => {
+                signal = options?.signal;
+                signal?.addEventListener('abort', () => {
+                    pending.reject(new DOMException('The operation was aborted.', 'AbortError'));
+                });
+
+                return pending.promise;
+            },
+        );
+
+        const request = getAdditionalLogs();
+        cancelQueryLogRequests();
+        await request;
+
+        expect(signal?.aborted).toBe(true);
+        expect(queryLogsState.logs).toHaveLength(1);
+        expect(queryLogsState.logs[0]?.domain).toBe('kept.example');
+        expect(queryLogsState.processingAdditionalLogs).toBe(false);
+        expect(addErrorToast).not.toHaveBeenCalled();
     });
 });

--- a/client_v2/src/components/QueryLog/QueryLog.tsx
+++ b/client_v2/src/components/QueryLog/QueryLog.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createEffect, onMount, Show, For } from 'solid-js';
+import { createSignal, createEffect, onMount, onCleanup, Show, For } from 'solid-js';
 import cn from 'clsx';
 import { useNavigate, useLocation } from '@solidjs/router';
 
@@ -11,6 +11,7 @@ import {
     setFilteredLogs,
     refreshFilteredLogs,
     getAdditionalLogs,
+    cancelQueryLogRequests,
 } from 'panel/stores/queryLogs';
 import { accessState, getAccessList, toggleClientBlock } from 'panel/stores/access';
 import { dashboardState, getClients } from 'panel/stores/dashboard';
@@ -67,6 +68,8 @@ export const QueryLog = () => {
         getFilteringStatus();
         getAllBlockedServices();
     });
+
+    onCleanup(cancelQueryLogRequests);
 
     // Watch location.search for filter changes
     createEffect(() => {

--- a/client_v2/src/stores/queryLogs.ts
+++ b/client_v2/src/stores/queryLogs.ts
@@ -57,6 +57,11 @@ const initialState: QueryLogsState = {
 
 const [state, setState] = createStore<QueryLogsState>(initialState);
 
+let filteredLogsAbortController: AbortController | null = null;
+let filteredLogsRequestId = 0;
+let additionalLogsAbortController: AbortController | null = null;
+let additionalLogsRequestId = 0;
+
 // ---------- Short-poll helpers (v2 parity) ----------
 
 /** Maps frontend status filter → exact backend reason strings */
@@ -93,7 +98,11 @@ const getReasons = (filter?: QueryLogFilter): string[] => {
     return STATUS_TO_REASONS[status] ?? [];
 };
 
-const fetchLogsWithParams = async (olderThan: string, filter?: QueryLogFilter) => {
+const fetchLogsWithParams = async (
+    olderThan: string,
+    filter?: QueryLogFilter,
+    signal?: AbortSignal,
+) => {
     const params: Record<string, string | string[] | number | undefined> = {
         search: filter?.search ?? DEFAULT_LOGS_FILTER.search,
         older_than: olderThan,
@@ -103,7 +112,7 @@ const fetchLogsWithParams = async (olderThan: string, filter?: QueryLogFilter) =
     if (reasons.length > 0) {
         params.reason = reasons;
     }
-    const raw = await queryLog(params);
+    const raw = signal ? await queryLog(params, { signal }) : await queryLog(params);
     return { logs: normalizeLogs(raw.data || []), oldest: raw.oldest || '' };
 };
 
@@ -121,6 +130,7 @@ const filterLogsByStatus = (
 const shortPollQueryLogs = async (
     data: { logs: NormalizedQueryLogItem[]; oldest: string },
     filter: QueryLogFilter,
+    signal?: AbortSignal,
     total?: { logs: NormalizedQueryLogItem[]; oldest: string },
 ): Promise<{ logs: NormalizedQueryLogItem[]; oldest: string }> => {
     const totalData = total
@@ -131,11 +141,81 @@ const shortPollQueryLogs = async (
         filter?.status || DEFAULT_LOGS_FILTER.status,
     ).length;
     if (visible >= QUERY_LOGS_PAGE_LIMIT || totalData.oldest === '') return totalData;
-    const more = await fetchLogsWithParams(totalData.oldest, filter);
-    return shortPollQueryLogs(more, filter, totalData);
+    if (signal?.aborted) return totalData;
+
+    const more = await fetchLogsWithParams(totalData.oldest, filter, signal);
+    return shortPollQueryLogs(more, filter, signal, totalData);
+};
+
+const startFilteredLogsRequest = () => {
+    const previousController = filteredLogsAbortController;
+    const controller = new AbortController();
+    const requestId = ++filteredLogsRequestId;
+
+    filteredLogsAbortController = controller;
+    previousController?.abort();
+
+    return { controller, requestId };
+};
+
+const isLatestFilteredLogsRequest = (requestId: number): boolean =>
+    requestId === filteredLogsRequestId;
+
+const finishFilteredLogsRequest = (requestId: number): boolean => {
+    if (!isLatestFilteredLogsRequest(requestId)) {
+        return false;
+    }
+
+    filteredLogsAbortController = null;
+
+    return true;
+};
+
+const abortFilteredLogsRequest = (): void => {
+    filteredLogsRequestId += 1;
+    const controller = filteredLogsAbortController;
+    filteredLogsAbortController = null;
+    controller?.abort();
+};
+
+const startAdditionalLogsRequest = () => {
+    const previousController = additionalLogsAbortController;
+    const controller = new AbortController();
+    const requestId = ++additionalLogsRequestId;
+
+    additionalLogsAbortController = controller;
+    previousController?.abort();
+
+    return { controller, requestId };
+};
+
+const finishAdditionalLogsRequest = (requestId: number): boolean => {
+    if (requestId !== additionalLogsRequestId) {
+        return false;
+    }
+
+    additionalLogsAbortController = null;
+
+    return true;
+};
+
+const abortAdditionalLogsRequest = (): void => {
+    additionalLogsRequestId += 1;
+    const controller = additionalLogsAbortController;
+    additionalLogsAbortController = null;
+    controller?.abort();
 };
 
 // ---------- Public actions ----------
+
+export const cancelQueryLogRequests = (): void => {
+    abortFilteredLogsRequest();
+    abortAdditionalLogsRequest();
+    setState({
+        processingGetLogs: false,
+        processingAdditionalLogs: false,
+    });
+};
 
 export const getLogs = async (currentQuery?: string) => {
     setState('processingGetLogs', true);
@@ -166,10 +246,15 @@ export const getLogs = async (currentQuery?: string) => {
 };
 
 export const getAdditionalLogs = async () => {
+    const { controller, requestId } = startAdditionalLogsRequest();
     setState('processingAdditionalLogs', true);
     try {
         const { filter, oldest } = untrack(() => state);
-        const data = await fetchLogsWithParams(oldest, filter);
+        const data = await fetchLogsWithParams(oldest, filter, controller.signal);
+        if (!finishAdditionalLogsRequest(requestId)) {
+            return;
+        }
+
         setState({
             logs: [...state.logs, ...data.logs],
             oldest: data.oldest,
@@ -177,7 +262,13 @@ export const getAdditionalLogs = async () => {
             processingAdditionalLogs: false,
         });
     } catch (error) {
-        addErrorToast({ error });
+        if (!finishAdditionalLogsRequest(requestId)) {
+            return;
+        }
+
+        if (!controller.signal.aborted) {
+            addErrorToast({ error });
+        }
         setState('processingAdditionalLogs', false);
     }
 };
@@ -234,24 +325,38 @@ export const setLogsConfig = async (values: GetQueryLogConfigResponse): Promise<
 };
 
 export const setFilteredLogs = async (filter?: QueryLogFilter): Promise<boolean> => {
+    abortAdditionalLogsRequest();
+    const currentFilter = filter ?? DEFAULT_LOGS_FILTER;
+    const { controller, requestId } = startFilteredLogsRequest();
     setState({
-        filter: filter ?? DEFAULT_LOGS_FILTER,
+        filter: currentFilter,
         isFiltered: true,
         processingGetLogs: true,
+        processingAdditionalLogs: false,
     });
     try {
-        const data = await fetchLogsWithParams('', filter);
-        const accumulated = await shortPollQueryLogs(data, filter);
+        const data = await fetchLogsWithParams('', currentFilter, controller.signal);
+        const accumulated = await shortPollQueryLogs(data, currentFilter, controller.signal);
+        if (!finishFilteredLogsRequest(requestId)) {
+            return false;
+        }
+
         setState({
             logs: accumulated.logs,
             oldest: accumulated.oldest,
             isEntireLog: accumulated.oldest === '',
-            filter: filter ?? DEFAULT_LOGS_FILTER,
+            filter: currentFilter,
             processingGetLogs: false,
         });
         return true;
     } catch (error) {
-        addErrorToast({ error });
+        if (!finishFilteredLogsRequest(requestId)) {
+            return false;
+        }
+
+        if (!controller.signal.aborted) {
+            addErrorToast({ error });
+        }
         setState('processingGetLogs', false);
         return false;
     }


### PR DESCRIPTION
Closes #1370.

Cancel superseded query-log searches and pass the same `AbortSignal` through
the complete short-poll chain.  A new filter also cancels pending load-more
work, and unmounting the Query Log page cancels both request families.

Request IDs prevent stale successes, failures, loading-state updates, and
error toasts from affecting the latest search.  This keeps the filter inputs
usable while a large query log is still being searched without allowing an
older request to overwrite newer results.

Regression tests cover:

- an older filtered request completing after a newer filter;
- aborting a multi-page short-poll chain;
- a new filter superseding pending load-more work;
- filtered and load-more cleanup when the page unmounts;
- loading-state ownership and suppression of stale error toasts.

Validation:

- `npm run check` (58 files, 626 tests in the implementation run; 59 files,
  627 tests in an independent disposable-copy review)
- `npm run build-prod` (2,345 modules)
- focused query-log store tests repeated 20 times
- `go test -race -count=1 ./internal/querylog`
- `make md-lint`
- `make txt-lint`
- `git diff --check`
