### PR TITLE
dnsforward: test EDNS in filtered responses

### DIFF
--- a/internal/dnsforward/requesthandler_internal_test.go
+++ b/internal/dnsforward/requesthandler_internal_test.go
@@ -91,16 +91,47 @@ func TestServer_ServeDNS(t *testing.T) {
 	}
 	startDeferStop(t, s)
 
+	const ednsUDPSize = 1452
+
+	ednsReq := createTestMessage("blocked.domain.")
+	ednsReq.SetEdns0(ednsUDPSize, false)
+	dnssecReq := createTestMessage("blocked.domain.")
+	dnssecReq.SetEdns0(ednsUDPSize, true)
+
+	blockedAns := []dns.RR{&dns.A{
+		Hdr: dns.RR_Header{
+			Name:   "blocked.domain.",
+			Rrtype: dns.TypeA,
+			Class:  dns.ClassINET,
+		},
+		A: netutil.IPv4Zero(),
+	}}
+
 	testCases := []struct {
 		req       *dns.Msg
 		name      string
 		wantRCode int
 		wantAns   []dns.RR
+		wantEDNS  bool
+		wantDO    bool
 	}{{
 		req:       createTestMessage(aghtest.ReqFQDN),
 		name:      "pass",
 		wantRCode: dns.RcodeNameError,
 		wantAns:   nil,
+	}, {
+		req:       ednsReq,
+		name:      "blocked_edns",
+		wantRCode: dns.RcodeSuccess,
+		wantAns:   blockedAns,
+		wantEDNS:  true,
+	}, {
+		req:       dnssecReq,
+		name:      "blocked_edns_dnssec",
+		wantRCode: dns.RcodeSuccess,
+		wantAns:   blockedAns,
+		wantEDNS:  true,
+		wantDO:    true,
 	}, {
 		req:       createTestMessage("cname.exception."),
 		name:      "cname_exception",
@@ -211,6 +242,17 @@ func TestServer_ServeDNS(t *testing.T) {
 
 			assert.Equal(t, tc.wantRCode, dctx.Res.Rcode)
 			assert.Equal(t, tc.wantAns, dctx.Res.Answer)
+
+			respOPT := dctx.Res.IsEdns0()
+			if !tc.wantEDNS {
+				assert.Nil(t, respOPT)
+
+				return
+			}
+
+			require.NotNil(t, respOPT)
+			assert.Equal(t, uint16(ednsUDPSize), respOPT.UDPSize())
+			assert.Equal(t, tc.wantDO, respOPT.Do())
 		})
 	}
 }


### PR DESCRIPTION
Updates #8183.

The production fix is already present on current `master` in commit `4da21522`, but the filtered-response path had no regression coverage for the EDNS metadata that triggered the issue.

Extend the existing `TestServer_ServeDNS` integration table to verify that locally filtered responses:

- preserve the request EDNS UDP size;
- preserve both clear and set DNSSEC OK flags; and
- do not add an OPT record to requests that did not use EDNS.

The identical assertions fail against the parent of `4da21522` because the filtered response has no OPT record, and pass at that fix and on current `master`.

Validation:

```text
go test -race -count=20 -run "^TestServer_ServeDNS$/^blocked_edns" ./internal/dnsforward
PASS

go test -race -count=1 ./internal/dnsforward
PASS

make go-check
PASS

git diff --check
PASS
```