### PR TITLE
go.mod: bump insomniacslk/dhcp past the nclient4 ReadFrom panic fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/google/renameio/v2 v2.0.2
 	github.com/google/uuid v1.6.0
 	github.com/gopacket/gopacket v1.7.0
-	github.com/insomniacslk/dhcp v0.0.0-20260603135910-a415979eb11e
+	github.com/insomniacslk/dhcp v0.0.0-20260719225207-c76316d4aa82
 	// TODO(e.burkov):  Get rid of this dependency.  At least, don't update it,
 	// unless all custom templates will be migrated to the new format, see
 	// https://github.com/kardianos/service/issues/418.

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714 h1:/jC7qQFrv8CrSJVmaolDVOxTfS9kc36uB6H40kdbQq8=
 github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714/go.mod h1:2Goc3h8EklBH5mspfHFxBnEoURQCGzQQH1ga9Myjvis=
-github.com/insomniacslk/dhcp v0.0.0-20260603135910-a415979eb11e h1:7j1+lOuGBg7PQF1RxeVx0iP+/GpiAxSG/F+9t5JOS94=
-github.com/insomniacslk/dhcp v0.0.0-20260603135910-a415979eb11e/go.mod h1:qfvBmyDNp+/liLEYWRvqny/PEz9hGe2Dz833eXILSmo=
+github.com/insomniacslk/dhcp v0.0.0-20260719225207-c76316d4aa82 h1:y5aU8Uvl7eyM5WNgdQvRxbMJb+zo7pD+S72/Yo4pvnQ=
+github.com/insomniacslk/dhcp v0.0.0-20260719225207-c76316d4aa82/go.mod h1:qfvBmyDNp+/liLEYWRvqny/PEz9hGe2Dz833eXILSmo=
 github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8iyZjg=
 github.com/invopop/jsonschema v0.14.0/go.mod h1:ygm6C2EaVNMBDPpaPlnOA2pFAxBnxGjFlMZABxm9n2I=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=


### PR DESCRIPTION
This bumps `insomniacslk/dhcp` past insomniacslk/dhcp#583, which I wrote. AdGuard Home reaches the affected code through its check for other DHCP servers: on Linux `aghnet.listenPacketReusable` returns `nclient4.NewRawUDPConn` and `tryConn4` calls `ReadFrom` on it (`internal/aghnet/dhcp_unix.go`, `interfaces_linux.go`), reached from the DHCP HTTP handler in `internal/dhcpd/http_unix.go`.

Before #583, `BroadcastRawUDPConn.ReadFrom` subtracted the 8-byte UDP header from the IPv4 payload length without checking the payload was that long, so a malformed reply could drive the length negative and panic on a bad slice bound. A malformed frame can trigger a panic in that probe receive path; whether it becomes a process-wide termination depends on the surrounding recovery boundary. The current pin is the June 3 snapshot, before the fix.

The change is dependency metadata only: one line in `go.mod` and the matching hashes in `go.sum`. After `go mod tidy`, `go build ./...` and `go vet ./internal/aghnet/... ./internal/dhcpd/...` pass. No CVE for it, and I haven't tried to reproduce a crash inside AdGuard Home.

CONTRIBUTING asks to discuss changes in an issue first. Since this is a one-line bump for an already-merged upstream fix I opened the PR directly, but I'm happy to file an issue if you'd rather track it that way.
