### PR TITLE
filtering: use validators for unchanged lists

### DIFF
--- a/internal/filtering/filter.go
+++ b/internal/filtering/filter.go
@@ -2,6 +2,9 @@ package filtering
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -21,11 +24,26 @@ import (
 	"github.com/AdguardTeam/golibs/errors"
 	"github.com/AdguardTeam/golibs/ioutil"
 	"github.com/AdguardTeam/golibs/logutil/slogutil"
+	"golang.org/x/net/http/httpguts"
 )
 
 // filterDir is the subdirectory of a data directory to store downloaded
 // filters.
 const filterDir = "filters"
+
+// filterHTTPMetadataSuffix is the suffix of a file containing the cached HTTP
+// validators of a downloaded filter.
+const filterHTTPMetadataSuffix = ".metadata"
+
+// filterHTTPMetadata contains the HTTP validators cached for a downloaded
+// filter.  URL prevents using validators after a filter source has changed,
+// and Digest binds them to the exact cached contents.
+type filterHTTPMetadata struct {
+	URL          string `json:"url"`
+	ETag         string `json:"etag,omitempty"`
+	LastModified string `json:"last_modified,omitempty"`
+	Digest       string `json:"digest"`
+}
 
 // FilterYAML represents a filter list in the configuration file.
 //
@@ -56,6 +74,11 @@ func (filter *FilterYAML) Path(dataDir string) string {
 		filterDir,
 		strconv.FormatUint(uint64(filter.ID), 10)+".txt",
 	)
+}
+
+// httpMetadataPath returns the path to filter's cached HTTP validators.
+func (filter *FilterYAML) httpMetadataPath(dataDir string) string {
+	return filter.Path(dataDir) + filterHTTPMetadataSuffix
 }
 
 // ensureName sets provided title or default name for the filter if it doesn't
@@ -502,21 +525,64 @@ func (d *DNSFilter) updateIntl(ctx context.Context, flt *FilterYAML) (ok bool, e
 	d.logger.DebugContext(ctx, "downloading update for filter", "id", flt.ID, "url", flt.URL)
 
 	var res *rulelist.ParseResult
+	var metadata *filterHTTPMetadata
+	var previous filterHTTPMetadata
+	var currentDigest string
+	var responseDigest string
+	hasCurrentContents := false
+	hasPrevious := false
+	forceUpdate := false
+
+	if !filepath.IsAbs(flt.URL) {
+		previous, hasPrevious = d.loadHTTPMetadata(ctx, flt)
+		currentDigest, hasCurrentContents, hasPrevious, forceUpdate = d.currentHTTPFilterState(
+			ctx,
+			flt,
+			previous,
+			hasPrevious,
+		)
+	}
 
 	tmpFile, err := aghrenameio.NewPendingFile(flt.Path(d.conf.DataDir), aghos.DefaultPermFile)
 	if err != nil {
 		// Don't wrap the error because it's informative enough as is.
 		return false, err
 	}
-	defer func() { err = d.finalizeUpdate(ctx, tmpFile, flt, res, err, ok) }()
+	defer func() {
+		err = d.finalizeUpdateWithHTTPMetadata(
+			ctx,
+			tmpFile,
+			flt,
+			res,
+			metadata,
+			err,
+			ok,
+			hasCurrentContents,
+		)
+	}()
 
 	if filepath.IsAbs(flt.URL) {
 		// Initialise this variable to avoid any confusion.
 		path := flt.URL
 
 		res, err = d.readFromFile(tmpFile, path)
+		if err == nil {
+			// Remove obsolete HTTP metadata after a successful update from a local
+			// source.
+			metadata = &filterHTTPMetadata{}
+		}
 	} else {
-		res, err = d.readFromHTTP(tmpFile, flt.URL)
+		var notModified bool
+		res, metadata, responseDigest, notModified, err = d.readFromHTTP(
+			ctx,
+			tmpFile,
+			flt,
+			previous,
+			hasPrevious,
+		)
+		if notModified {
+			return false, err
+		}
 	}
 
 	if err != nil {
@@ -524,24 +590,136 @@ func (d *DNSFilter) updateIntl(ctx context.Context, flt *FilterYAML) (ok bool, e
 		return false, err
 	}
 
-	return res.Checksum != flt.checksum, nil
+	return forceUpdate ||
+		res.Checksum != flt.checksum ||
+		(hasCurrentContents && responseDigest != currentDigest), nil
 }
 
-// readFromHTTP reads filter data from urlStr via HTTP and parses it into the
-// tmpFile file.  tmpFile must not be nil.  urlStr must be a valid URL.
+// currentHTTPFilterState returns the current digest and whether the filter
+// has usable contents.  forceUpdate is true if contents previously loaded for
+// flt can no longer be read.
+func (d *DNSFilter) currentHTTPFilterState(
+	ctx context.Context,
+	flt *FilterYAML,
+	metadata filterHTTPMetadata,
+	hasMetadata bool,
+) (digest string, hasContents, useMetadata, forceUpdate bool) {
+	hasLoadedContents := flt.checksum != 0 || flt.RulesCount != 0
+	if !hasLoadedContents {
+		return "", false, false, false
+	}
+
+	digest, err := d.currentFilterDigest(flt)
+	if err == nil {
+		return digest, true, hasMetadata && metadata.Digest == digest, false
+	}
+
+	if !errors.Is(err, os.ErrNotExist) {
+		d.logger.WarnContext(
+			ctx,
+			"checking current filter contents",
+			"id", flt.ID,
+			slogutil.KeyError, err,
+		)
+	}
+
+	return "", false, false, true
+}
+
+// finalizeUpdateWithHTTPMetadata finalizes a filter update and stores its HTTP
+// metadata after a successful finalization.
+func (d *DNSFilter) finalizeUpdateWithHTTPMetadata(
+	ctx context.Context,
+	file aghrenameio.PendingFile,
+	flt *FilterYAML,
+	res *rulelist.ParseResult,
+	metadata *filterHTTPMetadata,
+	returned error,
+	updated bool,
+	hadContents bool,
+) (err error) {
+	err = d.finalizeUpdate(ctx, file, flt, res, returned, updated)
+	if err != nil || metadata == nil {
+		return err
+	}
+
+	var metaErr error
+	if updated || hadContents {
+		metaErr = d.storeHTTPMetadata(flt, *metadata)
+	} else {
+		metaErr = d.removeHTTPMetadata(flt)
+	}
+	if metaErr != nil {
+		d.logger.WarnContext(
+			ctx,
+			"storing filter http metadata",
+			"id", flt.ID,
+			slogutil.KeyError, metaErr,
+		)
+	}
+
+	return err
+}
+
+// readFromHTTP reads flt's data via HTTP and parses it into tmpFile.  flt and
+// tmpFile must not be nil.  flt.URL must be a valid URL.
 func (d *DNSFilter) readFromHTTP(
+	ctx context.Context,
 	tmpFile aghrenameio.PendingFile,
-	urlStr string,
-) (res *rulelist.ParseResult, err error) {
-	resp, err := d.conf.HTTPClient.Get(urlStr)
+	flt *FilterYAML,
+	previous filterHTTPMetadata,
+	hasPrevious bool,
+) (
+	res *rulelist.ParseResult,
+	metadata *filterHTTPMetadata,
+	digest string,
+	notModified bool,
+	err error,
+) {
+	req, err := newHTTPFilterRequest(ctx, flt, previous, hasPrevious)
+	if err != nil {
+		return nil, nil, "", false, err
+	}
+
+	httpClient := d.conf.HTTPClient
+	if hasPrevious {
+		httpClient = httpClientWithoutRedirectValidators(httpClient)
+	}
+
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		// Don't wrap the error because it's informative enough as is.
-		return nil, err
+		return nil, nil, "", false, err
 	}
 	defer func() { err = errors.WithDeferred(err, resp.Body.Close()) }()
 
+	finalURLDiffers := resp.Request.URL.String() != req.URL.String()
+	if resp.StatusCode == http.StatusNotModified {
+		if finalURLDiffers {
+			return nil, nil, "", false, errors.Error("got status code 304 after redirect")
+		}
+
+		metadata, err = updateNotModifiedHTTPMetadata(resp, previous, hasPrevious)
+
+		return nil, metadata, "", err == nil, err
+	}
+
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("got status code %d, want %d", resp.StatusCode, http.StatusOK)
+		return nil, nil, "", false, fmt.Errorf(
+			"got status code %d, want %d or %d",
+			resp.StatusCode,
+			http.StatusOK,
+			http.StatusNotModified,
+		)
+	}
+
+	metadata = &filterHTTPMetadata{}
+	if !finalURLDiffers {
+		*metadata = filterHTTPMetadata{
+			URL:          flt.URL,
+			ETag:         resp.Header.Get("ETag"),
+			LastModified: resp.Header.Get("Last-Modified"),
+		}
 	}
 
 	bufPtr := d.bufPool.Get()
@@ -549,8 +727,187 @@ func (d *DNSFilter) readFromHTTP(
 
 	p := rulelist.NewParser()
 	httpBody := ioutil.LimitReader(resp.Body, d.conf.MaxHTTPSize.Bytes())
+	hasher := sha256.New()
+	dst := io.MultiWriter(tmpFile, hasher)
 
-	return p.Parse(tmpFile, httpBody, *bufPtr)
+	res, err = p.Parse(dst, httpBody, *bufPtr)
+	if err == nil {
+		digest = hex.EncodeToString(hasher.Sum(nil))
+		metadata.Digest = digest
+	}
+
+	return res, metadata, digest, false, err
+}
+
+// updateNotModifiedHTTPMetadata returns metadata updated from a 304 response.
+func updateNotModifiedHTTPMetadata(
+	resp *http.Response,
+	previous filterHTTPMetadata,
+	hasPrevious bool,
+) (metadata *filterHTTPMetadata, err error) {
+	if !hasPrevious {
+		return nil, errors.Error("got status code 304 without cached validators")
+	}
+
+	if etag := resp.Header.Get("ETag"); etag != "" {
+		previous.ETag = etag
+	}
+	if lastModified := resp.Header.Get("Last-Modified"); lastModified != "" {
+		previous.LastModified = lastModified
+	}
+
+	return &previous, nil
+}
+
+// newHTTPFilterRequest returns a GET request for flt, adding metadata's cached
+// HTTP validators when available.  flt must not be nil and its URL must be
+// valid.
+func newHTTPFilterRequest(
+	ctx context.Context,
+	flt *FilterYAML,
+	metadata filterHTTPMetadata,
+	hasMetadata bool,
+) (req *http.Request, err error) {
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, flt.URL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if hasMetadata {
+		if metadata.ETag != "" {
+			req.Header.Set("If-None-Match", metadata.ETag)
+		}
+		if metadata.LastModified != "" {
+			req.Header.Set("If-Modified-Since", metadata.LastModified)
+		}
+	}
+
+	return req, nil
+}
+
+// httpClientWithoutRedirectValidators returns a shallow copy of c that removes
+// filter validators from redirected requests.  It preserves c's transport,
+// timeout, cookie jar, and redirect policy.
+func httpClientWithoutRedirectValidators(c *http.Client) (clone *http.Client) {
+	cloned := *c
+	originalCheckRedirect := c.CheckRedirect
+	cloned.CheckRedirect = func(req *http.Request, via []*http.Request) (err error) {
+		if originalCheckRedirect != nil {
+			err = originalCheckRedirect(req, via)
+		} else if len(via) >= 10 {
+			return errors.Error("stopped after 10 redirects")
+		}
+		if err != nil {
+			return err
+		}
+
+		req.Header.Del("If-None-Match")
+		req.Header.Del("If-Modified-Since")
+
+		return nil
+	}
+
+	return &cloned
+}
+
+// loadHTTPMetadata loads flt's cached HTTP validators.  It returns false if the
+// metadata cannot be used.  Invalid metadata is ignored so that this optional
+// cache cannot prevent a filter update.
+func (d *DNSFilter) loadHTTPMetadata(
+	ctx context.Context,
+	flt *FilterYAML,
+) (metadata filterHTTPMetadata, ok bool) {
+	b, err := os.ReadFile(flt.httpMetadataPath(d.conf.DataDir))
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			d.logger.WarnContext(
+				ctx,
+				"reading filter http metadata",
+				"id", flt.ID,
+				slogutil.KeyError, err,
+			)
+		}
+
+		return filterHTTPMetadata{}, false
+	}
+
+	err = json.Unmarshal(b, &metadata)
+	if err != nil {
+		d.logger.WarnContext(
+			ctx,
+			"decoding filter http metadata",
+			"id", flt.ID,
+			slogutil.KeyError, err,
+		)
+
+		return filterHTTPMetadata{}, false
+	}
+
+	if !validFilterHTTPMetadata(metadata, flt.URL) {
+		return filterHTTPMetadata{}, false
+	}
+
+	return metadata, true
+}
+
+// validFilterHTTPMetadata returns true if metadata is safe and applies to the
+// current representation of the filter at urlStr.
+func validFilterHTTPMetadata(
+	metadata filterHTTPMetadata,
+	urlStr string,
+) (ok bool) {
+	if metadata.URL != urlStr {
+		return false
+	}
+
+	if metadata.ETag == "" && metadata.LastModified == "" {
+		return false
+	}
+
+	digest, err := hex.DecodeString(metadata.Digest)
+	if err != nil || len(digest) != sha256.Size {
+		return false
+	}
+
+	return httpguts.ValidHeaderFieldValue(metadata.ETag) &&
+		httpguts.ValidHeaderFieldValue(metadata.LastModified)
+}
+
+// storeHTTPMetadata stores flt's HTTP validators atomically.  Empty validators
+// remove previously cached metadata.
+func (d *DNSFilter) storeHTTPMetadata(
+	flt *FilterYAML,
+	metadata filterHTTPMetadata,
+) (err error) {
+	path := flt.httpMetadataPath(d.conf.DataDir)
+	if metadata.ETag == "" && metadata.LastModified == "" {
+		return d.removeHTTPMetadata(flt)
+	}
+
+	metadata.URL = flt.URL
+	b, err := json.Marshal(metadata)
+	if err != nil {
+		return fmt.Errorf("encoding: %w", err)
+	}
+
+	pending, err := aghrenameio.NewPendingFile(path, aghos.DefaultPermFile)
+	if err != nil {
+		return err
+	}
+
+	_, err = pending.Write(b)
+
+	return aghrenameio.WithDeferredCleanup(err, pending)
+}
+
+// removeHTTPMetadata removes flt's cached HTTP validators.
+func (d *DNSFilter) removeHTTPMetadata(flt *FilterYAML) (err error) {
+	err = os.Remove(flt.httpMetadataPath(d.conf.DataDir))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+
+	return err
 }
 
 // readFromFile reads filter data from a file located at path and parses it into
@@ -577,6 +934,27 @@ func (d *DNSFilter) readFromFile(
 	p := rulelist.NewParser()
 
 	return p.Parse(tmpFile, file, *bufPtr)
+}
+
+// currentFilterDigest returns the SHA-256 digest of flt's current contents.
+func (d *DNSFilter) currentFilterDigest(flt *FilterYAML) (digest string, err error) {
+	// #nosec G304 -- The filter path is always within DataDir.
+	file, err := os.Open(flt.Path(d.conf.DataDir))
+	if err != nil {
+		return "", err
+	}
+	defer func() { err = errors.WithDeferred(err, file.Close()) }()
+
+	hasher := sha256.New()
+	bufPtr := d.bufPool.Get()
+	defer d.bufPool.Put(bufPtr)
+
+	_, err = io.CopyBuffer(hasher, file, *bufPtr)
+	if err != nil {
+		return "", fmt.Errorf("calculating filter digest: %w", err)
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
 
 // finalizeUpdate closes and gets rid of temporary file f with filter's content

--- a/internal/filtering/filter.go
+++ b/internal/filtering/filter.go
@@ -154,7 +154,8 @@ func (d *DNSFilter) filterSetProperties(
 
 	flt.Name = newList.Name
 
-	if flt.URL != newList.URL {
+	urlChanged := flt.URL != newList.URL
+	if urlChanged {
 		if d.filterExistsLocked(newList.URL) {
 			return false, errFilterExists
 		}
@@ -178,6 +179,7 @@ func (d *DNSFilter) filterSetProperties(
 		// kick in when the filter is enabled.  Consider changing this behavior
 		// to be stricter.
 		flt.unload()
+		d.removeHTTPMetadataOnURLChangeAndLog(context.TODO(), flt, urlChanged)
 
 		return shouldRestart, err
 	}
@@ -187,6 +189,18 @@ func (d *DNSFilter) filterSetProperties(
 	}
 
 	return d.update(flt)
+}
+
+// removeHTTPMetadataOnURLChangeAndLog removes flt's HTTP metadata if its URL
+// has changed and logs any error.
+func (d *DNSFilter) removeHTTPMetadataOnURLChangeAndLog(
+	ctx context.Context,
+	flt *FilterYAML,
+	urlChanged bool,
+) {
+	if urlChanged {
+		d.removeHTTPMetadataAndLog(ctx, flt)
+	}
 }
 
 // filterExists returns true if a filter with the same url exists in d.  It's

--- a/internal/filtering/filter_internal_test.go
+++ b/internal/filtering/filter_internal_test.go
@@ -2,13 +2,19 @@ package filtering
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
 
+	"github.com/AdguardTeam/AdGuardHome/internal/filtering/rulelist"
 	"github.com/AdguardTeam/golibs/netutil/urlutil"
 	"github.com/AdguardTeam/golibs/testutil"
 	"github.com/c2h5oh/datasize"
@@ -139,6 +145,536 @@ func TestDNSFilter_Update(t *testing.T) {
 
 		f.unload()
 	})
+}
+
+func TestDNSFilter_UpdateHTTPValidators(t *testing.T) {
+	const (
+		contentV1      = "||one.example^\n"
+		contentV2      = "||two.example^\n"
+		etagV1         = `"v1"`
+		etagV2         = `"v2"`
+		lastModifiedV1 = "Wed, 21 Oct 2015 07:28:00 GMT"
+		lastModifiedV2 = "Thu, 22 Oct 2015 07:28:00 GMT"
+	)
+
+	requests := make(chan http.Header, 6)
+	requestNum := &atomic.Uint32{}
+	pt := testutil.NewPanicT(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.Header.Clone()
+
+		switch requestNum.Add(1) {
+		case 1:
+			w.Header().Set("ETag", etagV1)
+			w.Header().Set("Last-Modified", lastModifiedV1)
+			n, err := w.Write([]byte(contentV1))
+			require.NoError(pt, err)
+			require.Equal(pt, len(contentV1), n)
+		case 2:
+			w.WriteHeader(http.StatusNotModified)
+		case 3:
+			w.Header().Set("ETag", etagV2)
+			w.Header().Set("Last-Modified", lastModifiedV2)
+			n, err := w.Write([]byte(contentV2))
+			require.NoError(pt, err)
+			require.Equal(pt, len(contentV2), n)
+		case 4:
+			http.Error(w, "test error", http.StatusInternalServerError)
+		case 5:
+			w.WriteHeader(http.StatusNotModified)
+		case 6:
+			w.Header().Set("ETag", etagV2)
+			w.Header().Set("Last-Modified", lastModifiedV2)
+			n, err := w.Write([]byte(contentV2))
+			require.NoError(pt, err)
+			require.Equal(pt, len(contentV2), n)
+		default:
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	httpClient := srv.Client()
+	httpClient.Timeout = testTimeout
+
+	dataDir := t.TempDir()
+	const filterID = 1
+	filterPath := (&FilterYAML{Filter: Filter{ID: filterID}}).Path(dataDir)
+
+	update := func() (updated bool, err error) {
+		d, newErr := New(&Config{
+			Logger:      testLogger,
+			DataDir:     dataDir,
+			HTTPClient:  httpClient,
+			MaxHTTPSize: testFilterSize,
+			Filters: []FilterYAML{{
+				Enabled: true,
+				URL:     srv.URL,
+				Name:    "test-filter",
+				Filter: Filter{
+					ID: filterID,
+				},
+			}},
+		}, nil)
+		require.NoError(t, newErr)
+		defer d.Close()
+
+		return d.update(&d.conf.Filters[0])
+	}
+
+	assertRequestValidators := func(wantETag, wantLastModified string) {
+		t.Helper()
+
+		reqHeader := <-requests
+		assert.Equal(t, wantETag, reqHeader.Get("If-None-Match"))
+		assert.Equal(t, wantLastModified, reqHeader.Get("If-Modified-Since"))
+	}
+
+	updated, err := update()
+	require.NoError(t, err)
+	assert.True(t, updated)
+	assertRequestValidators("", "")
+
+	contentBeforeNotModified, err := os.ReadFile(filterPath)
+	require.NoError(t, err)
+
+	updated, err = update()
+	assertRequestValidators(etagV1, lastModifiedV1)
+	require.NoError(t, err)
+	assert.False(t, updated)
+
+	contentAfterNotModified, err := os.ReadFile(filterPath)
+	require.NoError(t, err)
+	assert.Equal(t, contentBeforeNotModified, contentAfterNotModified)
+
+	updated, err = update()
+	require.NoError(t, err)
+	assert.True(t, updated)
+	assertRequestValidators(etagV1, lastModifiedV1)
+
+	contentV2OnDisk, err := os.ReadFile(filterPath)
+	require.NoError(t, err)
+	require.NotEqual(t, contentBeforeNotModified, contentV2OnDisk)
+
+	updated, err = update()
+	assertRequestValidators(etagV2, lastModifiedV2)
+	require.Error(t, err)
+	assert.False(t, updated)
+
+	contentAfterError, err := os.ReadFile(filterPath)
+	require.NoError(t, err)
+	assert.Equal(t, contentV2OnDisk, contentAfterError)
+
+	updated, err = update()
+	assertRequestValidators(etagV2, lastModifiedV2)
+	require.NoError(t, err)
+	assert.False(t, updated)
+
+	contentAfterFinalNotModified, err := os.ReadFile(filterPath)
+	require.NoError(t, err)
+	assert.Equal(t, contentV2OnDisk, contentAfterFinalNotModified)
+
+	// Changing the filter contents invalidates the validators cached for the
+	// previous representation, so the next request must be unconditional.
+	require.NoError(t, os.WriteFile(filterPath, []byte(contentV1), 0o600))
+	updated, err = update()
+	assertRequestValidators("", "")
+	require.NoError(t, err)
+	assert.True(t, updated)
+
+	contentAfterUnconditionalUpdate, err := os.ReadFile(filterPath)
+	require.NoError(t, err)
+	assert.Equal(t, contentV2OnDisk, contentAfterUnconditionalUpdate)
+
+	dir, err := os.ReadDir(filepath.Join(dataDir, filterDir))
+	require.NoError(t, err)
+	assert.Len(t, dir, 2)
+	assert.Equal(t, uint32(6), requestNum.Load())
+}
+
+func TestDNSFilter_UpdateHTTPValidatorsInvalidHeaderValue(t *testing.T) {
+	const (
+		contentV1 = "||one.example^\n"
+		contentV2 = "||two.example^\n"
+	)
+
+	requests := make(chan http.Header, 2)
+	requestNum := &atomic.Uint32{}
+	pt := testutil.NewPanicT(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.Header.Clone()
+
+		content := contentV2
+		if requestNum.Add(1) == 1 {
+			w.Header().Set("ETag", `"v1"`)
+			content = contentV1
+		}
+
+		n, err := w.Write([]byte(content))
+		require.NoError(pt, err)
+		require.Equal(pt, len(content), n)
+	}))
+	t.Cleanup(srv.Close)
+
+	d := newDNSFilter(t)
+	flt := &FilterYAML{
+		URL: srv.URL,
+		Filter: Filter{
+			ID: 1,
+		},
+	}
+
+	updated, err := d.update(flt)
+	require.NoError(t, err)
+	require.True(t, updated)
+	assert.Empty(t, (<-requests).Get("If-None-Match"))
+
+	digest, err := d.currentFilterDigest(flt)
+	require.NoError(t, err)
+	metadata, err := json.Marshal(filterHTTPMetadata{
+		URL:    srv.URL,
+		ETag:   "invalid\x01etag",
+		Digest: digest,
+	})
+	require.NoError(t, err)
+	require.True(t, json.Valid(metadata))
+	require.NoError(t, os.WriteFile(flt.httpMetadataPath(d.conf.DataDir), metadata, 0o600))
+
+	updated, err = d.update(flt)
+	require.NoError(t, err)
+	require.True(t, updated)
+	assert.Empty(t, (<-requests).Get("If-None-Match"))
+	assert.Equal(t, uint32(2), requestNum.Load())
+
+	content, err := os.ReadFile(flt.Path(d.conf.DataDir))
+	require.NoError(t, err)
+	assert.Equal(t, contentV2, string(content))
+}
+
+func TestDNSFilter_UpdateHTTPValidatorsEditedContents(t *testing.T) {
+	const (
+		serverContent = "||server.example^\n"
+		editedContent = "||edited.example^\n"
+	)
+
+	requests := make(chan http.Header, 2)
+	pt := testutil.NewPanicT(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.Header.Clone()
+		w.Header().Set("ETag", `"v1"`)
+
+		n, err := w.Write([]byte(serverContent))
+		require.NoError(pt, err)
+		require.Equal(pt, len(serverContent), n)
+	}))
+	t.Cleanup(srv.Close)
+
+	d := newDNSFilter(t)
+	flt := &FilterYAML{
+		URL: srv.URL,
+		Filter: Filter{
+			ID: 1,
+		},
+	}
+
+	updated, err := d.update(flt)
+	require.NoError(t, err)
+	require.True(t, updated)
+	assert.Empty(t, (<-requests).Get("If-None-Match"))
+
+	require.NoError(t, os.WriteFile(flt.Path(d.conf.DataDir), []byte(editedContent), 0o600))
+
+	updated, err = d.update(flt)
+	require.NoError(t, err)
+	require.True(t, updated)
+	assert.Empty(t, (<-requests).Get("If-None-Match"))
+
+	content, err := os.ReadFile(flt.Path(d.conf.DataDir))
+	require.NoError(t, err)
+	assert.Equal(t, serverContent, string(content))
+}
+
+func TestDNSFilter_UpdateHTTPValidatorsEditedContentsMatchServer(t *testing.T) {
+	const (
+		contentV1 = "||one.example^\n"
+		contentV2 = "||two.example^\n"
+	)
+
+	requests := make(chan http.Header, 2)
+	requestNum := &atomic.Uint32{}
+	pt := testutil.NewPanicT(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.Header.Clone()
+
+		content := contentV2
+		etag := `"v2"`
+		if requestNum.Add(1) == 1 {
+			content = contentV1
+			etag = `"v1"`
+		}
+
+		w.Header().Set("ETag", etag)
+		n, err := w.Write([]byte(content))
+		require.NoError(pt, err)
+		require.Equal(pt, len(content), n)
+	}))
+	t.Cleanup(srv.Close)
+
+	d := newDNSFilter(t)
+	flt := &FilterYAML{
+		URL: srv.URL,
+		Filter: Filter{
+			ID: 1,
+		},
+	}
+
+	updated, err := d.update(flt)
+	require.NoError(t, err)
+	require.True(t, updated)
+	assert.Empty(t, (<-requests).Get("If-None-Match"))
+	checksumV1 := flt.checksum
+
+	// Simulate an external atomic replacement of the cache with the same V2
+	// representation that the server now returns.  The active filter is still
+	// V1, so the update must be reported even though disk and server match.
+	require.NoError(t, os.WriteFile(flt.Path(d.conf.DataDir), []byte(contentV2), 0o600))
+
+	updated, err = d.update(flt)
+	require.NoError(t, err)
+	require.True(t, updated)
+	assert.Empty(t, (<-requests).Get("If-None-Match"))
+	assert.NotEqual(t, checksumV1, flt.checksum)
+}
+
+func TestDNSFilter_UpdateHTTPValidatorsDifferentContentsSameChecksum(t *testing.T) {
+	const (
+		serverContent = "ab.com\ncd.com\n"
+		editedContent = "ab.comc\nd.com\n"
+		etag          = `"v1"`
+	)
+
+	requests := make(chan http.Header, 2)
+	pt := testutil.NewPanicT(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.Header.Clone()
+		if r.Header.Get("If-None-Match") == etag {
+			w.WriteHeader(http.StatusNotModified)
+
+			return
+		}
+
+		w.Header().Set("ETag", etag)
+		n, err := w.Write([]byte(serverContent))
+		require.NoError(pt, err)
+		require.Equal(pt, len(serverContent), n)
+	}))
+	t.Cleanup(srv.Close)
+
+	d := newDNSFilter(t)
+	flt := &FilterYAML{
+		URL: srv.URL,
+		Filter: Filter{
+			ID: 1,
+		},
+	}
+
+	updated, err := d.update(flt)
+	require.NoError(t, err)
+	require.True(t, updated)
+	assert.Empty(t, (<-requests).Get("If-None-Match"))
+
+	res, err := rulelist.NewParser().Parse(
+		io.Discard,
+		strings.NewReader(editedContent),
+		make([]byte, rulelist.DefaultRuleBufSize),
+	)
+	require.NoError(t, err)
+	require.Equal(t, flt.checksum, res.Checksum)
+	require.NoError(t, os.WriteFile(flt.Path(d.conf.DataDir), []byte(editedContent), 0o600))
+
+	updated, err = d.update(flt)
+	require.NoError(t, err)
+	require.True(t, updated)
+	assert.Empty(t, (<-requests).Get("If-None-Match"))
+
+	content, err := os.ReadFile(flt.Path(d.conf.DataDir))
+	require.NoError(t, err)
+	assert.Equal(t, serverContent, string(content))
+}
+
+func TestDNSFilter_UpdateHTTPValidatorsMissingContents(t *testing.T) {
+	const serverContent = "||server.example^\n"
+
+	requests := make(chan http.Header, 2)
+	pt := testutil.NewPanicT(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.Header.Clone()
+		w.Header().Set("ETag", `"v1"`)
+
+		n, err := w.Write([]byte(serverContent))
+		require.NoError(pt, err)
+		require.Equal(pt, len(serverContent), n)
+	}))
+	t.Cleanup(srv.Close)
+
+	d := newDNSFilter(t)
+	flt := &FilterYAML{
+		URL: srv.URL,
+		Filter: Filter{
+			ID: 1,
+		},
+	}
+
+	updated, err := d.update(flt)
+	require.NoError(t, err)
+	require.True(t, updated)
+	assert.Empty(t, (<-requests).Get("If-None-Match"))
+
+	filterPath := flt.Path(d.conf.DataDir)
+	require.NoError(t, os.Remove(filterPath))
+
+	updated, err = d.update(flt)
+	require.NoError(t, err)
+	require.True(t, updated)
+	assert.Empty(t, (<-requests).Get("If-None-Match"))
+
+	content, err := os.ReadFile(filterPath)
+	require.NoError(t, err)
+	assert.Equal(t, serverContent, string(content))
+}
+
+func TestDNSFilter_UpdateHTTPValidatorsRedirect(t *testing.T) {
+	const (
+		contentV1 = "||one.example^\n"
+		contentV2 = "||two.example^\n"
+		etag      = `"same"`
+		lastMod   = "Wed, 21 Oct 2015 07:28:00 GMT"
+	)
+
+	targetRequests := make(chan http.Header, 1)
+	pt := testutil.NewPanicT(t)
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetRequests <- r.Header.Clone()
+		if r.Header.Get("If-None-Match") == etag {
+			w.WriteHeader(http.StatusNotModified)
+
+			return
+		}
+
+		w.Header().Set("ETag", etag)
+		n, err := w.Write([]byte(contentV2))
+		require.NoError(pt, err)
+		require.Equal(pt, len(contentV2), n)
+	}))
+	t.Cleanup(target.Close)
+
+	requestNum := &atomic.Uint32{}
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requestNum.Add(1) == 1 {
+			w.Header().Set("ETag", etag)
+			w.Header().Set("Last-Modified", lastMod)
+			n, err := w.Write([]byte(contentV1))
+			require.NoError(pt, err)
+			require.Equal(pt, len(contentV1), n)
+
+			return
+		}
+
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	t.Cleanup(origin.Close)
+
+	d := newDNSFilter(t)
+	redirectNum := &atomic.Uint32{}
+	d.conf.HTTPClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) (err error) {
+		redirectNum.Add(1)
+
+		return nil
+	}
+	flt := &FilterYAML{
+		URL: origin.URL,
+		Filter: Filter{
+			ID: 1,
+		},
+	}
+
+	updated, err := d.update(flt)
+	require.NoError(t, err)
+	require.True(t, updated)
+	require.FileExists(t, flt.httpMetadataPath(d.conf.DataDir))
+
+	updated, err = d.update(flt)
+	targetHeader := <-targetRequests
+	require.NoError(t, err)
+	require.True(t, updated)
+	assert.Empty(t, targetHeader.Get("If-None-Match"))
+	assert.Empty(t, targetHeader.Get("If-Modified-Since"))
+	assert.Equal(t, uint32(1), redirectNum.Load())
+
+	content, err := os.ReadFile(flt.Path(d.conf.DataDir))
+	require.NoError(t, err)
+	assert.Equal(t, contentV2, string(content))
+	require.NoFileExists(t, flt.httpMetadataPath(d.conf.DataDir))
+}
+
+func TestDNSFilter_CurrentHTTPFilterStateMetadataSelection(t *testing.T) {
+	testCases := []struct {
+		name     string
+		metadata []byte
+	}{
+		{
+			name: "missing",
+		}, {
+			name:     "malformed",
+			metadata: []byte("{"),
+		}, {
+			name:     "validator_free",
+			metadata: []byte(`{"url":"https://example.org/filter.txt","digest":"bad"}`),
+		}, {
+			name: "invalid_digest",
+			metadata: []byte(
+				`{"url":"https://example.org/filter.txt","etag":"\"v1\"","digest":"bad"}`,
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newDNSFilter(t)
+			flt := &FilterYAML{
+				URL:        "https://example.org/filter.txt",
+				RulesCount: 1,
+				checksum:   1,
+				Filter: Filter{
+					ID: 1,
+				},
+			}
+			require.NoError(t, os.WriteFile(
+				flt.Path(d.conf.DataDir),
+				[]byte("<html></html>"),
+				0o600,
+			))
+			if tc.metadata != nil {
+				require.NoError(t, os.WriteFile(
+					flt.httpMetadataPath(d.conf.DataDir),
+					tc.metadata,
+					0o600,
+				))
+			}
+
+			ctx := context.Background()
+			metadata, hasMetadata := d.loadHTTPMetadata(ctx, flt)
+			digest, hasContents, useMetadata, forceUpdate := d.currentHTTPFilterState(
+				ctx,
+				flt,
+				metadata,
+				hasMetadata,
+			)
+			assert.NotEmpty(t, digest)
+			assert.True(t, hasContents)
+			assert.False(t, useMetadata)
+			assert.False(t, forceUpdate)
+		})
+	}
 }
 
 func TestFilterYAML_EnsureName(t *testing.T) {

--- a/internal/filtering/http.go
+++ b/internal/filtering/http.go
@@ -1,6 +1,7 @@
 package filtering
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -246,6 +247,8 @@ func (d *DNSFilter) handleFilteringRemoveURL(w http.ResponseWriter, r *http.Requ
 			return
 		}
 
+		d.removeHTTPMetadataAndLog(ctx, &deleted)
+
 		*filters = slices.Delete(*filters, delIdx, delIdx+1)
 
 		d.logger.InfoContext(ctx, "deleted filter", "id", deleted.ID)
@@ -270,6 +273,19 @@ func (d *DNSFilter) handleFilteringRemoveURL(w http.ResponseWriter, r *http.Requ
 			http.StatusInternalServerError,
 			"couldn't write body: %s",
 			err,
+		)
+	}
+}
+
+// removeHTTPMetadataAndLog removes flt's HTTP metadata and logs any error.
+func (d *DNSFilter) removeHTTPMetadataAndLog(ctx context.Context, flt *FilterYAML) {
+	err := d.removeHTTPMetadata(flt)
+	if err != nil {
+		d.logger.WarnContext(
+			ctx,
+			"removing filter http metadata",
+			"id", flt.ID,
+			slogutil.KeyError, err,
 		)
 	}
 }

--- a/internal/filtering/http_internal_test.go
+++ b/internal/filtering/http_internal_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -150,6 +152,92 @@ func TestDNSFilter_handleFilteringSetURL(t *testing.T) {
 			assert.Equal(t, tc.wantBody == "", confModifiedCalled)
 		})
 	}
+}
+
+func TestDNSFilter_handleFilteringRemoveURLRemovesHTTPMetadata(t *testing.T) {
+	const filterURL = "https://example.org/filter.txt"
+
+	confModifier := &aghtest.ConfigModifier{
+		OnApply: func(context.Context) {},
+	}
+	d, err := New(&Config{
+		Logger:       testLogger,
+		ConfModifier: confModifier,
+		HTTPReg:      aghhttp.EmptyRegistrar{},
+		DataDir:      t.TempDir(),
+		Filters: []FilterYAML{{
+			Enabled: false,
+			URL:     filterURL,
+			Filter: Filter{
+				ID: 1,
+			},
+		}},
+	}, nil)
+	require.NoError(t, err)
+	d.Start()
+	t.Cleanup(d.Close)
+
+	flt := &d.conf.Filters[0]
+	contentPath := flt.Path(d.conf.DataDir)
+	metadataPath := flt.httpMetadataPath(d.conf.DataDir)
+	require.NoError(t, os.WriteFile(contentPath, []byte("||example.org^\n"), 0o600))
+	digest, err := d.currentFilterDigest(flt)
+	require.NoError(t, err)
+	require.NoError(t, d.storeHTTPMetadata(flt, filterHTTPMetadata{
+		ETag:   `"v1"`,
+		Digest: digest,
+	}))
+	require.FileExists(t, metadataPath)
+
+	body, err := json.Marshal(&filterURLReq{
+		URL: filterURL,
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "http://example.org", bytes.NewReader(body))
+	resp := httptest.NewRecorder()
+
+	d.handleFilteringRemoveURL(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, "OK 0 rules\n", resp.Body.String())
+	require.NoFileExists(t, metadataPath)
+	require.FileExists(t, contentPath+".old")
+}
+
+func TestDNSFilter_handleFilteringAddURLEmptyHTTPMetadata(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("ETag", `"v1"`)
+		_, err := w.Write([]byte("! Empty filter\n"))
+		require.NoError(testutil.NewPanicT(t), err)
+	}))
+	t.Cleanup(srv.Close)
+
+	dataDir := t.TempDir()
+	d, err := New(&Config{
+		Logger:      testLogger,
+		DataDir:     dataDir,
+		HTTPClient:  srv.Client(),
+		MaxHTTPSize: testFilterSize,
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(d.Close)
+
+	body, err := json.Marshal(&filterAddJSON{
+		Name: "empty-filter",
+		URL:  srv.URL,
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "http://example.org", bytes.NewReader(body))
+	resp := httptest.NewRecorder()
+
+	d.handleFilteringAddURL(resp, req)
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Empty(t, d.conf.Filters)
+
+	files, err := filepath.Glob(filepath.Join(dataDir, filterDir, "*"))
+	require.NoError(t, err)
+	assert.Empty(t, files)
 }
 
 func TestDNSFilter_handleSafeBrowsingStatus(t *testing.T) {

--- a/internal/filtering/http_internal_test.go
+++ b/internal/filtering/http_internal_test.go
@@ -154,6 +154,73 @@ func TestDNSFilter_handleFilteringSetURL(t *testing.T) {
 	}
 }
 
+func TestDNSFilter_filterSetPropertiesHTTPMetadata(t *testing.T) {
+	const (
+		oldURL = "https://example.org/old.txt"
+		newURL = "https://example.org/new.txt"
+	)
+
+	testCases := []struct {
+		name             string
+		url              string
+		wantMetadataKept bool
+	}{
+		{
+			name:             "same_url",
+			url:              oldURL,
+			wantMetadataKept: true,
+		}, {
+			name: "changed_url",
+			url:  newURL,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newDNSFilter(t)
+			d.conf.Filters = []FilterYAML{{
+				Enabled:    true,
+				URL:        oldURL,
+				Name:       "test-filter",
+				RulesCount: 1,
+				Filter: Filter{
+					ID: 1,
+				},
+			}}
+
+			flt := &d.conf.Filters[0]
+			require.NoError(t, os.WriteFile(
+				flt.Path(d.conf.DataDir),
+				[]byte("||example.org^\n"),
+				0o600,
+			))
+			digest, err := d.currentFilterDigest(flt)
+			require.NoError(t, err)
+			require.NoError(t, d.storeHTTPMetadata(flt, filterHTTPMetadata{
+				ETag:   `"v1"`,
+				Digest: digest,
+			}))
+			metadataPath := flt.httpMetadataPath(d.conf.DataDir)
+			require.FileExists(t, metadataPath)
+
+			restart, err := d.filterSetProperties(oldURL, FilterYAML{
+				Enabled: false,
+				URL:     tc.url,
+				Name:    "test-filter",
+			}, false)
+			require.NoError(t, err)
+			assert.True(t, restart)
+			assert.False(t, flt.Enabled)
+			assert.Equal(t, tc.url, flt.URL)
+			if tc.wantMetadataKept {
+				require.FileExists(t, metadataPath)
+			} else {
+				require.NoFileExists(t, metadataPath)
+			}
+		})
+	}
+}
+
 func TestDNSFilter_handleFilteringRemoveURLRemovesHTTPMetadata(t *testing.T) {
 	const filterURL = "https://example.org/filter.txt"
 


### PR DESCRIPTION
## Summary

- cache HTTP `ETag` and `Last-Modified` validators for downloaded filter lists
- bind cached validators to the configured URL and SHA-256 of the exact local
  contents before sending a conditional request
- preserve correctness across redirects, manual cache edits, missing files,
  checksum collisions, failed downloads, and validator removal
- remove obsolete validator metadata when a filter is deleted or no longer has
  a reusable HTTP representation

## Testing

- [x] focused HTTP-validator regression tests under `-race`
- [x] full `internal/filtering` package under `-race`
- [x] `make go-check`
- [x] `git diff --check`

Fixes #7050.
