### PR TITLE
client: hide disabled dashboard feature statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 - The `edge` channel has been switched to the new UI and versioning scheme.
 
+- The dashboard no longer shows zero-valued statistics for disabled Safe
+  Browsing, Parental Control, and Safe Search features ([#689]).
+
 ### Deprecated
 
 - `strict_sni_check` is now deprecated.
@@ -45,6 +48,7 @@ NOTE: Add new changes BELOW THIS COMMENT.
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
+[#689]:  https://github.com/AdguardTeam/AdGuardHome/issues/689
 
 <!--
 NOTE: Add new changes ABOVE THIS COMMENT.

--- a/client_v2/src/__tests__/dashboard-feature-stats.test.tsx
+++ b/client_v2/src/__tests__/dashboard-feature-stats.test.tsx
@@ -1,0 +1,440 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library';
+
+const mocks = vi.hoisted(() => ({
+    initSettings: vi.fn(),
+    getStats: vi.fn(),
+    getStatsConfig: vi.fn(),
+    getClients: vi.fn(),
+    getAccessList: vi.fn(),
+    toggleProtection: vi.fn(),
+    setSettingsState: vi.fn(),
+    statsState: {
+        processingStats: false,
+        processingGetConfig: false,
+        interval: 24 * 60 * 60 * 1000,
+        enabled: true,
+        numDnsQueries: 10,
+        numBlockedFiltering: 2,
+        numReplacedSafebrowsing: 0,
+        numReplacedParental: 0,
+        numReplacedSafesearch: 0,
+        avgProcessingTime: 1,
+        dnsQueries: [10],
+        blockedFiltering: [2],
+        replacedSafebrowsing: [] as number[],
+        replacedParental: [] as number[],
+        topClients: [] as never[],
+        topQueriedDomains: [] as never[],
+        topBlockedDomains: [] as never[],
+        topUpstreamsResponses: [] as never[],
+        topUpstreamsAvgTime: [] as never[],
+    },
+}));
+
+vi.mock('panel/common/intl', () => ({
+    default: {
+        getMessage: (key: string) => key,
+        getPlural: (key: string) => key,
+        getUILanguage: () => 'en',
+    },
+}));
+
+vi.mock('panel/lib/theme', () => ({
+    default: {
+        layout: { container: '', containerIn: '' },
+        title: { h5: '' },
+        text: { t3: '' },
+    },
+}));
+
+vi.mock('panel/common/ui/Loader', () => ({
+    PageLoader: () => <div data-testid="page-loader" />,
+}));
+
+vi.mock('panel/stores/dashboard', () => ({
+    dashboardState: {
+        protectionEnabled: true,
+        protectionDisabledDuration: null,
+        processingProtection: false,
+    },
+    toggleProtection: mocks.toggleProtection,
+    getClients: mocks.getClients,
+}));
+
+vi.mock('panel/stores/stats', () => ({
+    get statsState() {
+        return mocks.statsState;
+    },
+    getStats: mocks.getStats,
+    getStatsConfig: mocks.getStatsConfig,
+}));
+
+vi.mock('panel/stores/access', () => ({
+    accessState: { processing: false },
+    getAccessList: mocks.getAccessList,
+}));
+
+vi.mock('panel/stores/settings', async () => {
+    const { createStore } = await import('solid-js/store');
+    const [settingsState, setSettingsState] = createStore({
+        loadStatus: 'idle' as FeatureLoadStatus,
+        processing: true,
+        settingsList: {
+            safebrowsing: { enabled: false as boolean | undefined },
+            parental: { enabled: false as boolean | undefined },
+            safesearch: { enabled: false as boolean | undefined },
+        },
+    });
+
+    mocks.setSettingsState.mockImplementation((state: FeatureState) => {
+        setSettingsState(state);
+    });
+
+    return {
+        settingsState,
+        initSettings: mocks.initSettings,
+    };
+});
+
+vi.mock('panel/components/Dashboard/blocks/Header/Header', () => ({
+    Header: (props: { onPeriodChange: (period: number) => void }) => (
+        <button type="button" onClick={() => props.onPeriodChange(2 * 24 * 60 * 60 * 1000)}>
+            change period
+        </button>
+    ),
+    getPeriodLabel: (period: number) => String(period),
+}));
+
+vi.mock('panel/components/Dashboard/blocks/StatCard', () => ({
+    CARDS_THEME: {
+        QUERIES: 'queries',
+        ADS: 'ads',
+        THREATS: 'threats',
+        ADULT: 'adult',
+    },
+    CARDS_COLORS: {
+        QUERIES: '',
+        ADS: '',
+        THREATS: '',
+        ADULT: '',
+    },
+    StatCard: (props: { cardTheme: string }) => (
+        <div data-testid={`stat-card-${props.cardTheme}`} />
+    ),
+}));
+
+vi.mock('panel/components/Dashboard/blocks/StatRow', () => ({
+    StatRow: (props: { rowTheme: string }) => <div data-testid={`stat-row-${props.rowTheme}`} />,
+}));
+
+vi.mock('panel/components/Dashboard/blocks/EmptyState', () => ({
+    EmptyState: () => <div data-testid="empty-state" />,
+}));
+
+vi.mock('panel/components/Dashboard/blocks/TopClients', () => ({
+    TopClients: (): null => null,
+}));
+vi.mock('panel/components/Dashboard/blocks/TopQueriedDomains', () => ({
+    TopQueriedDomains: (): null => null,
+}));
+vi.mock('panel/components/Dashboard/blocks/TopBlockedDomains', () => ({
+    TopBlockedDomains: (): null => null,
+}));
+vi.mock('panel/components/Dashboard/blocks/TopUpstreams', () => ({
+    TopUpstreams: (): null => null,
+}));
+vi.mock('panel/components/Dashboard/blocks/UpstreamAvgTime', () => ({
+    UpstreamAvgTime: (): null => null,
+}));
+
+import { Dashboard } from 'panel/components/Dashboard/Dashboard';
+
+type FeatureLoadStatus = 'idle' | 'loading' | 'loaded' | 'failed';
+
+type FeatureState = {
+    loadStatus: FeatureLoadStatus;
+    processing: boolean;
+    settingsList: {
+        safebrowsing: { enabled: boolean | undefined };
+        parental: { enabled: boolean | undefined };
+        safesearch: { enabled: boolean | undefined };
+    };
+};
+
+const setFeatureState = (
+    loadStatus: FeatureLoadStatus,
+    enabled: {
+        safebrowsing: boolean | undefined;
+        parental: boolean | undefined;
+        safesearch: boolean | undefined;
+    },
+) => {
+    mocks.setSettingsState({
+        loadStatus,
+        processing: loadStatus === 'idle' || loadStatus === 'loading',
+        settingsList: {
+            safebrowsing: { enabled: enabled.safebrowsing },
+            parental: { enabled: enabled.parental },
+            safesearch: { enabled: enabled.safesearch },
+        },
+    });
+};
+
+const setFeatureMetrics = ({
+    safebrowsingScalar = 0,
+    safebrowsingSeries = [],
+    parentalScalar = 0,
+    parentalSeries = [],
+    safesearchScalar = 0,
+}: {
+    safebrowsingScalar?: number;
+    safebrowsingSeries?: number[];
+    parentalScalar?: number;
+    parentalSeries?: number[];
+    safesearchScalar?: number;
+} = {}) => {
+    mocks.statsState.numReplacedSafebrowsing = safebrowsingScalar;
+    mocks.statsState.replacedSafebrowsing = safebrowsingSeries;
+    mocks.statsState.numReplacedParental = parentalScalar;
+    mocks.statsState.replacedParental = parentalSeries;
+    mocks.statsState.numReplacedSafesearch = safesearchScalar;
+};
+
+const deferred = <T,>() => {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+
+    return { promise, reject, resolve };
+};
+
+const expectCoreStats = () => {
+    expect(screen.getByTestId('stat-card-queries')).toBeInTheDocument();
+    expect(screen.getByTestId('stat-card-ads')).toBeInTheDocument();
+    expect(screen.getByTestId('stat-row-dnsQueries')).toBeInTheDocument();
+    expect(screen.getByTestId('stat-row-adsBlocked')).toBeInTheDocument();
+    expect(screen.getByTestId('stat-row-averageProcessingTime')).toBeInTheDocument();
+};
+
+const expectAllFeatureStats = () => {
+    expect(screen.getByTestId('stat-card-threats')).toBeInTheDocument();
+    expect(screen.getByTestId('stat-card-adult')).toBeInTheDocument();
+    expect(screen.getByTestId('stat-row-threatsBlocked')).toBeInTheDocument();
+    expect(screen.getByTestId('stat-row-adultWebsitesBlocked')).toBeInTheDocument();
+    expect(screen.getByTestId('stat-row-safeSearchUsed')).toBeInTheDocument();
+};
+
+describe('Dashboard feature statistics', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.initSettings.mockReset();
+        setFeatureMetrics();
+        setFeatureState('idle', {
+            safebrowsing: false,
+            parental: false,
+            safesearch: false,
+        });
+    });
+
+    it.each(['idle', 'loading', 'failed'] as const)(
+        'keeps feature statistics visible while status is %s',
+        (loadStatus) => {
+            setFeatureState(loadStatus, {
+                safebrowsing: false,
+                parental: false,
+                safesearch: false,
+            });
+
+            render(() => <Dashboard />);
+
+            expectCoreStats();
+            expectAllFeatureStats();
+        },
+    );
+
+    it('keeps enabled feature statistics visible after status loads', () => {
+        setFeatureState('loaded', {
+            safebrowsing: true,
+            parental: true,
+            safesearch: true,
+        });
+
+        render(() => <Dashboard />);
+
+        expectCoreStats();
+        expectAllFeatureStats();
+    });
+
+    it('keeps feature statistics visible when a loaded response omits a status', () => {
+        setFeatureState('loaded', {
+            safebrowsing: undefined,
+            parental: undefined,
+            safesearch: undefined,
+        });
+
+        render(() => <Dashboard />);
+
+        expectCoreStats();
+        expectAllFeatureStats();
+    });
+
+    it('hides disabled feature statistics after status loads', () => {
+        setFeatureState('loaded', {
+            safebrowsing: false,
+            parental: false,
+            safesearch: false,
+        });
+
+        render(() => <Dashboard />);
+
+        expectCoreStats();
+        expect(screen.queryByTestId('stat-card-threats')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('stat-card-adult')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('stat-row-threatsBlocked')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('stat-row-adultWebsitesBlocked')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('stat-row-safeSearchUsed')).not.toBeInTheDocument();
+    });
+
+    it('keeps disabled feature statistics visible when their scalar count is nonzero', () => {
+        setFeatureMetrics({
+            safebrowsingScalar: 1,
+            parentalScalar: 1,
+            safesearchScalar: 1,
+        });
+        setFeatureState('loaded', {
+            safebrowsing: false,
+            parental: false,
+            safesearch: false,
+        });
+
+        render(() => <Dashboard />);
+
+        expectCoreStats();
+        expectAllFeatureStats();
+    });
+
+    it('keeps disabled feature statistics visible when their series contains data', () => {
+        setFeatureMetrics({
+            safebrowsingSeries: [0, 1],
+            parentalSeries: [1, 0],
+        });
+        setFeatureState('loaded', {
+            safebrowsing: false,
+            parental: false,
+            safesearch: false,
+        });
+
+        render(() => <Dashboard />);
+
+        expectCoreStats();
+        expect(screen.getByTestId('stat-card-threats')).toBeInTheDocument();
+        expect(screen.getByTestId('stat-card-adult')).toBeInTheDocument();
+        expect(screen.getByTestId('stat-row-threatsBlocked')).toBeInTheDocument();
+        expect(screen.getByTestId('stat-row-adultWebsitesBlocked')).toBeInTheDocument();
+        expect(screen.queryByTestId('stat-row-safeSearchUsed')).not.toBeInTheDocument();
+    });
+
+    it('hides only disabled feature statistics in a mixed state', () => {
+        setFeatureState('loaded', {
+            safebrowsing: true,
+            parental: false,
+            safesearch: true,
+        });
+
+        render(() => <Dashboard />);
+
+        expectCoreStats();
+        expect(screen.getByTestId('stat-card-threats')).toBeInTheDocument();
+        expect(screen.queryByTestId('stat-card-adult')).not.toBeInTheDocument();
+        expect(screen.getByTestId('stat-row-threatsBlocked')).toBeInTheDocument();
+        expect(screen.queryByTestId('stat-row-adultWebsitesBlocked')).not.toBeInTheDocument();
+        expect(screen.getByTestId('stat-row-safeSearchUsed')).toBeInTheDocument();
+    });
+
+    it('initializes feature status once without refetching it for a period change', () => {
+        render(() => <Dashboard />);
+
+        expect(mocks.initSettings).toHaveBeenCalledOnce();
+        fireEvent.click(screen.getByRole('button', { name: 'change period' }));
+        expect(mocks.initSettings).toHaveBeenCalledOnce();
+    });
+
+    it.each(['loading', 'loaded'] as const)(
+        'does not duplicate feature status initialization while status is %s',
+        (loadStatus) => {
+            setFeatureState(loadStatus, {
+                safebrowsing: false,
+                parental: false,
+                safesearch: false,
+            });
+
+            render(() => <Dashboard />);
+
+            expect(mocks.initSettings).not.toHaveBeenCalled();
+        },
+    );
+
+    it('reactively hides zero-valued feature statistics after disabled status loads', async () => {
+        const status = deferred<void>();
+        mocks.initSettings.mockImplementation(async () => {
+            setFeatureState('loading', {
+                safebrowsing: false,
+                parental: false,
+                safesearch: false,
+            });
+            await status.promise;
+            setFeatureState('loaded', {
+                safebrowsing: false,
+                parental: false,
+                safesearch: false,
+            });
+        });
+
+        render(() => <Dashboard />);
+
+        expectAllFeatureStats();
+        const request = mocks.initSettings.mock.results[0].value as Promise<void>;
+        status.resolve();
+        await request;
+
+        await waitFor(() => {
+            expect(screen.queryByTestId('stat-card-threats')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('stat-card-adult')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('stat-row-threatsBlocked')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('stat-row-adultWebsitesBlocked')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('stat-row-safeSearchUsed')).not.toBeInTheDocument();
+        });
+    });
+
+    it('keeps zero-valued feature statistics visible when status loading fails', async () => {
+        const status = deferred<void>();
+        mocks.initSettings.mockImplementation(async () => {
+            setFeatureState('loading', {
+                safebrowsing: false,
+                parental: false,
+                safesearch: false,
+            });
+            await status.promise;
+            setFeatureState('failed', {
+                safebrowsing: false,
+                parental: false,
+                safesearch: false,
+            });
+        });
+
+        render(() => <Dashboard />);
+
+        expectAllFeatureStats();
+        const request = mocks.initSettings.mock.results[0].value as Promise<void>;
+        status.resolve();
+        await request;
+
+        await waitFor(() => {
+            expectAllFeatureStats();
+        });
+    });
+});

--- a/client_v2/src/__tests__/settings-store.test.ts
+++ b/client_v2/src/__tests__/settings-store.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    safebrowsingStatus: vi.fn(),
+    parentalStatus: vi.fn(),
+    safesearchStatus: vi.fn(),
+    addErrorToast: vi.fn(),
+}));
+
+vi.mock('panel/api/generated', () => ({
+    safebrowsingStatus: mocks.safebrowsingStatus,
+    safebrowsingEnable: vi.fn(),
+    safebrowsingDisable: vi.fn(),
+    parentalStatus: mocks.parentalStatus,
+    parentalEnable: vi.fn(),
+    parentalDisable: vi.fn(),
+    safesearchStatus: mocks.safesearchStatus,
+    safesearchSettings: vi.fn(),
+    testUpstreamDNS: vi.fn(),
+}));
+
+vi.mock('panel/stores/toasts', () => ({
+    addErrorToast: mocks.addErrorToast,
+    addSuccessToast: vi.fn(),
+}));
+
+vi.mock('panel/common/intl', () => ({
+    default: { getMessage: (key: string) => key },
+}));
+
+const loadStore = async () => {
+    vi.resetModules();
+    return import('panel/stores/settings');
+};
+
+const deferred = <T>() => {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+
+    return { promise, reject, resolve };
+};
+
+describe('settings status initialization', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.safebrowsingStatus.mockResolvedValue({ enabled: true });
+        mocks.parentalStatus.mockResolvedValue({ enabled: false });
+        mocks.safesearchStatus.mockResolvedValue({ enabled: true, google: true });
+    });
+
+    it('starts with feature status unknown', async () => {
+        const { settingsState } = await loadStore();
+
+        expect(settingsState.loadStatus).toBe('idle');
+    });
+
+    it('marks feature status loaded only after all status requests succeed', async () => {
+        const { initSettings, settingsState } = await loadStore();
+
+        const request = initSettings();
+        expect(settingsState.loadStatus).toBe('loading');
+
+        await request;
+
+        expect(settingsState.loadStatus).toBe('loaded');
+        expect(settingsState.processing).toBe(false);
+        expect(settingsState.settingsList).toEqual({
+            safebrowsing: { enabled: true },
+            parental: { enabled: false },
+            safesearch: { enabled: true, google: true },
+        });
+    });
+
+    it('marks feature status failed when any status request fails', async () => {
+        const error = new Error('status unavailable');
+        mocks.parentalStatus.mockRejectedValue(error);
+        const { initSettings, settingsState } = await loadStore();
+
+        await initSettings();
+
+        expect(settingsState.loadStatus).toBe('failed');
+        expect(settingsState.processing).toBe(false);
+        expect(mocks.addErrorToast).toHaveBeenCalledWith({ error });
+    });
+
+    it('does not let an older successful request overwrite a newer response', async () => {
+        const oldSafebrowsing = deferred<{ enabled: boolean }>();
+        const oldParental = deferred<{ enabled: boolean }>();
+        const oldSafesearch = deferred<{ enabled: boolean; google: boolean }>();
+        mocks.safebrowsingStatus
+            .mockImplementationOnce(() => oldSafebrowsing.promise)
+            .mockResolvedValueOnce({ enabled: false });
+        mocks.parentalStatus
+            .mockImplementationOnce(() => oldParental.promise)
+            .mockResolvedValueOnce({ enabled: true });
+        mocks.safesearchStatus
+            .mockImplementationOnce(() => oldSafesearch.promise)
+            .mockResolvedValueOnce({ enabled: false, google: false });
+        const { initSettings, settingsState } = await loadStore();
+
+        const olderRequest = initSettings();
+        const newerRequest = initSettings();
+        await newerRequest;
+        oldSafebrowsing.resolve({ enabled: true });
+        oldParental.resolve({ enabled: false });
+        oldSafesearch.resolve({ enabled: true, google: true });
+        await olderRequest;
+
+        expect(settingsState.loadStatus).toBe('loaded');
+        expect(settingsState.settingsList).toEqual({
+            safebrowsing: { enabled: false },
+            parental: { enabled: true },
+            safesearch: { enabled: false, google: false },
+        });
+    });
+
+    it('does not let an older failure replace a newer successful response', async () => {
+        const error = new Error('stale status failure');
+        const oldSafebrowsing = deferred<{ enabled: boolean }>();
+        const oldParental = deferred<{ enabled: boolean }>();
+        const oldSafesearch = deferred<{ enabled: boolean; google: boolean }>();
+        mocks.safebrowsingStatus
+            .mockImplementationOnce(() => oldSafebrowsing.promise)
+            .mockResolvedValueOnce({ enabled: false });
+        mocks.parentalStatus
+            .mockImplementationOnce(() => oldParental.promise)
+            .mockResolvedValueOnce({ enabled: true });
+        mocks.safesearchStatus
+            .mockImplementationOnce(() => oldSafesearch.promise)
+            .mockResolvedValueOnce({ enabled: false, google: false });
+        const { initSettings, settingsState } = await loadStore();
+
+        const olderRequest = initSettings();
+        const newerRequest = initSettings();
+        await newerRequest;
+        oldSafebrowsing.resolve({ enabled: true });
+        oldParental.reject(error);
+        oldSafesearch.resolve({ enabled: true, google: true });
+        await olderRequest;
+
+        expect(settingsState.loadStatus).toBe('loaded');
+        expect(settingsState.settingsList).toEqual({
+            safebrowsing: { enabled: false },
+            parental: { enabled: true },
+            safesearch: { enabled: false, google: false },
+        });
+        expect(mocks.addErrorToast).not.toHaveBeenCalled();
+    });
+});

--- a/client_v2/src/components/Dashboard/Dashboard.tsx
+++ b/client_v2/src/components/Dashboard/Dashboard.tsx
@@ -1,10 +1,11 @@
-import { createSignal, createMemo, createEffect, onCleanup, Show } from 'solid-js';
+import { createSignal, createMemo, createEffect, onCleanup, onMount, Show } from 'solid-js';
 
 import theme from 'panel/lib/theme';
 import { PageLoader } from 'panel/common/ui/Loader';
 import { dashboardState, toggleProtection, getClients } from 'panel/stores/dashboard';
 import { statsState, getStats, getStatsConfig } from 'panel/stores/stats';
 import { accessState, getAccessList } from 'panel/stores/access';
+import { initSettings, settingsState } from 'panel/stores/settings';
 import { ONE_SECOND_IN_MS, HOUR, DAY, STATS_INTERVALS_DAYS } from 'panel/helpers/constants';
 
 import { Header, getPeriodLabel } from './blocks/Header/Header';
@@ -23,6 +24,12 @@ export const Dashboard = () => {
     const [remainingTime, setRemainingTime] = createSignal<number | null>(null);
     const [selectedPeriod, setSelectedPeriod] = createSignal(DAY);
     let timerRef: ReturnType<typeof setInterval> | null = null;
+
+    onMount(() => {
+        if (settingsState.loadStatus === 'idle' || settingsState.loadStatus === 'failed') {
+            initSettings();
+        }
+    });
 
     const startCountdown = (duration: number) => {
         if (timerRef) {
@@ -119,6 +126,25 @@ export const Dashboard = () => {
     const isLoading = () =>
         statsState.processingStats || statsState.processingGetConfig || accessState.processing;
 
+    const featureStatusLoaded = () => settingsState.loadStatus === 'loaded';
+    const hasFeatureStats = (count: number, series: number[]) =>
+        count !== 0 || series.some((value) => value !== 0);
+    const showSafebrowsingStats = () =>
+        !featureStatusLoaded() ||
+        settingsState.settingsList.safebrowsing.enabled !== false ||
+        hasFeatureStats(
+            statsState.numReplacedSafebrowsing,
+            statsState.replacedSafebrowsing,
+        );
+    const showParentalStats = () =>
+        !featureStatusLoaded() ||
+        settingsState.settingsList.parental.enabled !== false ||
+        hasFeatureStats(statsState.numReplacedParental, statsState.replacedParental);
+    const showSafesearchStats = () =>
+        !featureStatusLoaded() ||
+        settingsState.settingsList.safesearch.enabled !== false ||
+        statsState.numReplacedSafesearch !== 0;
+
     return (
         <div class={theme.layout.container}>
             <div class={theme.layout.containerIn}>
@@ -151,6 +177,8 @@ export const Dashboard = () => {
                         blockedFiltering={statsState.blockedFiltering}
                         replacedSafebrowsing={statsState.replacedSafebrowsing}
                         replacedParental={statsState.replacedParental}
+                        showSafebrowsing={showSafebrowsingStats()}
+                        showParental={showParentalStats()}
                     />
 
                     <Show
@@ -165,6 +193,9 @@ export const Dashboard = () => {
                                 numReplacedParental={statsState.numReplacedParental}
                                 numReplacedSafesearch={statsState.numReplacedSafesearch}
                                 avgProcessingTime={statsState.avgProcessingTime}
+                                showSafebrowsing={showSafebrowsingStats()}
+                                showParental={showParentalStats()}
+                                showSafesearch={showSafesearchStats()}
                             />
 
                             <TopClients

--- a/client_v2/src/components/Dashboard/blocks/GeneralStatistics/GeneralStatistics.tsx
+++ b/client_v2/src/components/Dashboard/blocks/GeneralStatistics/GeneralStatistics.tsx
@@ -16,6 +16,9 @@ type Props = {
     numReplacedParental: number;
     numReplacedSafesearch: number;
     avgProcessingTime: number;
+    showSafebrowsing: boolean;
+    showParental: boolean;
+    showSafesearch: boolean;
 };
 
 export const GeneralStatistics = (props: Props) => {
@@ -66,32 +69,38 @@ export const GeneralStatistics = (props: Props) => {
                         tooltip={intl.getMessage('ads_blocked_tooltip')}
                     />
 
-                    <StatRow
-                        label={intl.getMessage('threats_blocked')}
-                        value={props.numReplacedSafebrowsing}
-                        percent={safebrowsingPercent()}
-                        icon="tracking"
-                        rowTheme="threatsBlocked"
-                        tooltip={intl.getMessage('threats_blocked_tooltip')}
-                    />
+                    <Show when={props.showSafebrowsing}>
+                        <StatRow
+                            label={intl.getMessage('threats_blocked')}
+                            value={props.numReplacedSafebrowsing}
+                            percent={safebrowsingPercent()}
+                            icon="tracking"
+                            rowTheme="threatsBlocked"
+                            tooltip={intl.getMessage('threats_blocked_tooltip')}
+                        />
+                    </Show>
 
-                    <StatRow
-                        label={intl.getMessage('adult_websites_blocked')}
-                        value={props.numReplacedParental}
-                        percent={parentalPercent()}
-                        icon="parental"
-                        rowTheme="adultWebsitesBlocked"
-                        tooltip={intl.getMessage('adult_websites_blocked_tooltip')}
-                    />
+                    <Show when={props.showParental}>
+                        <StatRow
+                            label={intl.getMessage('adult_websites_blocked')}
+                            value={props.numReplacedParental}
+                            percent={parentalPercent()}
+                            icon="parental"
+                            rowTheme="adultWebsitesBlocked"
+                            tooltip={intl.getMessage('adult_websites_blocked_tooltip')}
+                        />
+                    </Show>
 
-                    <StatRow
-                        label={intl.getMessage('safe_search_used')}
-                        value={props.numReplacedSafesearch}
-                        percent={safesearchPercent()}
-                        icon="search"
-                        rowTheme="safeSearchUsed"
-                        tooltip={intl.getMessage('safe_search_used_tooltip')}
-                    />
+                    <Show when={props.showSafesearch}>
+                        <StatRow
+                            label={intl.getMessage('safe_search_used')}
+                            value={props.numReplacedSafesearch}
+                            percent={safesearchPercent()}
+                            icon="search"
+                            rowTheme="safeSearchUsed"
+                            tooltip={intl.getMessage('safe_search_used_tooltip')}
+                        />
+                    </Show>
 
                     <div class={s.rowDivider} />
 

--- a/client_v2/src/components/Dashboard/blocks/StatCards/StatCards.tsx
+++ b/client_v2/src/components/Dashboard/blocks/StatCards/StatCards.tsx
@@ -1,4 +1,5 @@
 import intl from 'panel/common/intl';
+import { Show } from 'solid-js';
 import { RoutePath } from 'panel/components/Routes/Paths';
 import { QUERY_LOG_REASON_FILTER, QUERY_LOG_STATUS_FILTER } from 'panel/helpers/constants';
 
@@ -14,6 +15,8 @@ type Props = {
     blockedFiltering: number[];
     replacedSafebrowsing: number[];
     replacedParental: number[];
+    showSafebrowsing: boolean;
+    showParental: boolean;
 };
 
 export const StatCards = (props: Props) => {
@@ -44,26 +47,30 @@ export const StatCards = (props: Props) => {
                 linkTo={RoutePath.QueryLog}
                 query={{ status: QUERY_LOG_STATUS_FILTER.BLOCKED.QUERY }}
             />
-            <StatCard
-                value={props.numReplacedSafebrowsing}
-                label={intl.getMessage('blocked_threats_chart')}
-                data={props.replacedSafebrowsing}
-                color={CARDS_COLORS.THREATS}
-                percentValue={threatsPercent()}
-                cardTheme={CARDS_THEME.THREATS}
-                linkTo={RoutePath.QueryLog}
-                query={{ reason: QUERY_LOG_REASON_FILTER.BLOCKED_BY_THREATS.QUERY }}
-            />
-            <StatCard
-                value={props.numReplacedParental}
-                label={intl.getMessage('stats_adult')}
-                data={props.replacedParental}
-                color={CARDS_COLORS.ADULT}
-                percentValue={parentalPercent()}
-                cardTheme={CARDS_THEME.ADULT}
-                linkTo={RoutePath.QueryLog}
-                query={{ reason: QUERY_LOG_REASON_FILTER.BLOCKED_BY_PARENTAL_CONTROL.QUERY }}
-            />
+            <Show when={props.showSafebrowsing}>
+                <StatCard
+                    value={props.numReplacedSafebrowsing}
+                    label={intl.getMessage('blocked_threats_chart')}
+                    data={props.replacedSafebrowsing}
+                    color={CARDS_COLORS.THREATS}
+                    percentValue={threatsPercent()}
+                    cardTheme={CARDS_THEME.THREATS}
+                    linkTo={RoutePath.QueryLog}
+                    query={{ reason: QUERY_LOG_REASON_FILTER.BLOCKED_BY_THREATS.QUERY }}
+                />
+            </Show>
+            <Show when={props.showParental}>
+                <StatCard
+                    value={props.numReplacedParental}
+                    label={intl.getMessage('stats_adult')}
+                    data={props.replacedParental}
+                    color={CARDS_COLORS.ADULT}
+                    percentValue={parentalPercent()}
+                    cardTheme={CARDS_THEME.ADULT}
+                    linkTo={RoutePath.QueryLog}
+                    query={{ reason: QUERY_LOG_REASON_FILTER.BLOCKED_BY_PARENTAL_CONTROL.QUERY }}
+                />
+            </Show>
         </div>
     );
 };

--- a/client_v2/src/stores/settings.ts
+++ b/client_v2/src/stores/settings.ts
@@ -18,6 +18,7 @@ import type { SafeSearchConfig } from 'panel/api/model/safeSearchConfig';
 import type { UpstreamsConfig } from 'panel/api/model/upstreamsConfig';
 
 type SettingsState = {
+    loadStatus: 'idle' | 'loading' | 'loaded' | 'failed';
     processing: boolean;
     processingTestUpstream: boolean;
     processingDhcpStatus: boolean;
@@ -29,6 +30,7 @@ type SettingsState = {
 };
 
 const initialState: SettingsState = {
+    loadStatus: 'idle',
     processing: true,
     processingTestUpstream: false,
     processingDhcpStatus: false,
@@ -40,23 +42,34 @@ const initialState: SettingsState = {
 };
 
 const [state, setState] = createStore<SettingsState>(initialState);
+let initGeneration = 0;
 
 export const initSettings = async () => {
-    setState('processing', true);
+    const generation = ++initGeneration;
+    setState({ loadStatus: 'loading', processing: true });
     try {
         const [safebrowsingStatusData, parentalStatusData, safesearchStatusData] =
             await Promise.all([safebrowsingStatus(), parentalStatus(), safesearchStatus()]);
+        if (generation !== initGeneration) {
+            return;
+        }
+
         setState({
             settingsList: {
                 safebrowsing: { enabled: safebrowsingStatusData.enabled },
                 parental: { enabled: parentalStatusData.enabled },
                 safesearch: { ...safesearchStatusData },
             },
+            loadStatus: 'loaded',
             processing: false,
         });
     } catch (error) {
+        if (generation !== initGeneration) {
+            return;
+        }
+
         addErrorToast({ error });
-        setState('processing', false);
+        setState({ loadStatus: 'failed', processing: false });
     }
 };
 


### PR DESCRIPTION
Closes #689.

## Summary

- load Safe Browsing, Parental Control, and Safe Search status for the
  dashboard
- hide a disabled feature's card and general-statistics row only when its
  selected-period statistics are zero
- keep statistics visible while status is unknown or failed and whenever
  historical data is nonzero
- prevent an older status request from overwriting a newer result

## Validation

- focused frontend tests: 19 passed
- focused tests repeated across 20 seeds: 380 passed
- `npm run check`: 60 test files and 638 tests passed, with lint and type-check
- `npm run build-prod`: passed (2,345 modules)
- `make md-lint`: passed
- `make txt-lint`: passed
- `git diff --check`: passed

The status-loading and historical-data cases are covered by new deterministic
tests, including stale request success and failure ordering.
