### PR TITLE
filtering: report all matching blocking rules

### DIFF
--- a/internal/filtering/filtering.go
+++ b/internal/filtering/filtering.go
@@ -791,6 +791,76 @@ func hostRulesToRules(netRules []*rules.HostRule) (res []rules.Rule) {
 	return res
 }
 
+// isBasicBlock returns true if r is a basic blocking rule.  r must not be nil.
+func isBasicBlock(r *rules.NetworkRule) (ok bool) {
+	if r.Whitelist {
+		return false
+	}
+
+	single := [1]*rules.NetworkRule{r}
+
+	return rules.GetDNSBasicRule(single[:]) == r
+}
+
+// networkBadfilters returns the badfilter rules from all.  Every element of all
+// must not be nil.
+func networkBadfilters(all []*rules.NetworkRule) (badfilters []*rules.NetworkRule) {
+	for _, r := range all {
+		if r.IsOptionEnabled(rules.OptionBadfilter) {
+			badfilters = append(badfilters, r)
+		}
+	}
+
+	return badfilters
+}
+
+// isEffectiveBasicBlock returns true if r remains a basic blocking rule after
+// applying badfilters.  r and every badfilter must not be nil.  processed must
+// have room for all badfilters followed by r when badfilters is not empty.
+func isEffectiveBasicBlock(
+	r *rules.NetworkRule,
+	badfilters []*rules.NetworkRule,
+	processed []*rules.NetworkRule,
+) (ok bool) {
+	if !isBasicBlock(r) {
+		return false
+	} else if len(badfilters) == 0 {
+		return true
+	}
+
+	processed[len(badfilters)] = r
+
+	return rules.GetDNSBasicRule(processed) == r
+}
+
+// networkRulesToRules returns the winning network rule and all other effective
+// basic blocking matches.  dnsres must not be nil and must have a network rule.
+func networkRulesToRules(dnsres *urlfilter.DNSResult) (res []rules.Rule) {
+	winner := dnsres.NetworkRule
+	res = append(res, winner)
+	if winner.Whitelist {
+		return res
+	}
+
+	badfilters := networkBadfilters(dnsres.NetworkRules)
+
+	var processed []*rules.NetworkRule
+	if len(badfilters) > 0 {
+		processed = make([]*rules.NetworkRule, len(badfilters)+1)
+		copy(processed, badfilters)
+	}
+
+	for _, r := range dnsres.NetworkRules {
+		if r == winner || !isEffectiveBasicBlock(r, badfilters, processed) {
+			continue
+		}
+
+		res = append(res, r)
+	}
+
+	return res
+}
+
 // matchHostProcessAllowList processes the allowlist logic of host matching.
 func (d *DNSFilter) matchHostProcessAllowList(
 	ctx context.Context,
@@ -831,7 +901,7 @@ func (d *DNSFilter) matchHostProcessDNSResult(
 			reason = NotFilteredAllowList
 		}
 
-		return makeResult([]rules.Rule{dnsres.NetworkRule}, reason)
+		return makeResult(networkRulesToRules(dnsres), reason)
 	}
 
 	if result, ok := resultFromHostRules(qtype, dnsres); ok {

--- a/internal/filtering/filtering_internal_test.go
+++ b/internal/filtering/filtering_internal_test.go
@@ -10,9 +10,11 @@ import (
 
 	"github.com/AdguardTeam/AdGuardHome/internal/aghtest"
 	"github.com/AdguardTeam/AdGuardHome/internal/filtering/hashprefix"
+	"github.com/AdguardTeam/AdGuardHome/internal/filtering/rulelist"
 	"github.com/AdguardTeam/golibs/logutil/slogutil"
 	"github.com/AdguardTeam/golibs/netutil"
 	"github.com/AdguardTeam/golibs/testutil"
+	"github.com/AdguardTeam/urlfilter"
 	"github.com/AdguardTeam/urlfilter/rules"
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
@@ -171,6 +173,162 @@ func TestDNSFilter_CheckHost_hostRules(t *testing.T) {
 	require.Len(t, res.Rules, 1)
 
 	assert.Equal(t, res.Rules[0].IP, netutil.IPv6Localhost())
+}
+
+func TestDNSFilter_CheckHost_networkRules(t *testing.T) {
+	const basicRule = "||blocked.example^"
+
+	testCases := []struct {
+		name         string
+		rules        []string
+		wantIDs      []rulelist.APIID
+		wantTexts    []string
+		wantPrimary  rulelist.APIID
+		wantText     string
+		wantReason   Reason
+		wantFiltered bool
+	}{
+		{
+			name:         "duplicate",
+			rules:        []string{basicRule, basicRule},
+			wantIDs:      []rulelist.APIID{1, 2},
+			wantTexts:    []string{basicRule, basicRule},
+			wantPrimary:  1,
+			wantText:     basicRule,
+			wantReason:   FilteredBlockList,
+			wantFiltered: true,
+		},
+		{
+			name:         "distinct",
+			rules:        []string{basicRule, basicRule + "$dnstype=A"},
+			wantIDs:      []rulelist.APIID{1, 2},
+			wantTexts:    []string{basicRule, basicRule + "$dnstype=A"},
+			wantPrimary:  2,
+			wantText:     basicRule + "$dnstype=A",
+			wantReason:   FilteredBlockList,
+			wantFiltered: true,
+		},
+		{
+			name:         "same_list",
+			rules:        []string{basicRule + "\n" + basicRule + "$dnstype=A"},
+			wantIDs:      []rulelist.APIID{1, 1},
+			wantTexts:    []string{basicRule, basicRule + "$dnstype=A"},
+			wantPrimary:  1,
+			wantText:     basicRule + "$dnstype=A",
+			wantReason:   FilteredBlockList,
+			wantFiltered: true,
+		},
+		{
+			name: "losing_exception",
+			rules: []string{
+				basicRule,
+				"@@" + basicRule,
+				basicRule + "$important",
+			},
+			wantIDs:      []rulelist.APIID{1, 3},
+			wantTexts:    []string{basicRule, basicRule + "$important"},
+			wantPrimary:  3,
+			wantText:     basicRule + "$important",
+			wantReason:   FilteredBlockList,
+			wantFiltered: true,
+		},
+		{
+			name: "badfilter",
+			rules: []string{
+				basicRule,
+				basicRule + "$badfilter",
+				basicRule + "$important",
+			},
+			wantIDs:      []rulelist.APIID{3},
+			wantTexts:    []string{basicRule + "$important"},
+			wantPrimary:  3,
+			wantText:     basicRule + "$important",
+			wantReason:   FilteredBlockList,
+			wantFiltered: true,
+		},
+		{
+			name:         "winning_exception",
+			rules:        []string{basicRule, "@@" + basicRule},
+			wantIDs:      []rulelist.APIID{2},
+			wantTexts:    []string{"@@" + basicRule},
+			wantPrimary:  2,
+			wantText:     "@@" + basicRule,
+			wantReason:   NotFilteredAllowList,
+			wantFiltered: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			filters := make([]Filter, len(tc.rules))
+			for i, rule := range tc.rules {
+				filters[i] = Filter{
+					ID:   rules.ListID(i + 1),
+					Data: []byte(rule + "\n"),
+				}
+			}
+
+			d, setts := newForTest(t, nil, filters)
+			t.Cleanup(d.Close)
+
+			res, err := d.CheckHostRules("blocked.example", dns.TypeA, setts)
+			require.NoError(t, err)
+			require.NotEmpty(t, res.Rules)
+
+			gotIDs := make([]rulelist.APIID, len(res.Rules))
+			gotTexts := make([]string, len(res.Rules))
+			for i, r := range res.Rules {
+				gotIDs[i] = r.FilterListID
+				gotTexts[i] = r.Text
+			}
+
+			assert.Equal(t, tc.wantPrimary, gotIDs[0])
+			assert.Equal(t, tc.wantText, gotTexts[0])
+			assert.ElementsMatch(t, tc.wantIDs, gotIDs)
+			assert.ElementsMatch(t, tc.wantTexts, gotTexts)
+			assert.Equal(t, tc.wantReason, res.Reason)
+			assert.Equal(t, tc.wantFiltered, res.IsFiltered)
+		})
+	}
+}
+
+func TestNetworkRulesToRules_effectiveBasicBlocks(t *testing.T) {
+	newRule := func(text string, id rules.ListID) (r *rules.NetworkRule) {
+		r, err := rules.NewNetworkRule(text, id)
+		require.NoError(t, err)
+
+		return r
+	}
+
+	winner := newRule("||blocked.example^$important", 1)
+	active := newRule("|blocked.example|", 2)
+	disabled := newRule("||blocked.example^", 3)
+	badfilter := newRule("||blocked.example^$badfilter", 4)
+	exception := newRule("@@||blocked.example^", 5)
+	rewrite := newRule("||blocked.example^$dnsrewrite=NOERROR;A;192.0.2.1", 6)
+	cosmetic := newRule("@@||blocked.example^$elemhide", 7)
+	unrelatedBadfilter := newRule("||blocked.example^$dnstype=AAAA,badfilter", 8)
+
+	dnsres := &urlfilter.DNSResult{
+		NetworkRule: winner,
+		NetworkRules: []*rules.NetworkRule{
+			disabled,
+			badfilter,
+			exception,
+			rewrite,
+			cosmetic,
+			unrelatedBadfilter,
+			active,
+			winner,
+		},
+	}
+
+	got := networkRulesToRules(dnsres)
+	assert.Equal(t, []rules.Rule{winner, active}, got)
+
+	dnsres.NetworkRule = exception
+	got = networkRulesToRules(dnsres)
+	assert.Equal(t, []rules.Rule{exception}, got)
 }
 
 // Safe Browsing.

--- a/internal/filtering/http_internal_test.go
+++ b/internal/filtering/http_internal_test.go
@@ -468,9 +468,10 @@ func TestDNSFilter_HandleCheckHost(t *testing.T) {
 		want: &checkHostResp{
 			Reason: reasonNames[FilteredBlockList],
 			Rule:   blockedClientQTypeRule,
-			Rules: []*checkHostRespRule{{
-				Text: blockedClientQTypeRule,
-			}},
+			Rules: []*checkHostRespRule{
+				{Text: blockedClientQTypeRule},
+				{Text: blockedQTypeRule},
+			},
 		},
 	}, {
 		name: "allowed_client_qtype",

--- a/openapi/CHANGELOG.md
+++ b/openapi/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## v0.107.79: API changes
 
+- The `rules` fields in `GET /control/filtering/check_host` and
+  `GET /control/querylog` now contain all effective basic blocking rules that
+  matched a blocked request.  The selected rule remains the first item.
+
 - Field `bootstrap_dns` in `POST /control/dns_config` now accepts comments.  A comment must start with the `#` symbol.
 
 - Fixed wrong property names: `enable` → `enabled` in the Parental status response, `protection_disabled_until` → `protection_disabled_duration` in `ServerStatus`, `ratelimit_subnet_subnet_len_ipv4` and `ratelimit_subnet_subnet_len_ipv6` in `DNSConfig`.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1848,7 +1848,11 @@
 
             Deprecated: use `rules[*].text` instead.
         'rules':
-          'description': 'Applied rules.'
+          'description': >
+            Rules associated with the result.  For a blocked request using
+            network rules, the selected rule is first, followed by all other
+            effective basic blocking matches.  The first item is also exposed
+            through the deprecated `rule` and `filter_id` fields.
           'type': 'array'
           'items':
             '$ref': '#/components/schemas/ResultRule'
@@ -2358,7 +2362,11 @@
 
             Deprecated: use `rules[*].text` instead.
         'rules':
-          'description': 'Applied rules.'
+          'description': >
+            Rules associated with the result.  For a blocked request using
+            network rules, the selected rule is first, followed by all other
+            effective basic blocking matches.  The first item is also exposed
+            through the deprecated `rule` and `filterId` fields.
           'type': 'array'
           'items':
             '$ref': '#/components/schemas/ResultRule'
@@ -2480,7 +2488,7 @@
     'PutQueryLogConfigUpdateRequest':
       '$ref': '#/components/schemas/GetQueryLogConfigResponse'
     'ResultRule':
-      'description': 'Applied rule.'
+      'description': 'A filtering rule associated with a result.'
       'properties':
         'filter_list_id':
           'description': >


### PR DESCRIPTION
## Summary

- Preserve the selected blocking network rule as the first reported rule.
- Report every other effective basic blocking network rule that matched the
  request.
- Exclude exceptions, DNS rewrites, cosmetic rules, and rules disabled by
  `$badfilter`.
- Document the expanded `rules` response for filtering checks and query-log
  entries.

This gives users the complete blocklist provenance requested in #8262 without
changing the filtering decision.  Compatibility fields continue to expose the
selected first rule, and host-rule behavior is unchanged.

## Regression coverage

The tests cover duplicate rules from different lists, distinct rules, multiple
matches from one list, important rules versus exceptions, `$badfilter`, a
winning exception, and the filtering-check API response.

## Validation

```text
PASS: go test -race -count=10 -run '^(TestDNSFilter_CheckHost_networkRules|TestNetworkRulesToRules_effectiveBasicBlocks)$' ./internal/filtering
PASS: go test -race -count=1 ./internal/filtering
PASS: make go-check
PASS: make md-lint
PASS: ruby -e 'require "yaml"; YAML.load_file("openapi/openapi.yaml")'
PASS: gofmt inspection
PASS: git diff --check
```

Closes #8262.
