### PR TITLE
dnsforward: add use_client_addr_from_ecs for ECS-based client identification

### DIFF
--- a/client/src/__locales/en.json
+++ b/client/src/__locales/en.json
@@ -251,6 +251,8 @@
   "edns_enable": "Enable EDNS client subnet",
   "edns_use_custom_ip": "Use custom IP for EDNS",
   "edns_use_custom_ip_desc": "Allow to use custom IP for EDNS",
+  "edns_use_client_addr": "Use client address from ECS",
+  "edns_use_client_addr_desc": "Identify clients by their EDNS Client Subnet instead of the connection address.",
   "elapsed": "Elapsed",
   "empty_response_status": "Empty",
   "enable_protection": "Enable protection",

--- a/client/src/components/Settings/Dns/Config/Form.tsx
+++ b/client/src/components/Settings/Dns/Config/Form.tsx
@@ -19,6 +19,7 @@ type FormData = {
     edns_cs_enabled: boolean;
     edns_cs_use_custom: boolean;
     edns_cs_custom_ip?: string;
+    edns_cs_use_client_addr?: boolean;
     dnssec_enabled: boolean;
     disable_ipv6: boolean;
     blocking_mode: string;
@@ -275,6 +276,24 @@ const Form = ({ processing, initialValues, onSubmit }: Props) => {
                             )}
                         />
                     )}
+                </div>
+
+                <div className="col-12">
+                    <div className="form__group form__group--settings">
+                        <Controller
+                            name="edns_cs_use_client_addr"
+                            control={control}
+                            render={({ field }) => (
+                                <Checkbox
+                                    {...field}
+                                    data-testid="dns_config_edns_use_client_addr"
+                                    title={t('edns_use_client_addr')}
+                                    subtitle={t('edns_use_client_addr_desc')}
+                                    disabled={processing || !edns_cs_enabled}
+                                />
+                            )}
+                        />
+                    </div>
                 </div>
 
                 {checkboxes.map(({ name, placeholder, subtitle }) => (

--- a/client/src/components/Settings/Dns/Config/index.tsx
+++ b/client/src/components/Settings/Dns/Config/index.tsx
@@ -23,6 +23,7 @@ const Config = () => {
         edns_cs_enabled,
         edns_cs_use_custom,
         edns_cs_custom_ip,
+        edns_cs_use_client_addr,
         dnssec_enabled,
         disable_ipv6,
         processingSetConfig,
@@ -50,6 +51,7 @@ const Config = () => {
                         dnssec_enabled,
                         edns_cs_use_custom,
                         edns_cs_custom_ip,
+                        edns_cs_use_client_addr,
                     }}
                     onSubmit={handleFormSubmit}
                     processing={processingSetConfig}

--- a/client/src/initialState.ts
+++ b/client/src/initialState.ts
@@ -329,6 +329,7 @@ export type DnsConfigData = {
     ratelimit_subnet_len_ipv6?: number;
     edns_cs_use_custom?: boolean;
     edns_cs_custom_ip?: string;
+    edns_cs_use_client_addr?: boolean;
     cache_enabled?: boolean;
     cache_size?: number;
     cache_ttl_max?: number;
@@ -502,6 +503,7 @@ export const initialState: RootState = {
         blocked_response_ttl: 10,
         upstream_timeout: 10,
         edns_cs_enabled: false,
+        edns_cs_use_client_addr: false,
         disable_ipv6: false,
         dnssec_enabled: false,
         upstream_dns_file: '',

--- a/client/src/reducers/dnsConfig.ts
+++ b/client/src/reducers/dnsConfig.ts
@@ -68,6 +68,7 @@ const dnsConfig = handleActions(
         blocked_response_ttl: 10,
         upstream_timeout: 10,
         edns_cs_enabled: false,
+        edns_cs_use_client_addr: false,
         disable_ipv6: false,
         dnssec_enabled: false,
         upstream_dns_file: '',

--- a/internal/dnsforward/config.go
+++ b/internal/dnsforward/config.go
@@ -180,6 +180,10 @@ type EDNSClientSubnet struct {
 
 	// UseCustom defines if CustomIP should be used.
 	UseCustom bool `yaml:"use_custom"`
+
+	// UseClientAddrFromECS defines if the EDNS Client Subnet is used for
+	// client identification instead of the connection address.
+	UseClientAddrFromECS bool `yaml:"use_client_addr_from_ecs"`
 }
 
 // TLSConfig contains the TLS configuration settings for DNSCrypt,

--- a/internal/dnsforward/context.go
+++ b/internal/dnsforward/context.go
@@ -3,6 +3,7 @@ package dnsforward
 import (
 	"context"
 	"fmt"
+	"net/netip"
 )
 
 // ctxKey is the type for context keys.
@@ -11,6 +12,7 @@ type ctxKey int
 // Context key values.
 const (
 	ctxKeyClientID ctxKey = iota
+	ctxKeyECSClientAddr
 )
 
 // contextWithClientID returns a new context with the given ID.
@@ -31,4 +33,24 @@ func clientIDFromContext(ctx context.Context) (id string, ok bool) {
 	}
 
 	return id, true
+}
+
+// contextWithECSClientAddr returns a new context with the ECS client address.
+func contextWithECSClientAddr(parent context.Context, addr netip.Addr) (ctx context.Context) {
+	return context.WithValue(parent, ctxKeyECSClientAddr, addr)
+}
+
+// ecsClientAddrFromContext returns the ECS client address for this request.
+func ecsClientAddrFromContext(ctx context.Context) (addr netip.Addr, ok bool) {
+	v := ctx.Value(ctxKeyECSClientAddr)
+	if v == nil {
+		return addr, false
+	}
+
+	addr, ok = v.(netip.Addr)
+	if !ok {
+		panic(fmt.Errorf("bad type for ctxKeyECSClientAddr: %T(%[1]v)", v))
+	}
+
+	return addr, true
 }

--- a/internal/dnsforward/ecs_internal_test.go
+++ b/internal/dnsforward/ecs_internal_test.go
@@ -1,0 +1,141 @@
+package dnsforward
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/AdguardTeam/dnsproxy/proxy"
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestECSClientAddr is a test for the ecsClientAddr function.
+func TestECSClientAddr(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		msg    func(t *testing.T) *dns.Msg
+		wantOK bool
+		wantIP netip.Addr
+	}{{
+		name: "no_opt",
+		msg: func(t *testing.T) (m *dns.Msg) {
+			return new(dns.Msg)
+		},
+	}, {
+		name: "opt_without_ecs",
+		msg: func(t *testing.T) (m *dns.Msg) {
+			o := new(dns.OPT)
+			o.Hdr.Name = "."
+			o.Hdr.Rrtype = dns.TypeOPT
+			m = new(dns.Msg)
+			m.Extra = append(m.Extra, o)
+			return m
+		},
+	}, {
+		name: "ecs_v4",
+		msg: func(t *testing.T) (m *dns.Msg) {
+			return newTestMsgWithECS(t, 1, 24, "1.2.3.4")
+		},
+		wantOK: true,
+		wantIP: netip.MustParseAddr("1.2.3.4"),
+	}, {
+		name: "ecs_v6",
+		msg: func(t *testing.T) (m *dns.Msg) {
+			return newTestMsgWithECS(t, 2, 56, "2001:db8::1")
+		},
+		wantOK: true,
+		wantIP: netip.MustParseAddr("2001:db8::1"),
+	}, {
+		name: "ecs_unknown_family",
+		msg: func(t *testing.T) (m *dns.Msg) {
+			return newTestMsgWithECS(t, 3, 24, "1.2.3.4")
+		},
+	}, {
+		name: "ecs_unspecified",
+		msg: func(t *testing.T) (m *dns.Msg) {
+			return newTestMsgWithECS(t, 1, 24, "0.0.0.0")
+		},
+	}, {
+		name: "ecs_invalid_v4",
+		msg: func(t *testing.T) (m *dns.Msg) {
+			// A v6 address advertised as an IPv4 ECS option should be skipped.
+			return newTestMsgWithECS(t, 1, 24, "2001:db8::1")
+		},
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			addr, ok := ecsClientAddr(tc.msg(t))
+			assert.Equal(t, tc.wantOK, ok)
+			if tc.wantOK {
+				assert.Equal(t, tc.wantIP, addr)
+			} else {
+				assert.False(t, addr.IsValid())
+			}
+		})
+	}
+}
+
+// newTestMsgWithECS returns a new DNS message with an EDNS Client Subnet
+// option using the given family, netmask and address.
+func newTestMsgWithECS(t *testing.T, family uint16, netmask uint8, addr string) (m *dns.Msg) {
+	t.Helper()
+
+	ip := net.ParseIP(addr)
+	require.NotNil(t, ip)
+
+	o := &dns.OPT{
+		Hdr: dns.RR_Header{
+			Name:   ".",
+			Rrtype: dns.TypeOPT,
+		},
+	}
+	o.SetUDPSize(4096)
+
+	e := &dns.EDNS0_SUBNET{
+		Code:          dns.EDNS0SUBNET,
+		Family:        family,
+		SourceNetmask: netmask,
+		SourceScope:   0,
+		Address:       ip,
+	}
+	o.Option = append(o.Option, e)
+
+	m = new(dns.Msg)
+	m.Extra = append(m.Extra, o)
+
+	return m
+}
+
+// TestDNSContext_clientAddr is a test for the clientAddr method.
+func TestDNSContext_clientAddr(t *testing.T) {
+	t.Parallel()
+
+	const (
+		connAddr = "192.168.1.1"
+		ecsAddr  = "192.168.1.100"
+	)
+
+	dctx := &dnsContext{
+		proxyCtx: &proxy.DNSContext{
+			Addr: netip.AddrPortFrom(netip.MustParseAddr(connAddr), 53),
+		},
+	}
+
+	// Without ECS, the connection address is used.
+	assert.Equal(t, netip.MustParseAddr(connAddr), dctx.clientAddr())
+
+	// With ECS set, it takes precedence.
+	dctx.ecsClientAddr = netip.MustParseAddr(ecsAddr)
+	assert.Equal(t, netip.MustParseAddr(ecsAddr), dctx.clientAddr())
+
+	// Clearing it falls back again.
+	dctx.ecsClientAddr = netip.Addr{}
+	assert.Equal(t, netip.MustParseAddr(connAddr), dctx.clientAddr())
+}

--- a/internal/dnsforward/filter.go
+++ b/internal/dnsforward/filter.go
@@ -18,7 +18,7 @@ import (
 func (s *Server) clientRequestFilteringSettings(dctx *dnsContext) (setts *filtering.Settings) {
 	setts = s.dnsFilter.Settings()
 	setts.ProtectionEnabled = dctx.protectionEnabled
-	s.dnsFilter.ApplyAdditionalFiltering(dctx.proxyCtx.Addr.Addr(), dctx.clientID, setts)
+	s.dnsFilter.ApplyAdditionalFiltering(dctx.clientAddr(), dctx.clientID, setts)
 
 	return setts
 }

--- a/internal/dnsforward/http.go
+++ b/internal/dnsforward/http.go
@@ -73,6 +73,9 @@ type jsonDNSConfig struct {
 	// EDNSCSUseCustom defines if EDNSCSCustomIP should be used.
 	EDNSCSUseCustom *bool `json:"edns_cs_use_custom"`
 
+	// EDNSCSUseClientAddr defines if the client address comes from ECS.
+	EDNSCSUseClientAddr *bool `json:"edns_cs_use_client_addr"`
+
 	// DNSSECEnabled defines if DNSSEC is enabled.
 	DNSSECEnabled *bool `json:"dnssec_enabled"`
 
@@ -163,6 +166,7 @@ func (s *Server) getDNSConfig(ctx context.Context) (c *jsonDNSConfig) {
 	customIP := s.conf.EDNSClientSubnet.CustomIP
 	enableEDNSClientSubnet := s.conf.EDNSClientSubnet.Enabled
 	useCustom := s.conf.EDNSClientSubnet.UseCustom
+	useClientAddrFromECS := s.conf.EDNSClientSubnet.UseClientAddrFromECS
 
 	enableDNSSEC := s.conf.EnableDNSSEC
 	aaaaDisabled := s.conf.AAAADisabled
@@ -209,6 +213,7 @@ func (s *Server) getDNSConfig(ctx context.Context) (c *jsonDNSConfig) {
 		EDNSCSCustomIP:           customIP,
 		EDNSCSEnabled:            &enableEDNSClientSubnet,
 		EDNSCSUseCustom:          &useCustom,
+		EDNSCSUseClientAddr:      &useClientAddrFromECS,
 		DNSSECEnabled:            &enableDNSSEC,
 		DisableIPv6:              &aaaaDisabled,
 		BlockedResponseTTL:       &blockedResponseTTL,
@@ -659,6 +664,7 @@ func (s *Server) setConfigRestartable(dc *jsonDNSConfig) (shouldRestart bool) {
 		setIfNotNil(&s.conf.FallbackDNS, dc.Fallbacks),
 		setIfNotNil(&s.conf.EDNSClientSubnet.Enabled, dc.EDNSCSEnabled),
 		setIfNotNil(&s.conf.EDNSClientSubnet.UseCustom, dc.EDNSCSUseCustom),
+		setIfNotNil(&s.conf.EDNSClientSubnet.UseClientAddrFromECS, dc.EDNSCSUseClientAddr),
 		setIfNotNil(&s.conf.CacheEnabled, dc.CacheEnabled),
 		setIfNotNil(&s.conf.CacheSize, dc.CacheSize),
 		setIfNotNil(&s.conf.CacheMinTTL, dc.CacheMinTTL),

--- a/internal/dnsforward/middleware.go
+++ b/internal/dnsforward/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/netip"
 	"time"
 
 	"github.com/AdguardTeam/AdGuardHome/internal/aghnet"
@@ -34,7 +35,15 @@ func (s *Server) Wrap(h proxy.Handler) (wrapped proxy.Handler) {
 			return nil
 		}
 
-		blocked, _ := s.IsBlockedClient(pctx.Addr.Addr(), clientID)
+		// Try to extract the client address from the EDNS Client Subnet option.
+		clientAddr := pctx.Addr.Addr()
+		if s.conf.EDNSClientSubnet.UseClientAddrFromECS {
+			if ecsAddr, ok := ecsClientAddr(pctx.Req); ok {
+				clientAddr = ecsAddr
+			}
+		}
+
+		blocked, _ := s.IsBlockedClient(clientAddr, clientID)
 		if blocked {
 			return s.serveBlockedResponse(pctx)
 		}
@@ -48,10 +57,53 @@ func (s *Server) Wrap(h proxy.Handler) (wrapped proxy.Handler) {
 			ctx = contextWithClientID(ctx, clientID)
 		}
 
+		// Store the ECS client address in context for downstream processors.
+		if clientAddr != pctx.Addr.Addr() {
+			ctx = contextWithECSClientAddr(ctx, clientAddr)
+		}
+
 		return h.ServeDNS(ctx, p, pctx)
 	}
 
 	return proxy.HandlerFunc(f)
+}
+
+// ecsClientAddr extracts the client IP from the EDNS Client Subnet option, or
+// the zero address and false if absent.
+func ecsClientAddr(req *dns.Msg) (addr netip.Addr, ok bool) {
+	opt := req.IsEdns0()
+	if opt == nil {
+		return netip.Addr{}, false
+	}
+
+	for _, o := range opt.Option {
+		ecs, ok := o.(*dns.EDNS0_SUBNET)
+		if !ok {
+			continue
+		}
+
+		switch ecs.Family {
+		case 1:
+			// IPv4.
+			ip := ecs.Address.To4()
+			if ip == nil {
+				continue
+			}
+
+			addr, ok = netip.AddrFromSlice(ip)
+			if ok && addr.IsValid() && !addr.IsUnspecified() {
+				return addr, true
+			}
+		case 2:
+			// IPv6.
+			addr, ok = netip.AddrFromSlice(ecs.Address)
+			if ok && addr.IsValid() && !addr.IsUnspecified() {
+				return addr, true
+			}
+		}
+	}
+
+	return netip.Addr{}, false
 }
 
 // serveBlockedResponse sets a protocol-appropriate response for a request that

--- a/internal/dnsforward/middleware.go
+++ b/internal/dnsforward/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/netip"
 	"time"
 
@@ -82,28 +83,39 @@ func ecsClientAddr(req *dns.Msg) (addr netip.Addr, ok bool) {
 			continue
 		}
 
-		switch ecs.Family {
-		case 1:
-			// IPv4.
-			ip := ecs.Address.To4()
-			if ip == nil {
-				continue
-			}
-
-			addr, ok = netip.AddrFromSlice(ip)
-			if ok && addr.IsValid() && !addr.IsUnspecified() {
-				return addr, true
-			}
-		case 2:
-			// IPv6.
-			addr, ok = netip.AddrFromSlice(ecs.Address)
-			if ok && addr.IsValid() && !addr.IsUnspecified() {
-				return addr, true
-			}
+		if addr, ok = ecsSubnetAddr(ecs); ok {
+			return addr, true
 		}
 	}
 
 	return netip.Addr{}, false
+}
+
+// ecsSubnetAddr returns the client address from an EDNS Client Subnet option,
+// or the zero address and false if the option is absent or invalid.
+func ecsSubnetAddr(ecs *dns.EDNS0_SUBNET) (addr netip.Addr, ok bool) {
+	var ip net.IP
+	switch ecs.Family {
+	case 1:
+		// IPv4.
+		ip = ecs.Address.To4()
+	case 2:
+		// IPv6.
+		ip = ecs.Address
+	default:
+		return netip.Addr{}, false
+	}
+
+	if ip == nil {
+		return netip.Addr{}, false
+	}
+
+	addr, ok = netip.AddrFromSlice(ip)
+	if !ok || !addr.IsValid() || addr.IsUnspecified() {
+		return netip.Addr{}, false
+	}
+
+	return addr, true
 }
 
 // serveBlockedResponse sets a protocol-appropriate response for a request that

--- a/internal/dnsforward/process.go
+++ b/internal/dnsforward/process.go
@@ -21,6 +21,9 @@ import (
 type dnsContext struct {
 	proxyCtx *proxy.DNSContext
 
+	// ecsClientAddr is the client address from the EDNS Client Subnet option.
+	ecsClientAddr netip.Addr
+
 	// setts are the filtering settings for the client.
 	setts *filtering.Settings
 
@@ -57,6 +60,16 @@ type dnsContext struct {
 	// isDHCPHost is true if the request for a local domain name and the DHCP is
 	// available for this request.
 	isDHCPHost bool
+}
+
+// clientAddr returns the ECS client address if set, or the connection address
+// otherwise.
+func (dctx *dnsContext) clientAddr() netip.Addr {
+	if dctx.ecsClientAddr.IsValid() {
+		return dctx.ecsClientAddr
+	}
+
+	return dctx.proxyCtx.Addr.Addr()
 }
 
 // resultCode is the result of a request processing function.
@@ -110,7 +123,13 @@ func (s *Server) processInitial(
 	defer l.DebugContext(ctx, "finished processing initial")
 
 	pctx := dctx.proxyCtx
-	s.processClientIP(ctx, l, pctx.Addr.Addr())
+
+	// Check for the ECS client address passed from the middleware.
+	if ecsAddr, ok := ecsClientAddrFromContext(ctx); ok {
+		dctx.ecsClientAddr = ecsAddr
+	}
+
+	s.processClientIP(ctx, l, dctx.clientAddr())
 
 	q := pctx.Req.Question[0]
 	qt := q.Qtype

--- a/internal/dnsforward/stats.go
+++ b/internal/dnsforward/stats.go
@@ -29,7 +29,7 @@ func (s *Server) processQueryLogsAndStats(
 	host := aghnet.NormalizeDomain(q.Name)
 	processingTime := time.Since(dctx.startTime)
 
-	ip := pctx.Addr.Addr().AsSlice()
+	ip := dctx.clientAddr().AsSlice()
 	s.anonymizer.Load()(ip)
 	ipStr := net.IP(ip).String()
 

--- a/internal/dnsforward/testdata/TestDNSForwardHTTP_handleGetConfig.json
+++ b/internal/dnsforward/testdata/TestDNSForwardHTTP_handleGetConfig.json
@@ -38,7 +38,8 @@
     "use_private_ptr_resolvers": false,
     "local_ptr_upstreams": [],
     "edns_cs_use_custom": false,
-    "edns_cs_custom_ip": ""
+    "edns_cs_custom_ip": "",
+    "edns_cs_use_client_addr": false
   },
   "fastest_addr": {
     "upstream_dns": [
@@ -79,7 +80,8 @@
     "use_private_ptr_resolvers": false,
     "local_ptr_upstreams": [],
     "edns_cs_use_custom": false,
-    "edns_cs_custom_ip": ""
+    "edns_cs_custom_ip": "",
+    "edns_cs_use_client_addr": false
   },
   "parallel": {
     "upstream_dns": [
@@ -120,6 +122,7 @@
     "use_private_ptr_resolvers": false,
     "local_ptr_upstreams": [],
     "edns_cs_use_custom": false,
-    "edns_cs_custom_ip": ""
+    "edns_cs_custom_ip": "",
+    "edns_cs_use_client_addr": false
   }
 }

--- a/internal/dnsforward/testdata/TestDNSForwardHTTP_handleSetConfig.json
+++ b/internal/dnsforward/testdata/TestDNSForwardHTTP_handleSetConfig.json
@@ -43,7 +43,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "bootstraps": {
@@ -86,7 +87,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "blocking_mode_good": {
@@ -130,7 +132,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "blocking_mode_bad": {
@@ -174,7 +177,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "ratelimit": {
@@ -218,7 +222,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "ratelimit_subnet_len": {
@@ -264,7 +269,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "ratelimit_whitelist_not_ip": {
@@ -311,7 +317,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "edns_cs_enabled": {
@@ -355,7 +362,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "edns_cs_use_custom": {
@@ -401,7 +409,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": true,
-      "edns_cs_custom_ip": "1.2.3.4"
+      "edns_cs_custom_ip": "1.2.3.4",
+      "edns_cs_use_client_addr": false
     }
   },
   "edns_cs_use_custom_bad_ip": {
@@ -447,7 +456,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "dnssec_enabled": {
@@ -491,7 +501,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "cache_size": {
@@ -535,7 +546,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "cache_enabled": {
@@ -580,7 +592,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "upstream_mode_parallel": {
@@ -624,7 +637,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "upstream_mode_fastest_addr": {
@@ -668,7 +682,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "upstream_dns_bad": {
@@ -714,7 +729,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "bootstraps_bad": {
@@ -760,7 +776,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "cache_bad_ttl": {
@@ -805,7 +822,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "upstream_mode_bad": {
@@ -849,7 +867,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "local_ptr_upstreams_good": {
@@ -897,7 +916,8 @@
         "123.123.123.123"
       ],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "local_ptr_upstreams_bad": {
@@ -944,7 +964,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "local_ptr_upstreams_null": {
@@ -988,7 +1009,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "fallbacks": {
@@ -1036,7 +1058,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "blocked_response_ttl": {
@@ -1080,7 +1103,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "multiple_domain_specific_upstreams": {
@@ -1127,7 +1151,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   },
   "upstream_timeout": {
@@ -1171,7 +1196,8 @@
       "use_private_ptr_resolvers": false,
       "local_ptr_upstreams": [],
       "edns_cs_use_custom": false,
-      "edns_cs_custom_ip": ""
+      "edns_cs_custom_ip": "",
+      "edns_cs_use_client_addr": false
     }
   }
 }

--- a/internal/home/config.go
+++ b/internal/home/config.go
@@ -465,9 +465,10 @@ var config = &configuration{
 			EnableDNSSEC:             true,
 
 			EDNSClientSubnet: &dnsforward.EDNSClientSubnet{
-				CustomIP:  netip.Addr{},
-				Enabled:   false,
-				UseCustom: false,
+				CustomIP:             netip.Addr{},
+				Enabled:              false,
+				UseCustom:            false,
+				UseClientAddrFromECS: false,
 			},
 
 			// set default maximum concurrent queries to 300

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1635,6 +1635,9 @@
           'type': 'boolean'
         'edns_cs_custom_ip':
           'type': 'string'
+        'edns_cs_use_client_addr':
+          'type': 'boolean'
+          'description': 'Client address from EDNS Client Subnet instead of connection address.'
         'disable_ipv6':
           'type': 'boolean'
         'dnssec_enabled':


### PR DESCRIPTION
Closes #2514.

Adds a new option to identify clients by the EDNS Client Subnet (ECS) data injected into incoming requests by a forwarder, instead of the connection address. Without this, all queries appear to come from the forwarder's address and per-client filtering, query logs, and statistics lose client identity.

dnsmasq supports this via `add-subnet=32,128` (RFC 7871); other forwarders with ECS support also benefit.

The existing `edns_cs_use_custom` option sends a custom IP *out* to upstream resolvers for CDN routing. This new option is the inverse: it reads the client address *in* from incoming ECS options for client identification.

### What changed

Backend - new config flag `use_client_addr_from_ecs` (default `false`):

- `ecsClientAddr` extracts the client IP from the ECS option in incoming requests, with `ecsSubnetAddr` handling IPv4/IPv6 family detection
- `dnsContext.clientAddr()` returns the ECS address when valid, falling back to the connection address
- all consumer sites (blocked-client check, rDNS/WHOIS, per-client filtering, query log, stats) use `dctx.clientAddr()`
- OpenAPI spec and test data updated

Frontend -  new checkbox in Settings -> DNS -> EDNS Client Subnet:

- "Use client address from ECS" toggle, disabled when EDNS client subnet  is off

### Testing

- `go test ./internal/dnsforward/`, `go test ./internal/home/` pass
- `go vet`, `gofumpt`, `gocyclo --over 10` clean
- End-to-end on a real LAN: dnsmasq with `add-subnet=32,128` forwarding to AGH - query log shows real client IPs (eg. `192.168.0.163/32`) instead of the forwarder's address