### PR TITLE
filtering: remove debug.FreeOSMemory after engine rebuild

### DIFF
--- a/internal/filtering/filtering.go
+++ b/internal/filtering/filtering.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"runtime/debug"
 	"slices"
 	"strings"
 	"sync"
@@ -770,9 +769,12 @@ func (d *DNSFilter) initFiltering(ctx context.Context, allowFilters, blockFilter
 		d.filteringEngineAllow = filteringEngineAllow
 	}()
 
-	// Make sure that the OS reclaims memory as soon as possible.
-	debug.FreeOSMemory()
-
+	// NOTE: Don't call debug.FreeOSMemory here.  It forces a full
+	// stop-the-world GC and returns all free memory to the OS, which causes a
+	// sudden I/O and CPU spike on hosts with limited disk I/O (e.g. cloud
+	// VMs) and can make the process appear to hang right after a settings
+	// change.  The Go runtime scavenger already returns memory to the OS
+	// gradually without the spike.
 	d.logger.DebugContext(ctx, "initialized filtering engine")
 
 	return nil

--- a/internal/filtering/filtering.go
+++ b/internal/filtering/filtering.go
@@ -771,10 +771,9 @@ func (d *DNSFilter) initFiltering(ctx context.Context, allowFilters, blockFilter
 
 	// NOTE: Don't call debug.FreeOSMemory here.  It forces a full
 	// stop-the-world GC and returns all free memory to the OS, which causes a
-	// sudden I/O and CPU spike on hosts with limited disk I/O (e.g. cloud
-	// VMs) and can make the process appear to hang right after a settings
-	// change.  The Go runtime scavenger already returns memory to the OS
-	// gradually without the spike.
+	// sudden CPU and I/O spike that can hang or crash the process right after
+	// a settings change, on any host.  The Go runtime scavenger already
+	// returns memory to the OS gradually without the spike.
 	d.logger.DebugContext(ctx, "initialized filtering engine")
 
 	return nil


### PR DESCRIPTION
## Problem

Saving settings rebuilds the filtering engine, and `initFiltering` calls `debug.FreeOSMemory` afterwards.  `FreeOSMemory` forces a full stop-the-world GC and returns all free memory to the OS, which causes a sudden CPU and I/O spike that can hang or crash the process right after a settings change — on any host (dedicated machines included), even with a small data volume.

## Fix

Remove the `debug.FreeOSMemory` call and rely on the Go runtime scavenger, which returns memory to the OS gradually without the spike.

## Notes

- This was the only `FreeOSMemory` call in the codebase.
- Verified: `go build ./internal/filtering/` and `go test ./internal/filtering/` pass.

Signed-off-by: Chen Yun <ChenYun10@users.noreply.github.com>