### PR TITLE
filtering: show progress while toggling filter lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Changed
 
+- Enabling or disabling a filter list now blocks other UI actions and shows
+  progress while the filtering engine is rebuilt ([#667]).
+
 - The `edge` channel has been switched to the new UI and versioning scheme.
 
 ### Deprecated
@@ -44,6 +47,7 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+[#667]:  https://github.com/AdguardTeam/AdGuardHome/issues/667
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
 
 <!--

--- a/client_v2/src/__locales/en.json
+++ b/client_v2/src/__locales/en.json
@@ -385,6 +385,8 @@
   "filter_category_security_desc": "Lists designed specifically to block malicious, phishing, and scam domains",
   "filter_removed_successfully": "Removed blocklist: <strong>%value%</strong>",
   "filter_removed_successfully_allowlist": "Removed allowlist: <strong>%value%</strong>",
+  "filter_toggle_progress_desc": "Please wait while AdGuard Home applies the filter changes. Internet connectivity may be affected until this process is complete.",
+  "filter_toggle_progress_title": "Updating filter lists",
   "filters": "Filters",
   "forgot_password": "Forgot password?",
   "forgot_password_list_item_1": "Create a new password using the htpasswd tool or any online BCrypt generator.",

--- a/client_v2/src/__tests__/filter-toggle-progress.test.tsx
+++ b/client_v2/src/__tests__/filter-toggle-progress.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen, waitFor } from '@solidjs/testing-library';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { filteringSetURL, filteringStatus } from 'panel/api/generated';
+import intl from 'panel/common/intl';
+import { FilterToggleProgress } from 'panel/components/FilterLists/blocks/FilterToggleProgress';
+import { editFilter, filteringState, toggleFilterStatus } from 'panel/stores/filtering';
+
+vi.mock('panel/api/generated', () => ({
+    filteringAddURL: vi.fn(),
+    filteringCheckHost: vi.fn(),
+    filteringConfig: vi.fn(),
+    filteringRefresh: vi.fn(),
+    filteringRemoveURL: vi.fn(),
+    filteringSetRules: vi.fn(),
+    filteringSetURL: vi.fn(),
+    filteringStatus: vi.fn(),
+}));
+
+const createDeferred = <T,>() => {
+    let resolve: (value: T) => void = () => {};
+    let reject: (reason?: unknown) => void = () => {};
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+
+    return { promise, reject, resolve };
+};
+
+const filterURL = 'https://example.org/filter.txt';
+const filterData = {
+    enabled: false,
+    name: 'Example',
+    url: filterURL,
+};
+
+describe('FilterToggleProgress', () => {
+    afterEach(() => {
+        vi.mocked(filteringSetURL).mockReset();
+        vi.mocked(filteringStatus).mockReset();
+    });
+
+    it('blocks the interface and explains the filter rebuild while it is pending', async () => {
+        const request = createDeferred<void>();
+        const status = createDeferred<Awaited<ReturnType<typeof filteringStatus>>>();
+        vi.mocked(filteringSetURL).mockReturnValue(request.promise);
+        vi.mocked(filteringStatus).mockReturnValue(status.promise);
+
+        const user = userEvent.setup();
+        render(() => (
+            <>
+                <button type="button">Background action</button>
+                <FilterToggleProgress />
+            </>
+        ));
+        const backgroundAction = screen.getByRole('button', { name: 'Background action' });
+
+        const togglePromise = toggleFilterStatus(filterURL, filterData, false);
+
+        const dialog = await screen.findByRole('dialog', {
+            name: intl.getMessage('filter_toggle_progress_title'),
+        });
+        expect(dialog).toHaveAttribute('aria-modal', 'true');
+        expect(dialog).toHaveAttribute('aria-busy', 'true');
+        await waitFor(() => {
+            expect(backgroundAction.closest('[aria-hidden="true"]')).not.toBeNull();
+            expect(dialog.contains(document.activeElement)).toBe(true);
+        });
+        expect(
+            screen.getByText(intl.getMessage('filter_toggle_progress_desc')),
+        ).toBeInTheDocument();
+
+        await user.keyboard('{Escape}');
+        expect(dialog).toBeInTheDocument();
+
+        request.resolve();
+        await waitFor(() => {
+            expect(filteringStatus).toHaveBeenCalledOnce();
+        });
+        expect(dialog).toBeInTheDocument();
+
+        status.resolve({});
+        await togglePromise;
+
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+    });
+
+    it('keeps edit progress visible until the refreshed status is loaded', async () => {
+        const request = createDeferred<void>();
+        const status = createDeferred<Awaited<ReturnType<typeof filteringStatus>>>();
+        vi.mocked(filteringSetURL).mockReturnValue(request.promise);
+        vi.mocked(filteringStatus).mockReturnValue(status.promise);
+
+        render(() => <FilterToggleProgress />);
+        const editPromise = editFilter(filterURL, filterData, false);
+
+        const dialog = await screen.findByRole('dialog');
+        request.resolve();
+        await waitFor(() => {
+            expect(filteringStatus).toHaveBeenCalledOnce();
+        });
+        expect(dialog).toBeInTheDocument();
+
+        status.resolve({});
+        await editPromise;
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+        expect(filteringState.processingConfigFilter).toBe(false);
+    });
+
+    it.each([
+        ['toggle', () => toggleFilterStatus(filterURL, filterData, false)],
+        ['edit', () => editFilter(filterURL, filterData, false)],
+    ])('clears %s progress when the update request is rejected', async (_name, runAction) => {
+        const request = createDeferred<void>();
+        vi.mocked(filteringSetURL).mockReturnValue(request.promise);
+
+        render(() => <FilterToggleProgress />);
+        const actionPromise = runAction();
+
+        await screen.findByRole('dialog');
+        request.reject(new Error('request failed'));
+        await actionPromise;
+
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+        expect(filteringStatus).not.toHaveBeenCalled();
+        expect(filteringState.processingConfigFilter).toBe(false);
+    });
+
+    it('keeps progress visible until all overlapping updates finish', async () => {
+        const firstRequest = createDeferred<void>();
+        const secondRequest = createDeferred<void>();
+        vi.mocked(filteringSetURL)
+            .mockReturnValueOnce(firstRequest.promise)
+            .mockReturnValueOnce(secondRequest.promise);
+        vi.mocked(filteringStatus).mockResolvedValue({});
+
+        render(() => <FilterToggleProgress />);
+        const firstAction = toggleFilterStatus(filterURL, filterData, false);
+        const secondAction = editFilter(filterURL, filterData, false);
+
+        await screen.findByRole('dialog');
+        firstRequest.resolve();
+        await firstAction;
+
+        try {
+            expect(filteringState.processingConfigFilter).toBe(true);
+            expect(screen.getByRole('dialog')).toBeInTheDocument();
+        } finally {
+            secondRequest.resolve();
+            await secondAction;
+        }
+
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+        expect(filteringStatus).toHaveBeenCalledTimes(2);
+        expect(filteringState.processingConfigFilter).toBe(false);
+    });
+});

--- a/client_v2/src/components/App/index.tsx
+++ b/client_v2/src/components/App/index.tsx
@@ -13,6 +13,7 @@ import { Blocklists } from 'panel/components/FilterLists/Blocklists';
 import { LOCAL_STORAGE_KEYS, LocalStorageHelper } from 'panel/helpers/localStorageHelper';
 
 import { Allowlists } from 'panel/components/FilterLists/Allowlists';
+import { FilterToggleProgress } from 'panel/components/FilterLists/blocks/FilterToggleProgress';
 import { DNSRewrites } from 'panel/components/FilterLists/DNSRewrites';
 import { SetupGuide } from 'panel/components/SetupGuide';
 import { Dashboard } from 'panel/components/Dashboard';
@@ -119,6 +120,8 @@ const App = () => {
                     </div>
 
                     <Footer />
+
+                    <FilterToggleProgress />
 
                     <Toasts />
 

--- a/client_v2/src/components/FilterLists/blocks/FilterToggleProgress/FilterToggleProgress.module.pcss
+++ b/client_v2/src/components/FilterLists/blocks/FilterToggleProgress/FilterToggleProgress.module.pcss
@@ -1,0 +1,49 @@
+.backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 1600;
+    background-color: var(--modal-overlay);
+}
+
+.positioner {
+    position: fixed;
+    inset: 0;
+    z-index: 1601;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+}
+
+.content {
+    width: 100%;
+    max-width: 480px;
+    padding: 32px 24px;
+    color: var(--default-main-text);
+    text-align: center;
+    background: var(--default-page-background);
+    border-radius: 16px;
+    box-shadow: var(--main-box-shadow);
+    outline: 0;
+}
+
+.loader {
+    width: 56px;
+    height: 56px;
+    margin-bottom: 24px;
+    color: var(--default-product-icon);
+}
+
+.title {
+    margin: 0;
+    font-size: 24px;
+    font-weight: var(--weight-bold);
+    line-height: 28px;
+}
+
+.description {
+    margin: 16px 0 0;
+    color: var(--default-description-text);
+    font-size: var(--fs-text-t2);
+    line-height: var(--lh-t2-normal);
+}

--- a/client_v2/src/components/FilterLists/blocks/FilterToggleProgress/FilterToggleProgress.tsx
+++ b/client_v2/src/components/FilterLists/blocks/FilterToggleProgress/FilterToggleProgress.tsx
@@ -1,0 +1,39 @@
+import { Show } from 'solid-js';
+import { Portal } from 'solid-js/web';
+import { Dialog as ArkDialog } from '@ark-ui/solid';
+
+import intl from 'panel/common/intl';
+import { Loader } from 'panel/common/ui/Loader';
+import { filteringState } from 'panel/stores/filtering';
+
+import s from './FilterToggleProgress.module.pcss';
+
+export const FilterToggleProgress = () => (
+    <Show when={filteringState.processingConfigFilter}>
+        <ArkDialog.Root
+            open
+            closeOnEscape={false}
+            closeOnInteractOutside={false}
+            modal
+            preventScroll
+            trapFocus
+        >
+            <Portal>
+                <ArkDialog.Backdrop class={s.backdrop} />
+                <ArkDialog.Positioner class={s.positioner}>
+                    <ArkDialog.Content class={s.content} aria-busy="true">
+                        <div aria-hidden="true">
+                            <Loader class={s.loader} />
+                        </div>
+                        <ArkDialog.Title class={s.title}>
+                            {intl.getMessage('filter_toggle_progress_title')}
+                        </ArkDialog.Title>
+                        <ArkDialog.Description class={s.description}>
+                            {intl.getMessage('filter_toggle_progress_desc')}
+                        </ArkDialog.Description>
+                    </ArkDialog.Content>
+                </ArkDialog.Positioner>
+            </Portal>
+        </ArkDialog.Root>
+    </Show>
+);

--- a/client_v2/src/components/FilterLists/blocks/FilterToggleProgress/index.ts
+++ b/client_v2/src/components/FilterLists/blocks/FilterToggleProgress/index.ts
@@ -1,0 +1,1 @@
+export { FilterToggleProgress } from './FilterToggleProgress';

--- a/client_v2/src/stores/filtering.ts
+++ b/client_v2/src/stores/filtering.ts
@@ -67,6 +67,18 @@ const initialState: FilteringState = {
 
 const [state, setState] = createStore<FilteringState>(initialState);
 
+let processingConfigFilterCount = 0;
+
+const startProcessingConfigFilter = () => {
+    processingConfigFilterCount += 1;
+    setState('processingConfigFilter', true);
+};
+
+const finishProcessingConfigFilter = () => {
+    processingConfigFilterCount -= 1;
+    setState('processingConfigFilter', processingConfigFilterCount > 0);
+};
+
 export const getFilteringStatus = async () => {
     setState('processingFilters', true);
     try {
@@ -313,27 +325,28 @@ export const toggleFilterStatus = async (
     data: FilterSetUrlData,
     whitelist: boolean,
 ) => {
-    setState('processingConfigFilter', true);
+    startProcessingConfigFilter();
     try {
         await filteringSetURL({ url, data, whitelist });
-        setState('processingConfigFilter', false);
         await getFilteringStatus();
     } catch (error) {
         addErrorToast({ error });
-        setState('processingConfigFilter', false);
+    } finally {
+        finishProcessingConfigFilter();
     }
 };
 
 export const editFilter = async (url: string, data: FilterSetUrlData, whitelist: boolean) => {
-    setState('processingConfigFilter', true);
+    startProcessingConfigFilter();
     try {
         await filteringSetURL({ url, data, whitelist });
-        setState({ processingConfigFilter: false, isModalOpen: false });
+        setState('isModalOpen', false);
         addSuccessToast(intl.getMessage('changes_saved_success'));
         await getFilteringStatus();
     } catch (error) {
         addErrorToast({ error });
-        setState('processingConfigFilter', false);
+    } finally {
+        finishProcessingConfigFilter();
     }
 };
 

--- a/internal/filtering/filter.go
+++ b/internal/filtering/filter.go
@@ -662,14 +662,24 @@ func (d *DNSFilter) load(ctx context.Context, flt *FilterYAML) (err error) {
 
 // EnableFilters enables filters.
 func (d *DNSFilter) EnableFilters(async bool) {
+	ctx := context.TODO()
+	err := d.enableFilters(ctx, async)
+	if err != nil {
+		d.logger.ErrorContext(ctx, "enabling filters", slogutil.KeyError, err)
+	}
+}
+
+// enableFilters enables filters and returns any filtering-engine initialization
+// error to the caller.
+func (d *DNSFilter) enableFilters(ctx context.Context, async bool) (err error) {
 	d.conf.filtersMu.RLock()
 	defer d.conf.filtersMu.RUnlock()
 
-	d.enableFiltersLocked(context.TODO(), async)
+	return d.enableFiltersLocked(ctx, async)
 }
 
 // enableFiltersLocked enables filters under the conf.filtersMu lock.
-func (d *DNSFilter) enableFiltersLocked(ctx context.Context, async bool) {
+func (d *DNSFilter) enableFiltersLocked(ctx context.Context, async bool) (err error) {
 	filters := make([]Filter, 1, len(d.conf.Filters)+len(d.conf.WhitelistFilters)+1)
 	filters[0] = Filter{
 		ID:   rulelist.IDCustom,
@@ -699,12 +709,10 @@ func (d *DNSFilter) enableFiltersLocked(ctx context.Context, async bool) {
 		})
 	}
 
-	err := d.setFilters(ctx, filters, allowFilters, async)
-	if err != nil {
-		d.logger.ErrorContext(ctx, "enabling filters", slogutil.KeyError, err)
-	}
-
+	err = d.setFilters(ctx, filters, allowFilters, async)
 	d.SetEnabled(d.conf.FilteringEnabled)
+
+	return err
 }
 
 // ApplyAdditionalFiltering enhances the provided filtering settings with

--- a/internal/filtering/filtering.go
+++ b/internal/filtering/filtering.go
@@ -236,6 +236,8 @@ type Stats struct {
 type filtersInitializerParams struct {
 	allowFilters []Filter
 	blockFilters []Filter
+
+	generation uint64
 }
 
 type hostChecker struct {
@@ -293,8 +295,10 @@ type DNSFilter struct {
 	done chan struct{}
 
 	// Channel for passing data to filters-initializer goroutine
-	filtersInitializerChan chan filtersInitializerParams
-	filtersInitializerLock sync.Mutex
+	filtersInitializerChan       chan filtersInitializerParams
+	filtersInitializerGeneration uint64
+	filtersInitializerLock       sync.Mutex
+	filtersInitializerRunLock    sync.Mutex
 
 	refreshLock *sync.Mutex
 
@@ -351,6 +355,19 @@ func (d *DNSFilter) WriteDiskConfig(c *Config) {
 	c.UserRules = slices.Clone(d.conf.UserRules)
 }
 
+// discardPendingFilterInitializers discards all queued filter engine snapshots.
+// d.filtersInitializerLock must be locked.
+func (d *DNSFilter) discardPendingFilterInitializers() {
+	for {
+		select {
+		case <-d.filtersInitializerChan:
+			// Continue removing.
+		default:
+			return
+		}
+	}
+}
+
 // setFilters sets new filters, synchronously or asynchronously.  When filters
 // are set asynchronously, the old filters continue working until the new
 // filters are ready.
@@ -363,31 +380,53 @@ func (d *DNSFilter) setFilters(
 	async bool,
 ) (err error) {
 	if async {
-		params := filtersInitializerParams{
-			allowFilters: allowFilters,
-			blockFilters: blockFilters,
-		}
-
 		d.filtersInitializerLock.Lock()
 		defer d.filtersInitializerLock.Unlock()
 
-		// Remove all pending tasks.
-	removeLoop:
-		for {
-			select {
-			case <-d.filtersInitializerChan:
-				// Continue removing.
-			default:
-				break removeLoop
-			}
+		d.filtersInitializerGeneration++
+		params := filtersInitializerParams{
+			allowFilters: allowFilters,
+			blockFilters: blockFilters,
+			generation:   d.filtersInitializerGeneration,
 		}
 
+		d.discardPendingFilterInitializers()
 		d.filtersInitializerChan <- params
 
 		return nil
 	}
 
+	d.filtersInitializerRunLock.Lock()
+	defer d.filtersInitializerRunLock.Unlock()
+
+	d.filtersInitializerLock.Lock()
+	d.filtersInitializerGeneration++
+
+	// Remove all pending asynchronous snapshots, since this synchronous rebuild
+	// supersedes them.
+	d.discardPendingFilterInitializers()
+	d.filtersInitializerLock.Unlock()
+
 	return d.initFiltering(ctx, allowFilters, blockFilters)
+}
+
+// initFilteringAsync initializes the filtering engine from params unless a
+// newer snapshot has superseded it.
+func (d *DNSFilter) initFilteringAsync(
+	ctx context.Context,
+	params filtersInitializerParams,
+) (err error) {
+	d.filtersInitializerRunLock.Lock()
+	defer d.filtersInitializerRunLock.Unlock()
+
+	d.filtersInitializerLock.Lock()
+	isCurrent := params.generation == d.filtersInitializerGeneration
+	d.filtersInitializerLock.Unlock()
+	if !isCurrent {
+		return nil
+	}
+
+	return d.initFiltering(ctx, params.allowFilters, params.blockFilters)
 }
 
 // Close - close the object
@@ -1093,7 +1132,7 @@ func (d *DNSFilter) updatesLoop(ctx context.Context) {
 	for {
 		select {
 		case params := <-d.filtersInitializerChan:
-			err := d.initFiltering(ctx, params.allowFilters, params.blockFilters)
+			err := d.initFilteringAsync(ctx, params)
 			if err != nil {
 				d.logger.ErrorContext(ctx, "initializing", slogutil.KeyError, err)
 

--- a/internal/filtering/http.go
+++ b/internal/filtering/http.go
@@ -334,7 +334,9 @@ func (d *DNSFilter) handleFilteringSetURL(w http.ResponseWriter, r *http.Request
 
 	d.conf.ConfModifier.Apply(ctx)
 	if restart {
-		d.EnableFilters(true)
+		// Rebuild synchronously so that the response reports completion only
+		// after the new filtering engine is ready.
+		d.EnableFilters(false)
 	}
 }
 

--- a/internal/filtering/http.go
+++ b/internal/filtering/http.go
@@ -336,7 +336,18 @@ func (d *DNSFilter) handleFilteringSetURL(w http.ResponseWriter, r *http.Request
 	if restart {
 		// Rebuild synchronously so that the response reports completion only
 		// after the new filtering engine is ready.
-		d.EnableFilters(false)
+		err = d.enableFilters(ctx, false)
+		if err != nil {
+			aghhttp.ErrorAndLog(
+				ctx,
+				l,
+				r,
+				w,
+				http.StatusInternalServerError,
+				"enabling filters: %s",
+				err,
+			)
+		}
 	}
 }
 

--- a/internal/filtering/http_internal_test.go
+++ b/internal/filtering/http_internal_test.go
@@ -319,6 +319,69 @@ func TestDNSFilter_handleFilteringSetURLSupersedesQueuedEngine(t *testing.T) {
 	d.checkMatchEmpty(t, hostname, setts)
 }
 
+func TestDNSFilter_handleFilteringSetURLReportsEngineError(t *testing.T) {
+	const (
+		oldHostname = "old.example"
+		newHostname = "new.example"
+	)
+
+	disabledURL := serveFiltersLocally(t, []byte("||"+newHostname+"^"))
+	d, err := New(&Config{
+		Logger:           testLogger,
+		FilteringEnabled: true,
+		Filters: []FilterYAML{{
+			Enabled: false,
+			URL:     disabledURL,
+			Name:    "disabled",
+		}, {
+			Enabled: true,
+			URL:     "https://filters.example.org/enabled.txt",
+			Name:    "enabled",
+		}},
+		ConfModifier: agh.EmptyConfigModifier{},
+		HTTPReg:      aghhttp.EmptyRegistrar{},
+		HTTPClient:   http.DefaultClient,
+		DataDir:      t.TempDir(),
+		MaxHTTPSize:  testFilterSize,
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(d.Close)
+
+	// Install a known-good engine, then make the configured snapshot invalid so
+	// that enabling the list through the handler fails during engine creation.
+	require.NoError(t, d.setFilters(t.Context(), []Filter{{
+		ID:   d.idGen.next(),
+		Data: []byte("||" + oldHostname + "^"),
+	}}, nil, false))
+	d.conf.Filters[0].ID = d.conf.Filters[1].ID
+
+	setts := &Settings{
+		ProtectionEnabled: true,
+		FilteringEnabled:  true,
+	}
+	d.checkMatch(t, oldHostname, setts)
+
+	reqData := &filterURLReq{
+		Data: &filterURLReqData{
+			Name:    "disabled",
+			URL:     disabledURL,
+			Enabled: true,
+		},
+		URL: disabledURL,
+	}
+	data, err := json.Marshal(reqData)
+	require.NoError(t, err)
+
+	r := httptest.NewRequest(http.MethodPost, "http://example.org", bytes.NewReader(data))
+	w := httptest.NewRecorder()
+	d.handleFilteringSetURL(w, r)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "enabling filters")
+	d.checkMatch(t, oldHostname, setts)
+	d.checkMatchEmpty(t, newHostname, setts)
+}
+
 func TestDNSFilter_handleSafeBrowsingStatus(t *testing.T) {
 	const (
 		testTimeout = time.Second

--- a/internal/filtering/http_internal_test.go
+++ b/internal/filtering/http_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AdguardTeam/AdGuardHome/internal/agh"
 	"github.com/AdguardTeam/AdGuardHome/internal/aghhttp"
 	"github.com/AdguardTeam/AdGuardHome/internal/aghtest"
 	"github.com/AdguardTeam/AdGuardHome/internal/schedule"
@@ -150,6 +151,172 @@ func TestDNSFilter_handleFilteringSetURL(t *testing.T) {
 			assert.Equal(t, tc.wantBody == "", confModifiedCalled)
 		})
 	}
+}
+
+func TestDNSFilter_handleFilteringSetURLWaitsForEngine(t *testing.T) {
+	const filterURL = "https://filters.example.org/filter.txt"
+
+	filtersDir := t.TempDir()
+	confApplied := make(chan struct{})
+	confModifier := &aghtest.ConfigModifier{
+		OnApply: func(_ context.Context) {
+			close(confApplied)
+		},
+	}
+
+	d, err := New(&Config{
+		Logger:           testLogger,
+		FilteringEnabled: true,
+		Filters: []FilterYAML{{
+			Enabled: true,
+			URL:     filterURL,
+			Name:    "example",
+		}},
+		ConfModifier: confModifier,
+		HTTPReg:      aghhttp.EmptyRegistrar{},
+		DataDir:      filtersDir,
+		MaxHTTPSize:  testFilterSize,
+	}, nil)
+	require.NoError(t, err)
+
+	// Initialize the asynchronous queue without starting its consumer.  This
+	// makes the previous fire-and-forget behavior return immediately while the
+	// synchronous behavior below is blocked at the engine swap.
+	d.filtersInitializerChan = make(chan filtersInitializerParams, 1)
+
+	d.engineLock.RLock()
+	engineLocked := true
+	t.Cleanup(func() {
+		if engineLocked {
+			d.engineLock.RUnlock()
+		}
+
+		d.Close()
+	})
+
+	reqData := &filterURLReq{
+		Data: &filterURLReqData{
+			Name:    "example",
+			URL:     filterURL,
+			Enabled: false,
+		},
+		URL: filterURL,
+	}
+	data, err := json.Marshal(reqData)
+	require.NoError(t, err)
+
+	r := httptest.NewRequest(http.MethodPost, "http://example.org", bytes.NewReader(data))
+	w := httptest.NewRecorder()
+	handlerDone := make(chan struct{})
+	go func() {
+		d.handleFilteringSetURL(w, r)
+		close(handlerDone)
+	}()
+
+	testutil.RequireReceive(t, confApplied, testTimeout)
+
+	deadline := time.NewTimer(testTimeout)
+	defer deadline.Stop()
+
+	for d.engineLock.TryRLock() {
+		d.engineLock.RUnlock()
+
+		select {
+		case <-handlerDone:
+			require.FailNow(t, "handler returned before the filtering engine was rebuilt")
+		case <-deadline.C:
+			require.FailNow(t, "filtering engine rebuild did not reach the engine swap")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	select {
+	case <-handlerDone:
+		require.FailNow(t, "handler returned while the filtering engine rebuild was blocked")
+	default:
+	}
+
+	d.engineLock.RUnlock()
+	engineLocked = false
+	testutil.RequireReceive(t, handlerDone, testTimeout)
+	assert.Empty(t, w.Body.String())
+}
+
+func TestDNSFilter_handleFilteringSetURLSupersedesQueuedEngine(t *testing.T) {
+	const hostname = "example.org"
+
+	filterURL := serveFiltersLocally(t, []byte("||"+hostname+"^"))
+	d, err := New(&Config{
+		Logger:           testLogger,
+		FilteringEnabled: true,
+		Filters: []FilterYAML{{
+			Enabled: true,
+			URL:     filterURL,
+			Name:    "example",
+			Filter: Filter{
+				ID: 1,
+			},
+		}},
+		ConfModifier: agh.EmptyConfigModifier{},
+		HTTPReg:      aghhttp.EmptyRegistrar{},
+		HTTPClient:   http.DefaultClient,
+		DataDir:      t.TempDir(),
+		MaxHTTPSize:  testFilterSize,
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(d.Close)
+
+	updated, err := d.update(&d.conf.Filters[0])
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	setts := &Settings{
+		ProtectionEnabled: true,
+		FilteringEnabled:  true,
+	}
+	d.EnableFilters(false)
+	d.checkMatch(t, hostname, setts)
+
+	// Simulate an asynchronous initializer that has already received an older
+	// enabled snapshot but has not rebuilt the engine yet.
+	d.filtersInitializerChan = make(chan filtersInitializerParams, 1)
+	d.EnableFilters(true)
+	staleParams, ok := testutil.RequireReceive(t, d.filtersInitializerChan, testTimeout)
+	require.True(t, ok)
+	require.Len(t, staleParams.blockFilters, 2)
+
+	// Also leave an older snapshot queued, to verify that the synchronous
+	// update discards snapshots that the worker has not received yet.
+	d.EnableFilters(true)
+
+	reqData := &filterURLReq{
+		Data: &filterURLReqData{
+			Name:    "example",
+			URL:     filterURL,
+			Enabled: false,
+		},
+		URL: filterURL,
+	}
+	data, err := json.Marshal(reqData)
+	require.NoError(t, err)
+
+	r := httptest.NewRequest(http.MethodPost, "http://example.org", bytes.NewReader(data))
+	w := httptest.NewRecorder()
+	d.handleFilteringSetURL(w, r)
+	require.Empty(t, w.Body.String())
+	d.checkMatchEmpty(t, hostname, setts)
+
+	select {
+	case <-d.filtersInitializerChan:
+		require.FailNow(t, "synchronous rebuild left an older snapshot queued")
+	default:
+	}
+
+	// A worker that received the older snapshot before the synchronous update
+	// must not restore that stale engine afterwards.
+	require.NoError(t, d.initFilteringAsync(t.Context(), staleParams))
+	d.checkMatchEmpty(t, hostname, setts)
 }
 
 func TestDNSFilter_handleSafeBrowsingStatus(t *testing.T) {


### PR DESCRIPTION
## Summary

- wait for the filtering engine rebuild before a filter enable/disable request
  completes
- serialize rebuilds and invalidate queued or already-received stale snapshots
  so an older asynchronous rebuild cannot restore the previous filter state
- show a modal, focus-trapped progress overlay while filter toggles or edits are
  still applying
- count overlapping frontend operations so the overlay remains until every
  update and status refresh has finished

This keeps the UI from accepting conflicting actions while the old filtering
engine is still active and makes the rebuild state visible to the user.

Closes #667.

## Validation

- `go test -race -count=20 -run '^(TestDNSFilter_handleFilteringSetURLWaitsForEngine|TestDNSFilter_handleFilteringSetURLSupersedesQueuedEngine)$' ./internal/filtering`
- `go test -race -count=1 ./internal/filtering`
- `make go-check`
- `NODE_OPTIONS=--no-experimental-webstorage npm run test -- src/__tests__/filter-toggle-progress.test.tsx`
- `NODE_OPTIONS=--no-experimental-webstorage npm run check`
- `NODE_OPTIONS=--no-experimental-webstorage npm run build-prod`
- `make md-lint`
- `npm run translations:check`

The focused frontend suite has five deterministic cases covering toggle, edit,
request failure, status-refresh completion, modal behavior, and overlapping
updates.  The full frontend gate passed 624 tests, and the production build
compiled 2,345 modules.

`npm run locales:check` still reports the repository's existing stale
`locales.generated.ts`; this change adds English strings but does not change
the locale list, Twosky configuration, or generated imports.
