### PR TITLE
client: restore dashboard query-log drill-down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,12 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Fixed
 
+- Query-log drill-down links for top queried domains and clients on the
+  dashboard ([#1368]).
+
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#1368]: https://github.com/AdguardTeam/AdGuardHome/issues/1368
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/client_v2/src/__tests__/dashboard-query-log-links.test.tsx
+++ b/client_v2/src/__tests__/dashboard-query-log-links.test.tsx
@@ -1,0 +1,48 @@
+import { HashRouter, Route } from '@solidjs/router';
+import { render, screen } from '@solidjs/testing-library';
+import type { JSX } from 'solid-js';
+import { describe, expect, it } from 'vitest';
+
+import { TopClients } from 'panel/components/Dashboard/blocks/TopClients';
+import { TopQueriedDomains } from 'panel/components/Dashboard/blocks/TopQueriedDomains';
+
+const renderAtDashboard = (component: () => JSX.Element) => {
+    window.location.hash = '#/';
+
+    return render(() => (
+        <HashRouter>
+            <Route path="/" component={component} />
+        </HashRouter>
+    ));
+};
+
+describe('Dashboard query log links', () => {
+    it('links a top queried domain to an exact query log search', () => {
+        const domain = 'matching.example.org';
+
+        renderAtDashboard(() => (
+            <TopQueriedDomains
+                topQueriedDomains={[{ name: domain, count: 7 }]}
+                numDnsQueries={10}
+            />
+        ));
+
+        expect(screen.getByRole('link', { name: domain })).toHaveAttribute(
+            'href',
+            '#/logs?search=%22matching.example.org%22',
+        );
+    });
+
+    it('links a top client to an exact query log search', () => {
+        const client = '192.0.2.1';
+
+        renderAtDashboard(() => (
+            <TopClients topClients={[{ name: client, count: 6 }]} numDnsQueries={10} />
+        ));
+
+        expect(screen.getByRole('link', { name: client })).toHaveAttribute(
+            'href',
+            '#/logs?search=%22192.0.2.1%22',
+        );
+    });
+});

--- a/client_v2/src/components/Dashboard/blocks/TopClients/TopClients.tsx
+++ b/client_v2/src/components/Dashboard/blocks/TopClients/TopClients.tsx
@@ -4,9 +4,11 @@ import { MOBILE_TABLE_MAX_ROWS } from 'panel/helpers/constants';
 
 import intl from 'panel/common/intl';
 import { Icon } from 'panel/common/ui/Icon';
+import { Link } from 'panel/common/ui/Link';
 import { Tooltip } from 'panel/common/ui/Tooltip';
 import { Dropdown } from 'panel/common/ui/Dropdown';
 import { ConfirmDialog } from 'panel/common/ui/ConfirmDialog';
+import { RoutePath } from 'panel/components/Routes/Paths';
 import { formatNumber, formatCompactNumber } from 'panel/helpers/helpers';
 import { addErrorToast } from 'panel/stores/toasts';
 import { accessState, toggleClientBlock } from 'panel/stores/access';
@@ -181,7 +183,12 @@ export const TopClients = (props: Props) => {
                                                 <Icon icon="location" class={s.tableRowIcon} />
                                             </Show>
 
-                                            {client.name}
+                                            <Link
+                                                to={RoutePath.QueryLog}
+                                                query={{ search: `"${client.name}"` }}
+                                            >
+                                                {client.name}
+                                            </Link>
                                         </div>
                                     </div>
 

--- a/client_v2/src/components/Dashboard/blocks/TopQueriedDomains/TopQueriedDomains.tsx
+++ b/client_v2/src/components/Dashboard/blocks/TopQueriedDomains/TopQueriedDomains.tsx
@@ -4,7 +4,9 @@ import { useIsDesktop } from 'panel/helpers/useMediaQuery';
 import { MOBILE_TABLE_MAX_ROWS } from 'panel/helpers/constants';
 import intl from 'panel/common/intl';
 import { Icon } from 'panel/common/ui/Icon';
+import { Link } from 'panel/common/ui/Link';
 import { Tooltip } from 'panel/common/ui/Tooltip';
+import { RoutePath } from 'panel/components/Routes/Paths';
 import { formatNumber, formatCompactNumber } from 'panel/helpers/helpers';
 import { getTrackerData } from 'panel/helpers/trackers/trackers';
 import theme from 'panel/lib/theme';
@@ -91,7 +93,13 @@ export const TopQueriedDomains = (props: Props) => {
                                                 <Icon icon="eye_open" class={s.tableRowIcon} />
                                             </Tooltip>
                                         </Show>
-                                        <span class={s.domainName}>{domain.name}</span>
+                                        <Link
+                                            to={RoutePath.QueryLog}
+                                            query={{ search: `"${domain.name}"` }}
+                                            class={s.domainName}
+                                        >
+                                            {domain.name}
+                                        </Link>
                                     </div>
 
                                     <div class={s.tableRowRight}>


### PR DESCRIPTION
Updates #1368.

Restores the dashboard-to-query-log drill-down that was lost during the
SolidJS migration.  Top queried domains and top clients are now native links
to a quoted, exact Query Log search, while the existing client block/unblock
control remains separate.

The regression tests verify the exact generated URLs for a domain and an IPv4
client.  Additional validation covered IPv6, ClientID, Unicode, spaces, and
embedded quotes through the shared URL encoder and backend exact-match path.

Validation:

- `npm run check` (59 files, 621 tests)
- `npm run build-prod`
- focused test across shuffled seeds 1 through 20
- backend strict-search contract with `-race -count=20`
- `make md-lint`
- `git diff --check`
