### PR TITLE
dnsforward: use bootstrap DNS for fallback upstreams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,10 @@ NOTE: Add new changes BELOW THIS COMMENT.
 
 - Blocked requests without an EDNS(0) OPT record ([#8183]).
 
+- Configured bootstrap DNS servers are now used to resolve fallback DNS server hostnames ([#7842]).
+
 [#8183]: https://github.com/AdguardTeam/AdGuardHome/issues/8183
+[#7842]: https://github.com/AdguardTeam/AdGuardHome/issues/7842
 
 <!--
 NOTE: Add new changes ABOVE THIS COMMENT.

--- a/internal/dnsforward/dnsforward.go
+++ b/internal/dnsforward/dnsforward.go
@@ -687,11 +687,11 @@ func (s *Server) setupFallbackDNS() (uc *proxy.UpstreamConfig, err error) {
 	}
 
 	uc, err = proxy.ParseUpstreamsConfig(fallbacks, &upstream.Options{
-		Logger: aghslog.NewForUpstream(s.baseLogger, aghslog.UpstreamTypeFallback),
+		Logger:    aghslog.NewForUpstream(s.baseLogger, aghslog.UpstreamTypeFallback),
+		Bootstrap: s.bootstrap,
 		// TODO(s.chzhen):  Investigate if other options are needed.
 		Timeout:    s.conf.UpstreamTimeout,
 		PreferIPv6: s.conf.BootstrapPreferIPv6,
-		// TODO(e.burkov):  Use bootstrap.
 	})
 	if err != nil {
 		// Do not wrap the error because it's informative enough as is.

--- a/internal/dnsforward/dnsforward_internal_test.go
+++ b/internal/dnsforward/dnsforward_internal_test.go
@@ -534,11 +534,28 @@ func TestServer_Prepare_fallbackBootstrap(t *testing.T) {
 
 	lookupCh := make(chan dns.Question, 4)
 	pt := testutil.NewPanicT(t)
+	failedBootstrapAddr := newLocalUpstreamListener(t, 0, dns.HandlerFunc(
+		func(_ dns.ResponseWriter, _ *dns.Msg) {},
+	))
 	bootstrapHandler := dns.HandlerFunc(func(w dns.ResponseWriter, req *dns.Msg) {
 		require.Len(pt, req.Question, 1)
-		testutil.RequireSend(pt, lookupCh, req.Question[0], testTimeout)
+		q := req.Question[0]
+		testutil.RequireSend(pt, lookupCh, q, testTimeout)
 
-		err := w.WriteMsg(new(dns.Msg).SetReply(req))
+		resp := new(dns.Msg).SetReply(req)
+		if q.Qtype == dns.TypeA {
+			resp.Answer = append(resp.Answer, &dns.A{
+				Hdr: dns.RR_Header{
+					Name:   q.Name,
+					Rrtype: dns.TypeA,
+					Class:  dns.ClassINET,
+					Ttl:    60,
+				},
+				A: net.IP(netutil.IPv4Localhost().AsSlice()),
+			})
+		}
+
+		err := w.WriteMsg(resp)
 		require.NoError(pt, err)
 	})
 	bootstrapAddr := newLocalUpstreamListener(t, 0, bootstrapHandler)
@@ -547,7 +564,10 @@ func TestServer_Prepare_fallbackBootstrap(t *testing.T) {
 		UpstreamTimeout: 100 * time.Millisecond,
 		TLSConf:         &TLSConfig{},
 		Config: Config{
-			BootstrapDNS: []string{"tcp://" + bootstrapAddr.String()},
+			BootstrapDNS: []string{
+				"tcp://" + failedBootstrapAddr.String(),
+				"tcp://" + bootstrapAddr.String(),
+			},
 			FallbackDNS: []string{
 				"tls://" + netutil.JoinHostPort(fallbackHost, 1),
 			},

--- a/internal/dnsforward/dnsforward_internal_test.go
+++ b/internal/dnsforward/dnsforward_internal_test.go
@@ -529,6 +529,55 @@ func TestServer_Prepare_fallbacks(t *testing.T) {
 	assert.Len(t, s.dnsProxy.Fallbacks.Upstreams, 1)
 }
 
+func TestServer_Prepare_fallbackBootstrap(t *testing.T) {
+	const fallbackHost = "fallback.example"
+
+	lookupCh := make(chan dns.Question, 4)
+	pt := testutil.NewPanicT(t)
+	bootstrapHandler := dns.HandlerFunc(func(w dns.ResponseWriter, req *dns.Msg) {
+		require.Len(pt, req.Question, 1)
+		testutil.RequireSend(pt, lookupCh, req.Question[0], testTimeout)
+
+		err := w.WriteMsg(new(dns.Msg).SetReply(req))
+		require.NoError(pt, err)
+	})
+	bootstrapAddr := newLocalUpstreamListener(t, 0, bootstrapHandler)
+
+	srvConf := &ServerConfig{
+		UpstreamTimeout: 100 * time.Millisecond,
+		TLSConf:         &TLSConfig{},
+		Config: Config{
+			BootstrapDNS: []string{"tcp://" + bootstrapAddr.String()},
+			FallbackDNS: []string{
+				"tls://" + netutil.JoinHostPort(fallbackHost, 1),
+			},
+			UpstreamMode:     UpstreamModeLoadBalance,
+			EDNSClientSubnet: &EDNSClientSubnet{Enabled: false},
+			ClientsContainer: EmptyClientsContainer{},
+		},
+		ServePlainDNS: true,
+	}
+
+	s, err := NewServer(DNSCreateParams{
+		Logger:            testLogger,
+		TLSConfigProvider: testTLSConfigProvider,
+	})
+	require.NoError(t, err)
+
+	ctx := testutil.ContextWithTimeout(t, testTimeout)
+	err = s.Prepare(ctx, srvConf)
+	require.NoError(t, err)
+	require.NotNil(t, s.dnsProxy.Fallbacks)
+	require.Len(t, s.dnsProxy.Fallbacks.Upstreams, 1)
+
+	_, err = s.dnsProxy.Fallbacks.Upstreams[0].Exchange(createGoogleATestMessage())
+	require.Error(t, err)
+
+	q, ok := testutil.RequireReceive(t, lookupCh, testTimeout)
+	require.True(t, ok)
+	assert.Equal(t, dns.Fqdn(fallbackHost), q.Name)
+}
+
 func TestServerWithProtectionDisabled(t *testing.T) {
 	s := createTestServer(
 		t,


### PR DESCRIPTION
## Summary

- pass AdGuard Home's configured bootstrap resolver into encrypted fallback
  upstream construction
- prevent fallback hostnames from silently using the operating system's
  default resolver
- add deterministic integration regressions proving that:
  - the configured bootstrap resolver receives the fallback-host lookup
  - one unavailable bootstrap server does not block another working bootstrap

## Testing

- [x] focused fallback-bootstrap regression, 20 times under `-race`
- [x] full `internal/dnsforward` package under `-race`
- [x] `make go-check`
- [x] `git diff --check`

Fixes #7842.

Related: #7931.
