### PR TITLE
client: add activity clear actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 ### Added
 
+- Confirmation-protected clear actions on the Query Log and Dashboard pages
+  ([#3896], [#4087]).
+
 - Bootstrap servers configuration now supports comments.
 
 - New property `"language"` in `POST /control/install/check_config` and `POST /control/install/configure` HTTP APIs.
@@ -45,6 +48,8 @@ NOTE: Add new changes BELOW THIS COMMENT.
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
+[#3896]: https://github.com/AdguardTeam/AdGuardHome/issues/3896
+[#4087]: https://github.com/AdguardTeam/AdGuardHome/issues/4087
 
 <!--
 NOTE: Add new changes ABOVE THIS COMMENT.

--- a/client_v2/src/__tests__/activity-clear-actions.test.tsx
+++ b/client_v2/src/__tests__/activity-clear-actions.test.tsx
@@ -1,7 +1,7 @@
 import { HashRouter, Route } from '@solidjs/router';
 import { fireEvent, render, screen } from '@solidjs/testing-library';
 import { createSignal, type JSX } from 'solid-js';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { DAY } from 'panel/helpers/constants';
 import { Header as DashboardHeader } from 'panel/components/Dashboard/blocks/Header/Header';
@@ -26,6 +26,10 @@ const renderInRouter = (component: () => JSX.Element) => {
 };
 
 describe('Activity clear actions', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
     it('blocks query-log loading while a clear is in progress', () => {
         expect(isQueryLogBusy(false, false, true)).toBe(true);
     });
@@ -123,6 +127,35 @@ describe('Activity clear actions', () => {
         setIsLoading(true);
 
         expect(screen.getByTestId('query-log-clear-confirm')).toBeDisabled();
+    });
+
+    it('cancels a pending query-log search when clear confirmation opens', () => {
+        vi.useFakeTimers();
+        const onSearch = vi.fn();
+
+        renderInRouter(() => (
+            <QueryLogHeader
+                onSearch={onSearch}
+                onRefresh={vi.fn()}
+                onClear={vi.fn().mockResolvedValue(undefined)}
+                onStatusFilterChange={vi.fn()}
+                onReasonFilterChange={vi.fn()}
+                currentSearch=""
+                currentStatus="all"
+                currentReason="all"
+                isLoading={false}
+                isClearing={false}
+            />
+        ));
+
+        fireEvent.input(screen.getByPlaceholderText('domain_or_client'), {
+            target: { value: 'pending.example' },
+        });
+        fireEvent.click(screen.getByTestId('query-log-clear-button-desktop'));
+        vi.runAllTimers();
+
+        expect(screen.getByText('settings_confirm_clear_query_log')).toBeInTheDocument();
+        expect(onSearch).not.toHaveBeenCalled();
     });
 
     it('confirms before clearing dashboard statistics', () => {

--- a/client_v2/src/__tests__/activity-clear-actions.test.tsx
+++ b/client_v2/src/__tests__/activity-clear-actions.test.tsx
@@ -1,0 +1,201 @@
+import { HashRouter, Route } from '@solidjs/router';
+import { fireEvent, render, screen } from '@solidjs/testing-library';
+import { createSignal, type JSX } from 'solid-js';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DAY } from 'panel/helpers/constants';
+import { Header as DashboardHeader } from 'panel/components/Dashboard/blocks/Header/Header';
+import { isQueryLogBusy } from 'panel/components/QueryLog/QueryLog';
+import { Header as QueryLogHeader } from 'panel/components/QueryLog/blocks/Header';
+
+vi.mock('panel/common/intl', () => ({
+    default: {
+        getMessage: (key: string) => key,
+        getPlural: (key: string, count: number) => `${key}:${count}`,
+    },
+}));
+
+const renderInRouter = (component: () => JSX.Element) => {
+    window.location.hash = '#/';
+
+    return render(() => (
+        <HashRouter>
+            <Route path="/" component={component} />
+        </HashRouter>
+    ));
+};
+
+describe('Activity clear actions', () => {
+    it('blocks query-log loading while a clear is in progress', () => {
+        expect(isQueryLogBusy(false, false, true)).toBe(true);
+    });
+
+    it('confirms before clearing the query log', () => {
+        const onClear = vi.fn().mockResolvedValue(undefined);
+
+        renderInRouter(() => (
+            <QueryLogHeader
+                onSearch={vi.fn()}
+                onRefresh={vi.fn()}
+                onClear={onClear}
+                onStatusFilterChange={vi.fn()}
+                onReasonFilterChange={vi.fn()}
+                currentSearch=""
+                currentStatus="all"
+                currentReason="all"
+                isLoading={false}
+                isClearing={false}
+            />
+        ));
+
+        fireEvent.click(screen.getByTestId('query-log-clear-button-desktop'));
+
+        expect(onClear).not.toHaveBeenCalled();
+        expect(screen.getByText('settings_confirm_clear_query_log')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('query-log-clear-confirm'));
+
+        expect(onClear).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables query-log clear actions while clearing', () => {
+        renderInRouter(() => (
+            <QueryLogHeader
+                onSearch={vi.fn()}
+                onRefresh={vi.fn()}
+                onClear={vi.fn().mockResolvedValue(undefined)}
+                onStatusFilterChange={vi.fn()}
+                onReasonFilterChange={vi.fn()}
+                currentSearch=""
+                currentStatus="all"
+                currentReason="all"
+                isLoading={false}
+                isClearing
+            />
+        ));
+
+        expect(screen.getByTestId('query-log-clear-button-mobile')).toBeDisabled();
+        expect(screen.getByTestId('query-log-clear-button-desktop')).toBeDisabled();
+        expect(screen.getByTestId('query-log-refresh-button-mobile')).toBeDisabled();
+        expect(screen.getByTestId('query-log-refresh-button-desktop')).toBeDisabled();
+        expect(screen.getByPlaceholderText('domain_or_client')).toBeDisabled();
+    });
+
+    it('disables query-log clear actions while logs are loading', () => {
+        renderInRouter(() => (
+            <QueryLogHeader
+                onSearch={vi.fn()}
+                onRefresh={vi.fn()}
+                onClear={vi.fn().mockResolvedValue(undefined)}
+                onStatusFilterChange={vi.fn()}
+                onReasonFilterChange={vi.fn()}
+                currentSearch=""
+                currentStatus="all"
+                currentReason="all"
+                isLoading
+                isClearing={false}
+            />
+        ));
+
+        expect(screen.getByTestId('query-log-clear-button-mobile')).toBeDisabled();
+        expect(screen.getByTestId('query-log-clear-button-desktop')).toBeDisabled();
+    });
+
+    it('disables query-log confirmation if loading starts while it is open', () => {
+        const [isLoading, setIsLoading] = createSignal(false);
+
+        renderInRouter(() => (
+            <QueryLogHeader
+                onSearch={vi.fn()}
+                onRefresh={vi.fn()}
+                onClear={vi.fn().mockResolvedValue(undefined)}
+                onStatusFilterChange={vi.fn()}
+                onReasonFilterChange={vi.fn()}
+                currentSearch=""
+                currentStatus="all"
+                currentReason="all"
+                isLoading={isLoading()}
+                isClearing={false}
+            />
+        ));
+
+        fireEvent.click(screen.getByTestId('query-log-clear-button-desktop'));
+        setIsLoading(true);
+
+        expect(screen.getByTestId('query-log-clear-confirm')).toBeDisabled();
+    });
+
+    it('confirms before clearing dashboard statistics', () => {
+        const onClear = vi.fn().mockResolvedValue(undefined);
+
+        renderInRouter(() => (
+            <DashboardHeader
+                protectionEnabled
+                processingProtection={false}
+                remainingTime={null}
+                selectedPeriod={DAY}
+                periodOptions={[{ value: DAY, label: 'last day' }]}
+                isLoading={false}
+                isClearing={false}
+                onToggleProtection={vi.fn()}
+                onRefreshStats={vi.fn()}
+                onClear={onClear}
+                onPeriodChange={vi.fn()}
+            />
+        ));
+
+        fireEvent.click(screen.getByTestId('dashboard-clear-stats-button-desktop'));
+
+        expect(onClear).not.toHaveBeenCalled();
+        expect(screen.getByText('settings_confirm_clear_statistics')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('dashboard-clear-stats-confirm'));
+
+        expect(onClear).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables dashboard clear actions while clearing', () => {
+        renderInRouter(() => (
+            <DashboardHeader
+                protectionEnabled
+                processingProtection={false}
+                remainingTime={null}
+                selectedPeriod={DAY}
+                periodOptions={[{ value: DAY, label: 'last day' }]}
+                isLoading={false}
+                isClearing
+                onToggleProtection={vi.fn()}
+                onRefreshStats={vi.fn()}
+                onClear={vi.fn().mockResolvedValue(undefined)}
+                onPeriodChange={vi.fn()}
+            />
+        ));
+
+        expect(screen.getByTestId('dashboard-clear-stats-button-mobile')).toBeDisabled();
+        expect(screen.getByTestId('dashboard-clear-stats-button-desktop')).toBeDisabled();
+        for (const refreshButton of screen.getAllByTitle('refresh_btn')) {
+            expect(refreshButton).toBeDisabled();
+        }
+    });
+
+    it('disables dashboard clear actions while statistics are loading', () => {
+        renderInRouter(() => (
+            <DashboardHeader
+                protectionEnabled
+                processingProtection={false}
+                remainingTime={null}
+                selectedPeriod={DAY}
+                periodOptions={[{ value: DAY, label: 'last day' }]}
+                isLoading
+                isClearing={false}
+                onToggleProtection={vi.fn()}
+                onRefreshStats={vi.fn()}
+                onClear={vi.fn().mockResolvedValue(undefined)}
+                onPeriodChange={vi.fn()}
+            />
+        ));
+
+        expect(screen.getByTestId('dashboard-clear-stats-button-mobile')).toBeDisabled();
+        expect(screen.getByTestId('dashboard-clear-stats-button-desktop')).toBeDisabled();
+    });
+});

--- a/client_v2/src/__tests__/stats-store.test.ts
+++ b/client_v2/src/__tests__/stats-store.test.ts
@@ -2,24 +2,49 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
     stats: vi.fn(),
+    statsReset: vi.fn(),
     clientsSearch: vi.fn(),
     addErrorToast: vi.fn(),
+    addSuccessToast: vi.fn(),
 }));
 
 vi.mock('panel/api/generated', () => ({
     stats: mocks.stats,
+    statsReset: mocks.statsReset,
     clientsSearch: mocks.clientsSearch,
 }));
 vi.mock('panel/stores/toasts', () => ({
     addErrorToast: mocks.addErrorToast,
+    addSuccessToast: mocks.addSuccessToast,
 }));
 
-import { getStats, statsState } from 'panel/stores/stats';
+import { getStats, resetStats, statsState } from 'panel/stores/stats';
 
 describe('getStats', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mocks.clientsSearch.mockResolvedValue([]);
+        mocks.statsReset.mockResolvedValue(undefined);
+    });
+
+    it('keeps reset busy until the refreshed statistics are loaded', async () => {
+        let resolveStats: (value: { num_dns_queries: number }) => void = () => {};
+        const statsPromise = new Promise<{ num_dns_queries: number }>((resolve) => {
+            resolveStats = resolve;
+        });
+        mocks.stats.mockReturnValue(statsPromise);
+
+        const resetPromise = resetStats();
+        await vi.waitFor(() => expect(mocks.stats).toHaveBeenCalledOnce());
+
+        expect(statsState.processingReset).toBe(true);
+
+        resolveStats({ num_dns_queries: 0 });
+        await resetPromise;
+
+        expect(statsState.numDnsQueries).toBe(0);
+        expect(statsState.processingStats).toBe(false);
+        expect(statsState.processingReset).toBe(false);
     });
 
     it('enriches top clients and stores normalizedTopClients', async () => {

--- a/client_v2/src/components/Dashboard/Dashboard.tsx
+++ b/client_v2/src/components/Dashboard/Dashboard.tsx
@@ -3,7 +3,7 @@ import { createSignal, createMemo, createEffect, onCleanup, Show } from 'solid-j
 import theme from 'panel/lib/theme';
 import { PageLoader } from 'panel/common/ui/Loader';
 import { dashboardState, toggleProtection, getClients } from 'panel/stores/dashboard';
-import { statsState, getStats, getStatsConfig } from 'panel/stores/stats';
+import { statsState, getStats, getStatsConfig, resetStats } from 'panel/stores/stats';
 import { accessState, getAccessList } from 'panel/stores/access';
 import { ONE_SECOND_IN_MS, HOUR, DAY, STATS_INTERVALS_DAYS } from 'panel/helpers/constants';
 
@@ -129,8 +129,10 @@ export const Dashboard = () => {
                     selectedPeriod={selectedPeriod()}
                     periodOptions={periodOptions()}
                     isLoading={isLoading()}
+                    isClearing={statsState.processingReset}
                     onToggleProtection={handleToggleProtection}
                     onRefreshStats={handleRefreshStats}
+                    onClear={resetStats}
                     onPeriodChange={handlePeriodChange}
                 />
 

--- a/client_v2/src/components/Dashboard/blocks/Header/Header.module.pcss
+++ b/client_v2/src/components/Dashboard/blocks/Header/Header.module.pcss
@@ -117,6 +117,12 @@
     }
 }
 
+.mobileActions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
 .refreshButton {
     display: inline-flex;
     align-items: center;

--- a/client_v2/src/components/Dashboard/blocks/Header/Header.tsx
+++ b/client_v2/src/components/Dashboard/blocks/Header/Header.tsx
@@ -8,6 +8,7 @@ import { Dropdown } from 'panel/common/ui/Dropdown';
 import { Select } from 'panel/common/controls/Select';
 import { Icon } from 'panel/common/ui/Icon';
 import { Link } from 'panel/common/ui/Link';
+import { ConfirmDialog } from 'panel/common/ui/ConfirmDialog';
 import { RoutePath, SCROLL_QUERY_KEY } from 'panel/components/Routes/Paths';
 import { useIsMobile } from 'panel/hooks/useIsMobile';
 import { DISABLE_PROTECTION_TIMINGS, ONE_SECOND_IN_MS } from 'panel/helpers/constants';
@@ -79,15 +80,19 @@ type Props = {
     selectedPeriod: number;
     periodOptions: Array<{ value: number; label: string }>;
     isLoading: boolean;
+    isClearing: boolean;
     onToggleProtection: (enabled: boolean, duration?: number) => void;
     onRefreshStats: () => void;
+    onClear: () => Promise<void>;
     onPeriodChange: (period: number) => void;
 };
 
 export const Header = (props: Props) => {
     const [protectionMenuOpen, setProtectionMenuOpen] = createSignal(false);
     const [selectedDisableTime, setSelectedDisableTime] = createSignal<number | null>(null);
+    const [showClearConfirm, setShowClearConfirm] = createSignal(false);
     const isMobile = useIsMobile();
+    const isBusy = () => props.isLoading || props.isClearing;
 
     const handleToggleProtection = () => {
         props.onToggleProtection(props.protectionEnabled);
@@ -98,6 +103,11 @@ export const Header = (props: Props) => {
         setSelectedDisableTime(time);
         props.onToggleProtection(props.protectionEnabled, duration);
         setProtectionMenuOpen(false);
+    };
+
+    const handleClear = async () => {
+        await props.onClear();
+        setShowClearConfirm(false);
     };
 
     const protectionMenu = (
@@ -152,16 +162,30 @@ export const Header = (props: Props) => {
                 <div class={s.titleRow}>
                     <h1 class={cn(theme.title.h5, s.onlyMobile)}>{intl.getMessage('dashboard')}</h1>
 
-                    <button
-                        type="button"
-                        class={cn(s.refreshButton, s.refreshMobileButton, s.onlyMobile)}
-                        onClick={() => props.onRefreshStats?.()}
-                        disabled={props.isLoading}
-                        aria-label={intl.getMessage('refresh_btn')}
-                        title={intl.getMessage('refresh_btn')}
-                    >
-                        <Icon icon="refresh" color="green" />
-                    </button>
+                    <div class={cn(s.mobileActions, s.onlyMobile)}>
+                        <button
+                            type="button"
+                            data-testid="dashboard-clear-stats-button-mobile"
+                            class={cn(s.refreshButton, s.refreshMobileButton)}
+                            onClick={() => setShowClearConfirm(true)}
+                            disabled={isBusy()}
+                            aria-label={intl.getMessage('settings_statistics_clear')}
+                            title={intl.getMessage('settings_statistics_clear')}
+                        >
+                            <Icon icon="delete" color="red" />
+                        </button>
+
+                        <button
+                            type="button"
+                            class={cn(s.refreshButton, s.refreshMobileButton)}
+                            onClick={() => props.onRefreshStats?.()}
+                            disabled={isBusy()}
+                            aria-label={intl.getMessage('refresh_btn')}
+                            title={intl.getMessage('refresh_btn')}
+                        >
+                            <Icon icon="refresh" color="green" />
+                        </button>
+                    </div>
                 </div>
 
                 <h1 class={cn(theme.title.h3_tablet, s.onlyDesktop)}>
@@ -215,9 +239,22 @@ export const Header = (props: Props) => {
             <div class={s.headerRight}>
                 <button
                     type="button"
+                    data-testid="dashboard-clear-stats-button-desktop"
+                    class={cn(s.refreshButton, s.refreshDesktopButton, s.onlyDesktop)}
+                    onClick={() => setShowClearConfirm(true)}
+                    disabled={isBusy()}
+                    aria-label={intl.getMessage('settings_statistics_clear')}
+                    title={intl.getMessage('settings_statistics_clear')}
+                >
+                    {intl.getMessage('settings_statistics_clear')}
+                    <Icon icon="delete" color="red" />
+                </button>
+
+                <button
+                    type="button"
                     class={cn(s.refreshButton, s.refreshDesktopButton, s.onlyDesktop)}
                     onClick={() => props.onRefreshStats?.()}
-                    disabled={props.isLoading}
+                    disabled={isBusy()}
                     aria-label={intl.getMessage('refresh_btn')}
                     title={intl.getMessage('refresh_btn')}
                 >
@@ -235,11 +272,26 @@ export const Header = (props: Props) => {
                     height="big"
                     isSearchable={false}
                     borderless={!isMobile()}
+                    isDisabled={isBusy()}
                     menuSize="big"
                     menuPosition="right"
                     menuFooter={periodSettingsFooter}
                 />
             </div>
+
+            <Show when={showClearConfirm()}>
+                <ConfirmDialog
+                    title={intl.getMessage('settings_confirm_clear_statistics')}
+                    text={intl.getMessage('settings_confirm_clear_statistics_desc')}
+                    buttonText={intl.getMessage('settings_yes_clear')}
+                    cancelText={intl.getMessage('cancel')}
+                    buttonVariant="danger"
+                    submitDisabled={isBusy()}
+                    submitTestId="dashboard-clear-stats-confirm"
+                    onClose={() => setShowClearConfirm(false)}
+                    onConfirm={handleClear}
+                />
+            </Show>
         </div>
     );
 };

--- a/client_v2/src/components/QueryLog/QueryLog.tsx
+++ b/client_v2/src/components/QueryLog/QueryLog.tsx
@@ -11,6 +11,7 @@ import {
     setFilteredLogs,
     refreshFilteredLogs,
     getAdditionalLogs,
+    clearLogs,
 } from 'panel/stores/queryLogs';
 import { accessState, getAccessList, toggleClientBlock } from 'panel/stores/access';
 import { dashboardState, getClients } from 'panel/stores/dashboard';
@@ -51,6 +52,12 @@ const getEmptyStateMode = (enabled: boolean, interval?: number): EmptyStateMode 
     }
     return 'default';
 };
+
+export const isQueryLogBusy = (
+    processingGetLogs: boolean,
+    processingAdditionalLogs: boolean,
+    processingClear: boolean,
+): boolean => processingGetLogs || processingAdditionalLogs || processingClear;
 
 export const QueryLog = () => {
     const navigate = useNavigate();
@@ -119,7 +126,11 @@ export const QueryLog = () => {
     const logs = () => queryLogsState.logs || [];
 
     const isRequestInFlight = () =>
-        queryLogsState.processingGetLogs || queryLogsState.processingAdditionalLogs;
+        isQueryLogBusy(
+            queryLogsState.processingGetLogs,
+            queryLogsState.processingAdditionalLogs,
+            queryLogsState.processingClear,
+        );
     const isLoadingMore = () => isIncrementalLoad() && isRequestInFlight();
     const isInitialLoading = () =>
         queryLogsState.processingGetLogs && logs().length === 0 && !isIncrementalLoad();
@@ -226,12 +237,14 @@ export const QueryLog = () => {
                 <Header
                     onSearch={handleSearch}
                     onRefresh={handleRefresh}
+                    onClear={clearLogs}
                     onStatusFilterChange={handleStatusFilterChange}
                     onReasonFilterChange={handleReasonFilterChange}
                     currentSearch={currentSearch()}
                     currentStatus={currentStatus()}
                     currentReason={currentReason()}
                     isLoading={!!isRequestInFlight()}
+                    isClearing={queryLogsState.processingClear}
                 />
 
                 <div class={s.desktopView}>

--- a/client_v2/src/components/QueryLog/blocks/Header/Header.module.pcss
+++ b/client_v2/src/components/QueryLog/blocks/Header/Header.module.pcss
@@ -162,7 +162,9 @@
 }
 
 .refreshMobileButton,
-.refreshDesktopButton {
+.refreshDesktopButton,
+.clearMobileButton,
+.clearDesktopButton {
     flex-shrink: 0;
     width: 40px;
     height: 40px;
@@ -179,13 +181,15 @@
     }
 }
 
-.refreshMobileButton {
+.refreshMobileButton,
+.clearMobileButton {
     @media (min-width: 1024px) {
         display: none;
     }
 }
 
-.refreshDesktopButton {
+.refreshDesktopButton,
+.clearDesktopButton {
     display: none;
 
     @media (min-width: 1024px) {
@@ -205,6 +209,11 @@
 
 .refreshDesktopIcon {
     color: var(--default-product-icon);
+}
+
+.clearIcon {
+    width: 24px;
+    height: 24px;
 }
 
 .searchLoader {

--- a/client_v2/src/components/QueryLog/blocks/Header/Header.tsx
+++ b/client_v2/src/components/QueryLog/blocks/Header/Header.tsx
@@ -5,6 +5,7 @@ import intl from 'panel/common/intl';
 import theme from 'panel/lib/theme';
 import { Input } from 'panel/common/controls/Input';
 import { Button } from 'panel/common/ui/Button';
+import { ConfirmDialog } from 'panel/common/ui/ConfirmDialog';
 import { Icon } from 'panel/common/ui/Icon';
 import { Select } from 'panel/common/controls/Select';
 import { FaqTooltip } from 'panel/common/ui/FaqTooltip';
@@ -18,12 +19,14 @@ import s from './Header.module.pcss';
 type Props = {
     onSearch: (value: string) => void;
     onRefresh: () => void;
+    onClear: () => Promise<void>;
     onStatusFilterChange: (status: string) => void;
     onReasonFilterChange: (reason: string) => void;
     currentSearch: string;
     currentStatus: string;
     currentReason: string;
     isLoading: boolean;
+    isClearing: boolean;
 };
 
 const STATUS_OPTIONS = [
@@ -106,8 +109,10 @@ const REASON_OPTIONS = [
 
 export const Header = (props: Props) => {
     const [searchValue, setSearchValue] = createSignal(untrack(() => props.currentSearch));
+    const [showClearConfirm, setShowClearConfirm] = createSignal(false);
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
     const isMobile = useIsMobile();
+    const isBusy = () => props.isLoading || props.isClearing;
 
     createEffect(
         on(
@@ -138,6 +143,11 @@ export const Header = (props: Props) => {
         props.onSearch('');
     };
 
+    const handleClear = async () => {
+        await props.onClear();
+        setShowClearConfirm(false);
+    };
+
     onCleanup(() => {
         if (debounceTimer) {
             clearTimeout(debounceTimer);
@@ -166,6 +176,7 @@ export const Header = (props: Props) => {
                         placeholder={intl.getMessage('domain_or_client')}
                         value={searchValue()}
                         onInput={handleSearchChange}
+                        disabled={isBusy()}
                         size="small"
                         prefixIcon={<Icon icon="search" class={s.searchIcon} />}
                         suffixIcon={
@@ -180,6 +191,7 @@ export const Header = (props: Props) => {
                                                 data-testid="query-log-search-clear-button"
                                                 aria-label={intl.getMessage('reset')}
                                                 title={intl.getMessage('reset')}
+                                                disabled={isBusy()}
                                                 onMouseDown={(event) => event.preventDefault()}
                                                 onClick={handleClearSearch}
                                             >
@@ -197,12 +209,25 @@ export const Header = (props: Props) => {
                     />
 
                     <Button
+                        data-testid="query-log-clear-button-mobile"
+                        class={s.clearMobileButton}
+                        variant="secondary-danger"
+                        size="small"
+                        aria-label={intl.getMessage('clear_query_log')}
+                        title={intl.getMessage('clear_query_log')}
+                        onClick={() => setShowClearConfirm(true)}
+                        disabled={isBusy()}
+                    >
+                        <Icon icon="delete" class={s.clearIcon} />
+                    </Button>
+
+                    <Button
                         data-testid="query-log-refresh-button-mobile"
                         class={s.refreshMobileButton}
                         variant="primary"
                         size="small"
                         onClick={props.onRefresh}
-                        disabled={props.isLoading}
+                        disabled={isBusy()}
                     >
                         <Icon icon="refresh" class={s.refreshMobileIcon} />
                     </Button>
@@ -220,6 +245,7 @@ export const Header = (props: Props) => {
                             }
                             menuSize="big"
                             menuPosition="right"
+                            isDisabled={isBusy()}
                             borderless={!isMobile()}
                             class={s.filterSelect}
                         />
@@ -236,6 +262,7 @@ export const Header = (props: Props) => {
                             }
                             menuSize="big"
                             menuPosition="right"
+                            isDisabled={isBusy()}
                             borderless={!isMobile()}
                             class={s.filterSelect}
                         />
@@ -250,11 +277,38 @@ export const Header = (props: Props) => {
                     aria-label={intl.getMessage('refresh_btn')}
                     title={intl.getMessage('refresh_btn')}
                     onClick={props.onRefresh}
-                    disabled={props.isLoading}
+                    disabled={isBusy()}
                 >
                     <Icon icon="refresh" class={s.refreshDesktopIcon} />
                 </Button>
+
+                <Button
+                    data-testid="query-log-clear-button-desktop"
+                    class={s.clearDesktopButton}
+                    variant="secondary-danger"
+                    size="small"
+                    aria-label={intl.getMessage('clear_query_log')}
+                    title={intl.getMessage('clear_query_log')}
+                    onClick={() => setShowClearConfirm(true)}
+                    disabled={isBusy()}
+                >
+                    <Icon icon="delete" class={s.clearIcon} />
+                </Button>
             </div>
+
+            <Show when={showClearConfirm()}>
+                <ConfirmDialog
+                    title={intl.getMessage('settings_confirm_clear_query_log')}
+                    text={intl.getMessage('settings_confirm_clear_query_log_desc')}
+                    buttonText={intl.getMessage('settings_yes_clear')}
+                    cancelText={intl.getMessage('cancel')}
+                    buttonVariant="danger"
+                    submitDisabled={isBusy()}
+                    submitTestId="query-log-clear-confirm"
+                    onClose={() => setShowClearConfirm(false)}
+                    onConfirm={handleClear}
+                />
+            </Show>
         </div>
     );
 };

--- a/client_v2/src/components/QueryLog/blocks/Header/Header.tsx
+++ b/client_v2/src/components/QueryLog/blocks/Header/Header.tsx
@@ -114,6 +114,13 @@ export const Header = (props: Props) => {
     const isMobile = useIsMobile();
     const isBusy = () => props.isLoading || props.isClearing;
 
+    const cancelDebouncedSearch = () => {
+        if (debounceTimer) {
+            clearTimeout(debounceTimer);
+            debounceTimer = null;
+        }
+    };
+
     createEffect(
         on(
             () => props.currentSearch,
@@ -126,9 +133,7 @@ export const Header = (props: Props) => {
         const value = (e.target as HTMLInputElement).value;
         setSearchValue(value);
 
-        if (debounceTimer) {
-            clearTimeout(debounceTimer);
-        }
+        cancelDebouncedSearch();
 
         debounceTimer = setTimeout(() => {
             props.onSearch(value);
@@ -136,11 +141,14 @@ export const Header = (props: Props) => {
     };
 
     const handleClearSearch = () => {
-        if (debounceTimer) {
-            clearTimeout(debounceTimer);
-        }
+        cancelDebouncedSearch();
         setSearchValue('');
         props.onSearch('');
+    };
+
+    const handleOpenClearConfirm = () => {
+        cancelDebouncedSearch();
+        setShowClearConfirm(true);
     };
 
     const handleClear = async () => {
@@ -149,9 +157,7 @@ export const Header = (props: Props) => {
     };
 
     onCleanup(() => {
-        if (debounceTimer) {
-            clearTimeout(debounceTimer);
-        }
+        cancelDebouncedSearch();
     });
 
     const selectedStatus = createMemo(
@@ -215,7 +221,7 @@ export const Header = (props: Props) => {
                         size="small"
                         aria-label={intl.getMessage('clear_query_log')}
                         title={intl.getMessage('clear_query_log')}
-                        onClick={() => setShowClearConfirm(true)}
+                        onClick={handleOpenClearConfirm}
                         disabled={isBusy()}
                     >
                         <Icon icon="delete" class={s.clearIcon} />
@@ -289,7 +295,7 @@ export const Header = (props: Props) => {
                     size="small"
                     aria-label={intl.getMessage('clear_query_log')}
                     title={intl.getMessage('clear_query_log')}
-                    onClick={() => setShowClearConfirm(true)}
+                    onClick={handleOpenClearConfirm}
                     disabled={isBusy()}
                 >
                     <Icon icon="delete" class={s.clearIcon} />

--- a/client_v2/src/stores/stats.ts
+++ b/client_v2/src/stores/stats.ts
@@ -161,9 +161,9 @@ export const resetStats = async () => {
     setState('processingReset', true);
     try {
         await statsReset();
-        setState('processingReset', false);
         addSuccessToast(intl.getMessage('settings_notify_statistics_cleared'));
         await getStats();
+        setState('processingReset', false);
     } catch (error) {
         addErrorToast({ error });
         setState('processingReset', false);


### PR DESCRIPTION
Closes #3896.
Closes #4087.

## Summary

- add confirmation-protected clear actions beside the Query Log and Dashboard
  refresh controls on desktop and mobile
- reuse the existing query-log and statistics clear stores and translations
- disable clear, refresh, search, filtering, period selection, and incremental
  loading while a conflicting clear/read operation is active
- keep statistics reset busy until the post-reset refresh completes

## Validation

- focused tests: 12 passed
- focused tests repeated across 20 shuffled seeds: 240 passed
- `npm run check`: lint, type-check, 59 test files, and 628 tests passed
- `npm run build-prod`: passed (2,345 modules)
- `make md-lint`: passed
- `make txt-lint`: passed
- `git diff --check`: passed

The confirmation requirement discussed in #4087 is covered on both pages, and
the tests verify confirmation, responsive controls, mutual busy-state
serialization, and the post-reset refresh boundary.
